### PR TITLE
Add redirect from /getting-started to /quickstart

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2177,6 +2177,11 @@
       "statusCode": 308
     },
     {
+      "source": "/getting-started",
+      "destination": "/quickstart/",
+      "statusCode": 308
+    },
+    {
       "source": "/getting-started/account-and-login",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308


### PR DESCRIPTION
Adds a 308 redirect so that `/getting-started` routes to `/quickstart/`.

[Warp conversation](https://staging.warp.dev/conversation/f303b84a-eed6-4e19-8aa2-e577586f3e55)