### PR TITLE
Redirect /getting-started/what-is-warp to home

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2352,6 +2352,11 @@
       "statusCode": 308
     },
     {
+      "source": "/getting-started/what-is-warp",
+      "destination": "/",
+      "statusCode": 308
+    },
+    {
       "source": "/guide/ssh-guide",
       "destination": "/terminal/warpify/ssh/",
       "statusCode": 308


### PR DESCRIPTION
## Summary
Add a 308 redirect from `/getting-started/what-is-warp` (no trailing slash) to `/`.

## Why
The trailing-slash variant `/getting-started/what-is-warp/` already redirects to `/`, but the no-slash variant was returning 404. Vercel's redirect matching is literal, so the no-slash variant needs its own entry.

GSC shows this URL is the highest-traffic 404 on the new docs:
- **106 clicks** in the last 90 days
- **28,910 impressions** in the last 90 days
- All other 404s on the new docs combined have 0 clicks

After this lands, the no-slash variant will 308 to the homepage like the slash variant already does.

## Verification
After deploy, both variants should 308 to `/`:
```
curl -I https://docs.warp.dev/getting-started/what-is-warp
curl -I https://docs.warp.dev/getting-started/what-is-warp/
```

---
[Conversation](https://staging.warp.dev/conversation/1b231a38-315c-4eca-b773-7194ae0d6ff6)

Co-Authored-By: Oz <oz-agent@warp.dev>