### PR TITLE
Enable Vercel Web Analytics and Speed Insights

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -159,5 +159,14 @@ export default defineConfig({
 	],
 	adapter: vercel({
 		edgeMiddleware: true,
+		// Inject the Vercel Web Analytics + Speed Insights trackers. The
+		// `@vercel/analytics` and `@vercel/speed-insights` packages are
+		// already installed; the adapter is responsible for adding the
+		// `<script>` tags. Without these flags both Vercel dashboards stay
+		// empty (0 visitors / 0 RUM samples) even though the CSP in
+		// vercel.json allowlists va.vercel-scripts.com and
+		// vitals.vercel-insights.com.
+		webAnalytics: { enabled: true },
+		speedInsights: { enabled: true },
 	}),
 });


### PR DESCRIPTION
## Summary
Pass `webAnalytics: { enabled: true }` and `speedInsights: { enabled: true }` to the Astro Vercel adapter so the trackers are actually injected.

## Why
`@vercel/analytics` and `@vercel/speed-insights` are already in `package.json`, and the CSP in `vercel.json` already allowlists `va.vercel-scripts.com` and `vitals.vercel-insights.com` — but the Astro Vercel adapter only adds the tracker `<script>` tags when you opt in via these options. Without them, the live HTML on `docs.warp.dev` has no Vercel script tags, so both the **Analytics** and **Speed Insights** tabs in the Vercel project stay at 0 visitors / 0 RUM samples (currently showing -100% over the last 7 days).

## Verification
`npm run build` succeeds locally. The rendered `dist/index.html` now contains the Vercel Analytics initialization stub:
```
window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
```
After deploy, the Vercel Analytics dashboard for the `docs` project should start populating within a few minutes.

---
[Conversation](https://staging.warp.dev/conversation/1b231a38-315c-4eca-b773-7194ae0d6ff6)

Co-Authored-By: Oz <oz-agent@warp.dev>