### PR TITLE
Fix Vercel analytics script placement

### DIFF
--- a/src/components/CustomHead.astro
+++ b/src/components/CustomHead.astro
@@ -44,7 +44,7 @@ const fontsHref =
   onload="this.media='all'"
 />
 <RudderStackAnalytics />
-<noscript><link rel="stylesheet" href={fontsHref} /></noscript>
 
 <Analytics />
 <SpeedInsights />
+<noscript><link rel="stylesheet" href={fontsHref} /></noscript>


### PR DESCRIPTION
## Summary
Fixes Vercel Analytics and Speed Insights script placement so production builds execute the analytics bootstrap scripts.

## Changes
- Moves the Google Fonts `<noscript>` fallback after the Vercel Analytics and Speed Insights components in `src/components/CustomHead.astro`.
- Prevents Astro from emitting the Vercel custom elements and module scripts inside `<noscript>`, where browsers skip them when JavaScript is enabled.

## Validation
- Ran `npm run build` successfully.
- Verified generated `dist/index.html` places `<vercel-analytics>` and `<vercel-speed-insights>` before `<noscript>` and includes `/_vercel/insights/script.js` plus `/_vercel/speed-insights/script.js` references.

## Oz artifacts
- Conversation: https://staging.warp.dev/conversation/4229dea0-915b-4242-991f-2329d325b051

Co-Authored-By: Oz <oz-agent@warp.dev>
