### PR TITLE
docs: update contact emails and rename debugging ID to conversation ID

### DIFF
--- a/src/content/docs/agent-platform/getting-started/faqs.mdx
+++ b/src/content/docs/agent-platform/getting-started/faqs.mdx
@@ -64,6 +64,6 @@ To resolve or clarify this, please contact our team at [appeals@warp.dev](mailto
 Note that any error that does not mention appeals@warp.dev isn't related to being blocked and should be reported as feedback or a bug. See [Sending Us Feedback](/support-and-community/troubleshooting-and-support/sending-us-feedback/) for more.
 :::
 
-## Gathering AI debugging ID
+## Gathering AI conversation ID
 
-In cases where you have issues with the Agent, we may ask for the AI debugging ID to troubleshoot the specific conversation. To gather the debugging ID, see [Gathering AI Debugging ID](/support-and-community/troubleshooting-and-support/sending-us-feedback/#gathering-ai-debugging-id) for detailed steps.
+In cases where you have issues with the Agent, we may ask for the AI conversation ID to troubleshoot the specific conversation. To gather the conversation ID, see [Gathering AI conversation ID](/support-and-community/troubleshooting-and-support/sending-us-feedback/#gathering-ai-conversation-id) for detailed steps.

--- a/src/content/docs/enterprise/support-and-resources/feedback-and-feature-requests.mdx
+++ b/src/content/docs/enterprise/support-and-resources/feedback-and-feature-requests.mdx
@@ -24,12 +24,12 @@ When reporting a bug, include the following to help Warp's team investigate quic
 
 1. **Description** - What happened and what you expected to happen.
 2. **Steps to reproduce** - How to trigger the issue.
-3. **Debugging ID** (for Agent issues) - Right-click on the Agent conversation block in question, select **Copy debugging ID**, and include it in your report. When an Agent conversation produces an error, an option to copy the debugging ID also appears inline. See [Gathering debugging ID](/support-and-community/troubleshooting-and-support/sending-us-feedback/#gathering-ai-debugging-id) for more details.
+3. **Conversation ID** (for Agent issues) - Right-click on the Agent conversation block in question, select **Copy conversation ID**, and include it in your report. When an Agent conversation produces an error, an option to copy the conversation ID also appears inline. See [Gathering conversation ID](/support-and-community/troubleshooting-and-support/sending-us-feedback/#gathering-ai-conversation-id) for more details.
 4. **Logs** (if relevant) - See [Gathering logs](#gathering-logs) below.
 5. **Environment details** - OS, Warp version, and any relevant configuration.
 
 :::note
-Most Enterprise teams have user-generated content (UGC) collection disabled, which limits the diagnostic information available from debugging IDs. Logs and detailed reproduction steps are especially important for Enterprise bug reports.
+Most Enterprise teams have user-generated content (UGC) collection disabled, which limits the diagnostic information available from conversation IDs. Logs and detailed reproduction steps are especially important for Enterprise bug reports.
 :::
 
 ### Gathering logs

--- a/src/content/docs/support-and-community/community/contributing.mdx
+++ b/src/content/docs/support-and-community/community/contributing.mdx
@@ -28,7 +28,7 @@ Other channels:
 * Press `⌘+Shift+F` (macOS) or `Ctrl+Shift+F` (Windows/Linux) to open the in-app feedback dialog. On macOS, you can also use the **Send Feedback** option in Warp's Help menu.
 * Email [privacy@warp.dev](mailto:privacy@warp.dev) for privacy questions.
 
-For logs, crash reports, CPU samples, and AI debugging IDs, see [Sending feedback and logs](/support-and-community/troubleshooting-and-support/sending-us-feedback/).
+For logs, crash reports, CPU samples, and AI conversation IDs, see [Sending feedback and logs](/support-and-community/troubleshooting-and-support/sending-us-feedback/).
 
 ## Reporting security issues
 

--- a/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
@@ -27,7 +27,7 @@ Visit [warp.dev/pricing](https://warp.dev/pricing) to see the latest plans and w
 Please review the details of our refund policies below. To request a refund, email [**billing@warp.dev**](mailto:billing@warp.dev) with information about your situation — the more context you provide, the faster we can resolve your request.
 
 :::caution
-In case of product defect, we require [Debugging ID](/support-and-community/troubleshooting-and-support/sending-us-feedback/#gathering-ai-debugging-id), [Logs](/support-and-community/troubleshooting-and-support/sending-us-feedback/#gathering-warp-logs), and "[Help improve Warp](/support-and-community/privacy-and-security/privacy/#how-to-disable-telemetry-and-crash-reporting)" must be enabled in order for us to identify the issue before we can provide any refunds or credits.
+In case of product defect, we require [Conversation ID](/support-and-community/troubleshooting-and-support/sending-us-feedback/#gathering-ai-conversation-id), [Logs](/support-and-community/troubleshooting-and-support/sending-us-feedback/#gathering-warp-logs), and "[Help improve Warp](/support-and-community/privacy-and-security/privacy/#how-to-disable-telemetry-and-crash-reporting)" must be enabled in order for us to identify the issue before we can provide any refunds or credits.
 :::
 
 #### Subscription refund policy

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -227,7 +227,7 @@ There are certain prohibited and restricted businesses in which Stripe and major
 
 ### I have a question and need help. How can I reach a human at Warp?
 
-The team at Warp is standing by and ready to help you with any questions you have about your plan or subscription. Please email us at [billing@warp.dev](mailto:billing@warp.dev) and we will get back to you as soon as we can.
+The team at Warp is standing by and ready to help. For subscribers technical issues email [support@warp.dev](mailto:support@warp.dev), for subscribers billing issues email [billing@warp.dev](mailto:billing@warp.dev), for security concerns email [security@warp.dev](mailto:security@warp.dev), and for questions about privacy email [privacy@warp.dev](mailto:privacy@warp.dev).
 
 ---
 

--- a/src/content/docs/support-and-community/troubleshooting-and-support/sending-us-feedback.mdx
+++ b/src/content/docs/support-and-community/troubleshooting-and-support/sending-us-feedback.mdx
@@ -2,7 +2,7 @@
 title: Sending feedback and logs
 description: >-
   Send Warp feedback, bug reports, and feature requests, and gather logs,
-  crash reports, CPU samples, and AI debugging IDs to attach to them.
+  crash reports, CPU samples, and AI conversation IDs to attach to them.
 ---
 import DemoVideo from '@components/DemoVideo.astro';
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -67,7 +67,7 @@ Whether you use the `/feedback` slash command or file an issue manually, a good 
 * **What did you expect?** Describe the behavior you expected instead.
 * **How do we reproduce it?** List numbered steps when possible. If you can't reproduce the issue reliably, mention that too.
 * **What version of Warp are you on?** `/feedback` fills this in automatically; for manual reports, copy it from **Settings** > **Account**.
-* **Logs, screenshots, or debugging IDs.** See [Gathering Warp Logs](#gathering-warp-logs), [Collecting crash reports on macOS](#collecting-crash-reports-on-macos), or [Gathering AI debugging ID](#gathering-ai-debugging-id) below.
+* **Logs, screenshots, or conversation IDs.** See [Gathering Warp Logs](#gathering-warp-logs), [Collecting crash reports on macOS](#collecting-crash-reports-on-macos), or [Gathering AI conversation ID](#gathering-ai-conversation-id) below.
 
 See the [Slash Commands reference](/agent-platform/capabilities/slash-commands/) for the full list of commands available in Warp.
 
@@ -284,9 +284,9 @@ Collect a sample using the steps for your platform and attach it to a new [GitHu
   </TabItem>
 </Tabs>
 
-## Gathering AI debugging ID
+## Gathering AI conversation ID
 
-To gather the debugging ID, `RIGHT-CLICK` on the AI conversation block in question and select "Copy conversation ID", then paste that into the [bug report](/support-and-community/troubleshooting-and-support/sending-us-feedback/#sending-warp-feedback) that you submit so that our team can investigate the issue.
+To gather the conversation ID, `RIGHT-CLICK` on the AI conversation block in question and select "Copy conversation ID", then paste that into the [bug report](/support-and-community/troubleshooting-and-support/sending-us-feedback/#sending-warp-feedback) that you submit so that our team can investigate the issue.
 
 Whenever there is an error in the Agent Conversation, there will also be an option to directly copy the conversation ID for the bug report.
 

--- a/src/content/docs/support-and-community/troubleshooting-and-support/sending-us-feedback.mdx
+++ b/src/content/docs/support-and-community/troubleshooting-and-support/sending-us-feedback.mdx
@@ -286,8 +286,8 @@ Collect a sample using the steps for your platform and attach it to a new [GitHu
 
 ## Gathering AI debugging ID
 
-To gather the debugging ID, `RIGHT-CLICK` on the AI conversation block in question and select "Copy debugging ID", then paste that into the [bug report](/support-and-community/troubleshooting-and-support/sending-us-feedback/#sending-warp-feedback) that you submit so that our team can investigate the issue.
+To gather the debugging ID, `RIGHT-CLICK` on the AI conversation block in question and select "Copy conversation ID", then paste that into the [bug report](/support-and-community/troubleshooting-and-support/sending-us-feedback/#sending-warp-feedback) that you submit so that our team can investigate the issue.
 
-Whenever there is an error in the Agent Conversation, there will also be an option to directly copy the debugging ID for the bug report.
+Whenever there is an error in the Agent Conversation, there will also be an option to directly copy the conversation ID for the bug report.
 
 ![Agent Mode error message with Send Feedback button and debug information containing request and conversation IDs](../../../../assets/support-and-community/send-feedback-debugging-information.png)


### PR DESCRIPTION
## Summary
Two small, focused doc updates for the support and billing section.

## Changes

### `src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx`
- Expanded the "How can I reach a human at Warp?" answer to include all relevant contact emails: `support@warp.dev` (technical), `billing@warp.dev` (billing), `security@warp.dev` (security), and `privacy@warp.dev` (privacy)

### `src/content/docs/support-and-community/troubleshooting-and-support/sending-us-feedback.mdx`
- Renamed "Copy debugging ID" → "Copy conversation ID" to match the updated UI label
- Updated the accompanying description to refer to "conversation ID" consistently

---

Co-Authored-By: Oz <oz-agent@warp.dev>
