### PR TITLE
Harden respond-to-comment.yml against fork PRs

### DIFF
--- a/.github/workflows/respond-to-comment.yml
+++ b/.github/workflows/respond-to-comment.yml
@@ -21,6 +21,50 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Check PR is not from a fork
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.issue?.number
+              ?? context.payload.pull_request?.number;
+            if (!prNumber) {
+              core.setFailed('Could not determine PR number from event payload.');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const headRepo = pr.head?.repo?.full_name;
+            const upstream = `${owner}/${repo}`;
+            if (headRepo !== upstream) {
+              const author = context.payload.comment.user.login;
+              const body = `@${author}: Sorry, I can't run on pull requests from forks for security reasons (this PR's head is \`${headRepo ?? 'unknown'}\`). A maintainer can re-open this as a branch on \`${upstream}\` and I'll be happy to help there.`;
+
+              if (context.eventName === 'pull_request_review_comment') {
+                await github.rest.pulls.createReplyForReviewComment({
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                  comment_id: context.payload.comment.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body,
+                });
+              }
+
+              core.setFailed(`Refusing to run on fork PR (head repo: ${headRepo ?? 'unknown'}).`);
+            }
       - name: Check author permissions
         uses: actions/github-script@v7
         with:
@@ -145,7 +189,7 @@ jobs:
 
             core.setOutput('prompt', prompt);
       - name: Run Oz Agent
-        uses: warpdotdev/oz-agent-action@v1
+        uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # v1.0.12
         env:
           GH_TOKEN: ${{ github.token }}
         id: agent

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Review PR with Oz agent
-        uses: warpdotdev/oz-agent-action@v1
+        uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # v1.0.12
         env:
           GH_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary

Hardens the `@oz-agent` workflow surface in this repo against the same forked-PR exploit chain that was demonstrated in oz-for-oss: a maintainer commenting `@oz-agent` on a fork PR was sufficient to execute fork-controlled code on a runner holding `WARP_API_KEY` and a `contents: write` `GITHUB_TOKEN`, then push back upstream.

## Changes

### `.github/workflows/respond-to-comment.yml`
- Add a `Check PR is not from a fork` step as the first job step. It loads the PR via `github.rest.pulls.get`, posts a friendly decline comment back to the author when `pr.head.repo.full_name` doesn't match the upstream repo, and `core.setFailed`s before any checkout, agent invocation, or `git push`. This runs ahead of the existing commenter-permission check, so fork PRs are rejected even when a maintainer triggers them.
- Pin `warpdotdev/oz-agent-action` from the floating `@v1` tag to commit SHA `ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # v1.0.12`.

### `.github/workflows/review-pr.yml`
- Pin `warpdotdev/oz-agent-action` from the floating `@v1` tag to commit SHA `ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # v1.0.12`. The existing job-level `if: github.event.pull_request.head.repo.full_name == github.repository` already gates fork PRs.

## Out of scope

- **Vercel preview-deployment settings.** Tracked separately; will be coordinated alongside the warp-internal-side mitigations.
- **GitHub repo settings** (e.g. require approval for outside-collaborator workflow runs) and `WARP_API_KEY` rotation. Tracked separately.
- **Contributor guidance.** Worth a follow-up note in `AGENTS.md` once we have repo-wide guidance written down for any new agent workflow.

## Validation

- Re-read both workflow files after edits to confirm the fork-guard step runs before checkout / agent / push, the existing commenter-permission step still runs, and the user-facing decline comment explains why.
- YAML parses cleanly.

Co-Authored-By: Oz <oz-agent@warp.dev>

---

[Conversation](https://staging.warp.dev/conversation/7c5a0da1-9045-4c2b-a44c-633d42b401c8) · [Plan](https://staging.warp.dev/drive/notebook/7v8o1Cfpfx1y9YF9oWQFe4)
