### PR TITLE
fix(header): switch active topic nav from blue accent to grayscale

### DIFF
--- a/src/components/WarpTopicNav.astro
+++ b/src/components/WarpTopicNav.astro
@@ -20,11 +20,13 @@
 //     inside the visible glyph range — geometric centering then equals
 //     optical centering, no per-icon transform needed (Vercel/Stripe nav
 //     pattern).
-//   - Active link: accent-blue text + weight 600 + 2px accent underline
-//     anchored to the header's bottom edge so the line visually replaces the
-//     header hairline under the active item (Scalar pattern). Text and
-//     underline share `--sl-color-text-accent`, which auto-adapts to dark
-//     and light themes.
+//   - Active link: full-emphasis white text + weight 600 + 2px white
+//     underline anchored to the header's bottom edge so the line visually
+//     replaces the header hairline under the active item (Scalar pattern).
+//     Both pull from `--sl-color-white`, the brightest neutral text token —
+//     off-white in dark, near-black in light — so the active topic shares
+//     one grayscale visual language with the sidebar's active row
+//     (`warp-components.css` §1) per Warp brand guidelines.
 //   - No surrounding chip / box / bg — just type + icon
 import { Icon } from '@astrojs/starlight/components';
 
@@ -179,19 +181,19 @@ const CUSTOM_TOPIC_ICONS: Record<string, true> = {
 		border-radius: var(--sl-radius-xs);
 	}
 
-	/* Active link picks up the same accent blue as the underline so the
-	   text and indicator read as one unified active state, and it ties
-	   into the rest of the site's blue accents (links, callouts, focus
-	   ring). `--sl-color-text-accent` is theme-aware: a lighter blue in
-	   dark mode, a darker blue in light mode — both keep AA contrast
-	   against the nav background. Weight 600 reinforces it against the
-	   calmer gray-3 idle siblings. */
+	/* Active link uses the brightest neutral text token + weight 600 so
+	   it reads as obviously selected against the calmer gray-3 idle
+	   siblings without introducing a blue accent. `--sl-color-white` is
+	   theme-aware (off-white in dark, near-black in light) and matches
+	   the active text color used by the sidebar's selected row, so the
+	   two navigation surfaces share one grayscale active treatment per
+	   Warp brand guidelines. */
 	a[aria-current='page'] {
-		color: var(--sl-color-text-accent);
+		color: var(--sl-color-white);
 		font-weight: 600;
 	}
 
-	/* 2px accent underline that REPLACES the header's 1px bottom hairline
+	/* 2px neutral underline that REPLACES the header's 1px bottom hairline
 	   under the active topic (Scalar pattern). The outer Starlight
 	   `<header class="header">` owns the hairline
 	   (`border-bottom: 1px solid var(--sl-color-hairline-shade)`) and has
@@ -200,8 +202,10 @@ const CUSTOM_TOPIC_ICONS: Record<string, true> = {
 	   than directly on it. We anchor the indicator at the hairline by
 	   dropping it through the bottom padding (`-var(--sl-nav-pad-y)`) and the
 	   1px border (`-1px`); `height: 2px` then paints across both, leaving the
-	   blue accent as the only line at that position under the active tab.
-	   The remainder of the header keeps its hairline. */
+	   bar as the only line at that position under the active tab. The
+	   remainder of the header keeps its hairline. Color matches the active
+	   link text (`--sl-color-white`) so text and indicator read as one
+	   unified grayscale active state. */
 	a[aria-current='page']::after {
 		content: '';
 		position: absolute;
@@ -209,7 +213,7 @@ const CUSTOM_TOPIC_ICONS: Record<string, true> = {
 		right: 0;
 		bottom: calc(-1 * var(--sl-nav-pad-y) - 1px);
 		height: 2px;
-		background: var(--sl-color-text-accent);
+		background: var(--sl-color-white);
 	}
 
 	.warp-topic-nav__icon {


### PR DESCRIPTION
## Problem

In the docs site header, the active topic tab (e.g. **Terminal**) renders with pale blue text and a 2px pale blue underline. The sidebar's active page uses a neutral grayscale highlight instead, so the two "selected" treatments don't match. Per Warp brand guidelines flagged in internal review, the top nav should be grayscale.

## Root cause

In `src/components/WarpTopicNav.astro` the active state pulls from `--sl-color-text-accent` for both the text color and the 2px underline. That token resolves to `hsl(217, 90%, 84%)` in dark mode (pale blue) and `hsl(207, 80%, 40%)` in light mode (saturated blue) — defined in `src/styles/custom.css`.

## Fix

Switch the two `a[aria-current='page']` rules to `--sl-color-white` (theme-aware: off-white in dark, near-black in light). That's the same token the sidebar's selected row uses in `warp-components.css` §1, so the two navigation surfaces now share one grayscale "selected" visual language. The Scalar-style underline anchor (replacing the header hairline under the active tab) is preserved; only the color changes. Inline comments above both rules are updated to reflect the new design intent.

The `--warp-control-*` chrome tokens used by Search/Ask are intentionally cool-gray per the Oz brand ladder and are left untouched.

## Validation

- `npm run build` succeeds (309 pages built, no test suite per `AGENTS.md`).
- Visual check: active topic tab now matches the sidebar's grayscale active row in both themes.

_Conversation: https://staging.warp.dev/conversation/48c5a764-39e4-43a1-9da0-8a7cff67ed3d_
_Run: https://oz.staging.warp.dev/runs/019de56f-115d-77ac-beb4-ddd0d3b816dd_
_Plans_:
- _[Fix blue tint on top topic nav active state — switch to grayscale to match sidebar](https://staging.warp.dev/drive/notebook/Sif1kLz60NndQYgt9Jy6Uv)_

_This PR was generated with [Oz](https://warp.dev/oz)._
