### PR TITLE
docs: fix typos in changelog entries

### DIFF
--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -2509,7 +2509,7 @@ All of this comes with higher AI usage limits on our Pro and Turbo plans, plus n
 **New features**
 
 * Warp Drive items that failed to sync can now be retried
-* Workflows in Warp Drive drive can now be edited with the workflow execution modal
+* Workflows in Warp Drive can now be edited with the workflow execution modal
 
 **Improvements**
 
@@ -3174,7 +3174,7 @@ All of this comes with higher AI usage limits on our Pro and Turbo plans, plus n
 
 **Bug fixes**
 
-* Fixed referal links and share by email
+* Fixed referral links and share by email
 * Fixed a hang that would sometimes occur when connecting with SSH
 * Now support requesting media permissions (camera, audio, etc)
 * Correctly parse Git commit SHAs in completion menus


### PR DESCRIPTION
## Summary
Fixes two small copy issues in the changelog:
  - Corrected the misspelling `referal` to `referral` in a bug-fix entry.
  - Removed a duplicated word in the entry `Workflows in Warp Drive drive can now be edited...` to `Workflows in Warp Drive can now be edited...`

  Both changes are in src/content/docs/changelog/index.mdx and are documentation-only — no behavior, navigation, or asset changes.

## Related issues
N/A (because it's a small fix)

## Validation
Changes are limited to plain prose inside an .mdx file (no frontmatter, navigation, links, components, or code samples touched)

## Screenshots

N/A

## Follow-ups

N/A
