### PR TITLE
docs: updating is also periodically

### DIFF
--- a/src/content/docs/support-and-community/troubleshooting-and-support/updating-warp.mdx
+++ b/src/content/docs/support-and-community/troubleshooting-and-support/updating-warp.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 import DemoVideo from '@components/DemoVideo.astro';
 
-Warp automatically checks for updates on startup. A notification will appear in the top right corner of the Warp window when a new update is available.
+Warp automatically checks for updates on startup, and periodically while running, by connecting to `releases.warp.dev`. A notification will appear in the top right corner of the Warp window when a new update is available.
 
 ![Update Available](../../../../assets/support-and-community/update-available.png)
 


### PR DESCRIPTION
## Summary

Clarified the update checking process by specifying that it checks releases.warp.dev for updates periodically while running as well, not just on startup.

## Validation

Documentation change only.

## Screenshots

<img width="718" height="452" alt="image" src="https://github.com/user-attachments/assets/8d0ca42d-773b-41ce-835e-2fd4d9f333b2" />
