### PR TITLE
fix: deploy middleware as Vercel Edge Function for content negotiation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -166,5 +166,9 @@ export default defineConfig({
 		}),
 		docsMarkdownIntegration(),
 	],
-	adapter: vercel(),
+	// Deploy Astro middleware as a Vercel Edge Function so it runs at
+	// request time for ALL pages, including pre-rendered static pages.
+	// Without this, middleware only runs at build time for static pages
+	// and content negotiation (Accept: text/markdown) doesn't work.
+	adapter: vercel({ middlewareMode: 'edge' }),
 });


### PR DESCRIPTION
## Summary

One-line fix: `vercel()` to `vercel({ middlewareMode: 'edge' })`.

The content negotiation middleware from PR #23 wasn't working in production because pre-rendered pages are served as static files by Vercel's CDN -- the Astro middleware never runs at request time for them.

### Root cause

The default `middlewareMode: 'classic'` only runs middleware:
- At **build time** for pre-rendered (static) pages
- At **request time** for SSR pages

Since all doc pages are pre-rendered, the `Accept: text/markdown` check in `src/middleware.ts` was only evaluated during the build, not when agents actually request pages.

### Fix

`middlewareMode: 'edge'` deploys the Astro middleware as a separate Vercel Edge Function that runs at request time for ALL requests, including static pages.

### Expected impact

The `content-negotiation` AFDocs check should flip from FAIL to PASS, bringing the score from 88 (B+) toward 93+ (A).

Co-Authored-By: Oz <oz-agent@warp.dev>
