### PR TITLE
fix: use Vercel rewrites for content negotiation (Accept: text/markdown)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -166,9 +166,5 @@ export default defineConfig({
 		}),
 		docsMarkdownIntegration(),
 	],
-	// Deploy Astro middleware as a Vercel Edge Function so it runs at
-	// request time for ALL pages, including pre-rendered static pages.
-	// Without this, middleware only runs at build time for static pages
-	// and content negotiation (Accept: text/markdown) doesn't work.
-	adapter: vercel({ middlewareMode: 'edge' }),
+	adapter: vercel(),
 });

--- a/vercel.json
+++ b/vercel.json
@@ -70,6 +70,18 @@
       ]
     }
   ],
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
+      "destination": "/index.md"
+    },
+    {
+      "source": "/:path+",
+      "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
+      "destination": "/:path+.md"
+    }
+  ],
   "redirects": [
     {
       "source": "/advanced/command-line-flags",


### PR DESCRIPTION
## Summary

Fixes content negotiation for `Accept: text/markdown` requests by using Vercel's built-in `rewrites` instead of Astro edge middleware.

### Why the previous approach failed

PR #25 added `middlewareMode: 'edge'` to deploy the Astro middleware as a Vercel Edge Function. This doesn't work for pre-rendered static pages because the edge function's `next()` callback forwards requests to `/_render` (the Astro server), which doesn't exist for static pages. The CDN just serves the cached HTML regardless.

### What this PR does

1. **Reverts** `middlewareMode: 'edge'` back to the default `vercel()`
2. **Adds Vercel `rewrites`** in `vercel.json` with `has` header conditions:

```json
{
  "source": "/:path+",
  "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
  "destination": "/:path+.md"
}
```

This rewrites at the CDN level -- when an agent sends `Accept: text/markdown`, Vercel serves the `.md` file directly. No middleware, no serverless function, no edge function needed.

The Astro middleware in `src/middleware.ts` is kept for dev mode (where it works correctly since the Astro dev server handles all requests).

### Expected impact

The `content-negotiation` AFDocs check should flip from FAIL to PASS, bringing the score from 90 (A-) to 93+ (A).

Co-Authored-By: Oz <oz-agent@warp.dev>
