### PR TITLE
docs: remove Kapa branding from Ask AI tooltip and aria-label

### DIFF
--- a/src/components/KapaChatLauncher.tsx
+++ b/src/components/KapaChatLauncher.tsx
@@ -153,12 +153,12 @@ function ChatSurface({ title, welcomeMessage, autoOpen = false, onNewConversatio
 				ref={triggerRef}
 				className="warp-kapa-button"
 				onClick={openPanel}
-				aria-label="Ask Kapa AI"
+				aria-label="Ask AI"
 				aria-haspopup="dialog"
 				aria-expanded={isOpen}
 				aria-controls="sl-kapa-panel"
 				aria-keyshortcuts={isAppleDevice ? 'Meta+I' : 'Control+I'}
-				data-tooltip={isAppleDevice ? 'Ask Kapa AI ⌘I' : 'Ask Kapa AI Ctrl+I'}
+				data-tooltip={isAppleDevice ? 'Ask AI ⌘I' : 'Ask AI Ctrl+I'}
 			>
 				<LuMessageSquare aria-hidden="true" />
 				<span className="warp-kapa-button__label">Ask</span>


### PR DESCRIPTION
## Summary

Remove "Kapa" branding from user-facing text in the Ask AI button on docs.warp.dev. The tooltip previously read "Ask Kapa AI ⌘I" and the `aria-label` said "Ask Kapa AI" — "Kapa" is an implementation detail (the AI provider) that shouldn't be visible to users.

## Changes

### `src/components/KapaChatLauncher.tsx`
- `aria-label`: `"Ask Kapa AI"` → `"Ask AI"`
- `data-tooltip`: `"Ask Kapa AI ⌘I"` / `"Ask Kapa AI Ctrl+I"` → `"Ask AI ⌘I"` / `"Ask AI Ctrl+I"`

## Context

Part of the [docs v2 bug bash](https://www.notion.so/warpdev/HOLD-Warp-docs-v2-bug-bash-35043263616d80859ba9ce5ee0a0633a) follow-up work. Tracks to Notion item: [Migration FF: Kapa branding cleanup](https://www.notion.so/35943263616d81c5a7b9e0cdd78239e7).

---

[Oz conversation](https://staging.warp.dev/conversation/90f754fa-53f1-4ebc-948f-cee9fb0ce070) · [Plan](https://staging.warp.dev/drive/notebook/eI5BBqMj1Z0nnhiSORvWto)

Co-Authored-By: Oz <oz-agent@warp.dev>
