### PR TITLE
fix(docs): make Linux tar log-collection commands actually work (#16)

### DIFF
--- a/src/content/docs/support-and-community/troubleshooting-and-support/sending-us-feedback.mdx
+++ b/src/content/docs/support-and-community/troubleshooting-and-support/sending-us-feedback.mdx
@@ -158,7 +158,7 @@ Warp's logs and crash reports _**do not**_ contain any console input or output. 
     Run the following to zip the Warp logs to your home directory:
 
     ```bash
-    tar -czf ~/warp-logs.tar.gz -C ~/.local/state/warp-terminal warp.log*
+    (cd ~/.local/state/warp-terminal && tar -czf ~/warp-logs.tar.gz warp.log*)
     ```
 
     **Warp Preview logs on Linux**
@@ -166,19 +166,19 @@ Warp's logs and crash reports _**do not**_ contain any console input or output. 
     Run the following to zip the Warp Preview logs to your home directory:
 
     ```bash
-    tar -czf ~/warp_preview-logs.tar.gz -C ~/.local/state/warp-terminal-preview warp_preview.log*
+    (cd ~/.local/state/warp-terminal-preview && tar -czf ~/warp_preview-logs.tar.gz warp_preview.log*)
     ```
 
     :::caution
     If your issue is graphical (e.g. no display of windows) or a crash, please run Warp with the following command to capture more log information:
 
     ```bash
-# Run if Warp on Linux is installed
+    # Run if Warp on Linux is installed
     RUST_LOG=wgpu_core=info,wgpu_hal=info MESA_DEBUG=1 EGL_LOG_LEVEL=debug warp-terminal
-    
+
     # Run if Warp Preview on Linux is installed
     RUST_LOG=wgpu_core=info,wgpu_hal=info MESA_DEBUG=1 EGL_LOG_LEVEL=debug warp-terminal-preview
-```
+    ```
     :::
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Closes #16.

## Problem

The Linux tar commands in **Gathering Warp Logs** at `src/content/docs/support-and-community/troubleshooting-and-support/sending-us-feedback.mdx` (L161, L169) fail with `tar: warp.log*: Cannot stat: No such file or directory`. On Linux with bash + default `nullglob=off`, an unmatched `warp.log*` glob is left as a literal argument; tar then looks for a literal file named `warp.log*` inside the `-C` directory and fails. Reported in #16.

The macOS (`zip -j`) and Windows (`Compress-Archive`) commands aren't affected — only the Linux tab.

## Fix

`cd` into the log directory first, so the shell expands the glob in the right pwd. Wrap the `cd` + `tar` in subshell parens so the user's pwd is preserved after the command finishes:

```bash
(cd ~/.local/state/warp-terminal && tar -czf ~/warp-logs.tar.gz warp.log*)
```

```bash
(cd ~/.local/state/warp-terminal-preview && tar -czf ~/warp_preview-logs.tar.gz warp_preview.log*)
```

While I was in the file, also normalized the indentation in the Linux `:::caution` `RUST_LOG=…` block to the 4-space indent already used by the macOS and Windows tabs.

## Verification

Reproduced the bug + verified the fix with GNU tar 1.35 + bash on a sandbox dir:

- **OLD command** reproduces the reporter's failure: `gtar: warp.log*: Cannot stat: No such file or directory` (exit=2).
- **NEW command** exits 0 and archives `warp.log`, `warp.log.1`, `warp.log.2`.
- **Caller's pwd is preserved**: `before == after` after the subshell exits.

> _Note: an earlier draft of this fix used GNU tar's `--wildcards` flag. That flag only enables glob matching during **extraction/listing**; in **creation** mode tar still treats arguments as literal paths, so it didn't actually fix the bug. The cd-then-tar approach (which the issue reporter suggested) is correct and verified._

`npm run build` succeeds (315 pages).

_Conversation: https://staging.warp.dev/conversation/fddc3534-3d55-4783-a388-a1eb70e432f9_

_Plans:_
- _[Fix #16: Linux tar log-collection commands fail due to shell glob expansion](https://staging.warp.dev/drive/notebook/pjwtkuwluRAydN3t7BMHaN)_

_This PR was generated with [Oz](https://warp.dev/oz)._
