### PR TITLE
Automated SEO fixes: resolve multiple H1 headings on open-source-licenses page

### DIFF
--- a/src/content/docs/support-and-community/community/open-source-licenses.mdx
+++ b/src/content/docs/support-and-community/community/open-source-licenses.mdx
@@ -744,7 +744,6 @@ sidebar:
 
 <details>
 <summary>Click to expand</summary>
-
 <pre style="max-height:500px;overflow:auto">
 Third-Party Licenses for Warp
 ================================================================================


### PR DESCRIPTION
## Summary

Fix `multiple_h1` SEO warning on the Open Source Licenses page (`/support-and-community/community/open-source-licenses/`).

### Problem

The page had 10 H1 headings detected by crawlers. The root cause was a blank line between `</summary>` and `<pre>` inside a `<details>` block, which caused the MDX compiler to switch from JSX mode to markdown mode. License text containing Setext-style heading markers (`===` underlines) and ATX headings (`#`) was then parsed as HTML `<h1>` elements instead of being treated as preformatted text.

### Fix

Removed the blank line between `</summary>` and `<pre>` so MDX treats the entire `<details>/<summary>/<pre>` block as a single JSX expression, preventing markdown parsing of the license content.

### SEO audit results (314 pages scanned, 7 warnings)

**Fixed (1):**
- `multiple_h1` on `open-source-licenses.mdx` — 10 H1 headings → 1

**Allowlisted (5):**
- `title_too_short`: Changelog, Guides, Tabs, Split panes, Tab Configs (intentionally short per exceptions list)

**Unfixable (1):**
- `missing_h1` on `/api/` — auto-generated page, no local source file

---

_Conversation: https://app.warp.dev/conversation/1a48a8ae-1020-4e5e-8188-1b743786bd55_
_Run: https://oz.warp.dev/runs/019e0662-d27f-74bb-a14c-bb81e85f890c_

_This PR was generated with [Oz](https://warp.dev/oz)._
