### PR TITLE
fix: position copy button top-right and always visible in code blocks

### DIFF
--- a/src/styles/warp-components.css
+++ b/src/styles/warp-components.css
@@ -209,6 +209,17 @@ pre.astro-code,
   border-color: rgba(0, 0, 0, 0.12);
 }
 
+/* Always show copy button at reduced opacity so it's discoverable without
+   hovering. EC hides it with opacity:0 in @media(hover:hover) by default;
+   override to 0.4 so the button is subtly visible at all times, progressing
+   to 0.75 on frame hover and 1.0 when hovering the button itself (both via
+   higher-specificity EC rules that win over this one). */
+@media (hover: hover) {
+  .expressive-code .copy button {
+    opacity: 0.4;
+  }
+}
+
 /* Inline code — same optical size as fenced blocks (0.9375em / 15px) so
    prose, callouts, and code blocks share one type scale.
 
@@ -245,6 +256,17 @@ pre.astro-code,
 .expressive-code .frame.is-terminal:not(.has-title) .header::before,
 .expressive-code .frame.is-terminal:not(.has-title) .header::after {
   display: none;
+}
+
+/* For untitled frames of any type, directly override the copy button's
+   inset-block-start. EC's .is-terminal frames get a large --button-spacing
+   to clear the titlebar we hide; bypassing that variable with an explicit
+   0.5rem offset places the button cleanly inside the top-right corner of
+   every untitled block. Titled frames are unaffected — their button
+   continues to sit below the visible title bar via EC's default spacing. */
+.expressive-code .frame:not(.has-title) .copy {
+  inset-block-start: 0.5rem;
+  inset-inline-end: 0.5rem;
 }
 
 /* Code blocks inside asides: keep the standalone padding rhythm so a code

--- a/src/styles/warp-components.css
+++ b/src/styles/warp-components.css
@@ -210,13 +210,19 @@ pre.astro-code,
 }
 
 /* Always show copy button at reduced opacity so it's discoverable without
-   hovering. EC hides it with opacity:0 in @media(hover:hover) by default;
+   hovering. EC hides it with opacity:0 in @media (hover: hover) by default;
    override to 0.4 so the button is subtly visible at all times, progressing
    to 0.75 on frame hover and 1.0 when hovering the button itself (both via
-   higher-specificity EC rules that win over this one). */
+   higher-specificity EC rules that win over this one). Light mode bumps to
+   0.6 because the button surface is already very faint (rgba(0,0,0,0.04)
+   background) and 0.4 would render it nearly invisible. */
 @media (hover: hover) {
   .expressive-code .copy button {
     opacity: 0.4;
+  }
+
+  :root[data-theme='light'] .expressive-code .copy button {
+    opacity: 0.6;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the copy-to-clipboard button positioning and visibility in Expressive Code code blocks across the docs site.

**Problems fixed:**
- For `bash`/`sh`/`shell` blocks without a title, EC's `--button-spacing` variable is sized for the terminal titlebar (which we hide) — this pushed the copy button to the bottom of, or past, short code blocks
- The button was hidden with `opacity: 0` until hover (via EC's `@media (hover: hover)` rule), making it non-discoverable

## Changes

### `src/styles/warp-components.css`

- **Always visible at reduced opacity** — overrides EC's `opacity: 0` default inside `@media (hover: hover)` to `0.4`, so the button is subtly visible at rest. EC's existing higher-specificity rules handle the progression: `0.75` on frame hover, `1.0` on button hover
- **Pinned to top-right corner** — directly overrides `inset-block-start` and `inset-inline-end` on `.copy` for all untitled frames (`0.5rem` each), bypassing the problematic `--button-spacing` variable. Titled frames (with a visible tab/filename bar) are unaffected

## GIFs

**Before:**

<img width="796" height="416" alt="CleanShot 2026-05-08 at 13 06 45" src="https://github.com/user-attachments/assets/5acd0aa0-c365-4c29-b6c3-2df5ed6accdd" />

**After:**

<img width="800" height="369" alt="CleanShot 2026-05-08 at 13 05 53" src="https://github.com/user-attachments/assets/ca47aad5-c952-4d91-8b81-65bd524c9890" />

---

Co-Authored-By: Oz <oz-agent@warp.dev>

[Oz conversation](https://staging.warp.dev/conversation/e0eb012f-1740-4d80-b367-8b7bcf707ec1)
