### PR TITLE
docs: replace single-tab code block title with bolded label on BYOLLM page

### DIFF
--- a/src/content/docs/enterprise/enterprise-features/bring-your-own-llm.mdx
+++ b/src/content/docs/enterprise/enterprise-features/bring-your-own-llm.mdx
@@ -81,7 +81,9 @@ In the [Admin Panel](/enterprise/team-management/admin-panel/), configure which 
 
 Grant your team members the necessary permissions in AWS. Use least-privilege IAM policies.
 
-```json title="Example: AWS Bedrock minimum IAM policy"
+**Example: AWS Bedrock minimum IAM policy**
+
+```json
 {
   "Version": "2012-10-17",
   "Statement": [


### PR DESCRIPTION
## Summary
The Step 2 IAM policy code block on the **Bring your own LLM** page used a `title="Example: AWS Bedrock minimum IAM policy"` attribute, which Astro Starlight's Expressive Code renders as a single tab on top of the block. That looked like a vestigial tab strip rather than a label.

The style guide in `AGENTS.md` reserves the `title=` fence attribute for actual filenames (e.g., `` ```yaml title="config.yaml" ``), so using it for free-form descriptive text was off-pattern. A repo-wide grep for `^```[a-z]* title=` confirmed this was the **only** occurrence in `src/content/`.

## Changes

### `src/content/docs/enterprise/enterprise-features/bring-your-own-llm.mdx`
- Dropped the `title=` attribute from the JSON IAM-policy fence in the **Step 2: Provision IAM roles (cloud admin)** section.
- Added a `**Example: AWS Bedrock minimum IAM policy**` bolded label line directly above the fence instead.

## Validation
- `npm run build` succeeds for the route that includes this page (`/_llms-txt/enterprise.txt`).
- The pre-existing `RangeError` on `/_llms-txt/support.txt` reproduces on clean `main`; it is unrelated to this change.

## Artifacts
- [Conversation](https://staging.warp.dev/conversation/3afff881-1836-4409-9dd8-517410000436)
- [Plan: Fix awkward single-tab code block on Bring your own LLM page](https://staging.warp.dev/drive/notebook/5Dqio0AU3icPs6Jp8thgAQ)

Co-Authored-By: Oz <oz-agent@warp.dev>
