### PR TITLE
docs: add section eyebrow text above page H1

### DIFF
--- a/src/components/CustomPageTitle.astro
+++ b/src/components/CustomPageTitle.astro
@@ -13,8 +13,17 @@ const title = Astro.locals.starlightRoute.entry.data.title;
 // an empty paragraph.
 const description = Astro.locals.starlightRoute.entry.data.description;
 const body = Astro.locals.starlightRoute.entry.body ?? '';
+
+// Eyebrow: the current topic label (e.g. "Terminal", "Agents", "Enterprise")
+// shown as a small uppercase label above the H1 to orient readers who land
+// directly on a page from search. Uses the same `starlightSidebarTopics`
+// middleware data as WarpTopicNav.astro.
+const topics = Astro.locals.starlightSidebarTopics?.topics;
+const currentTopic = topics?.find((t: { isCurrent: boolean }) => t.isCurrent);
+const eyebrow = currentTopic?.label;
 ---
 
+{eyebrow && <p class="page-eyebrow">{eyebrow}</p>}
 <div class="page-title-row">
   <h1 id="_top">{title}</h1>
   <CopyPageButton body={body} title={title} />
@@ -29,10 +38,20 @@ const body = Astro.locals.starlightRoute.entry.body ?? '';
     gap: 1rem;
   }
 
+  .page-eyebrow {
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
+    font-size: var(--sl-text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--sl-color-text-accent);
+  }
+
   .page-title-row h1 {
     flex: 1;
     min-width: 0;
-    margin-top: 1rem;
+    margin-top: 0;
     font-size: var(--sl-text-h1);
     line-height: var(--sl-line-height-headings);
     font-weight: 700;

--- a/src/components/CustomPageTitle.astro
+++ b/src/components/CustomPageTitle.astro
@@ -14,13 +14,35 @@ const title = Astro.locals.starlightRoute.entry.data.title;
 const description = Astro.locals.starlightRoute.entry.data.description;
 const body = Astro.locals.starlightRoute.entry.body ?? '';
 
-// Eyebrow: the current topic label (e.g. "Terminal", "Agents", "Enterprise")
-// shown as a small uppercase label above the H1 to orient readers who land
-// directly on a page from search. Uses the same `starlightSidebarTopics`
-// middleware data as WarpTopicNav.astro.
+// Eyebrow: a 2-level breadcrumb (e.g. "Agents > Third-Party CLI Agents")
+// shown above the H1 to orient readers who land directly from search.
+// Level 1 = the current sidebar topic (from starlightSidebarTopics).
+// Level 2 = the immediate parent group of the current page in the sidebar
+// tree (from starlightRoute.sidebar). Truncated to 2 levels max.
 const topics = Astro.locals.starlightSidebarTopics?.topics;
 const currentTopic = topics?.find((t: { isCurrent: boolean }) => t.isCurrent);
-const eyebrow = currentTopic?.label;
+const topicLabel = currentTopic?.label;
+
+// Walk the sidebar tree to find the parent group of the current page.
+type SidebarEntry = { type: string; label: string; isCurrent?: boolean; entries?: SidebarEntry[] };
+function findParentGroup(entries: SidebarEntry[], parentLabel?: string): string | undefined {
+  for (const entry of entries) {
+    if (entry.type === 'link' && entry.isCurrent) return parentLabel;
+    if (entry.type === 'group' && entry.entries) {
+      const found = findParentGroup(entry.entries, entry.label);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+const sidebar = Astro.locals.starlightRoute?.sidebar as SidebarEntry[] | undefined;
+const parentGroup = sidebar ? findParentGroup(sidebar) : undefined;
+
+// Build the eyebrow: "Topic > Parent Group" or just "Topic" if the page
+// is at the top level of its topic (no parent group, or parent matches topic).
+const eyebrow = topicLabel && parentGroup && parentGroup !== topicLabel
+  ? `${topicLabel} > ${parentGroup}`
+  : topicLabel;
 ---
 
 {eyebrow && <p class="page-eyebrow">{eyebrow}</p>}


### PR DESCRIPTION
## Summary

Add a section eyebrow label above the H1 on every docs page to orient readers who land directly from search.

## Problem

When readers arrive on a docs page from Google or an AI engine, there's no visible section context in the main content area. The sidebar shows where you are, but it's not prominent. GitBook had breadcrumb-style section context above the title; the Starlight migration lost this.

## Fix

Added a small uppercase eyebrow label (e.g. "TERMINAL", "AGENTS", "ENTERPRISE") above the H1 in `CustomPageTitle.astro`. The label is derived from the current sidebar topic via the same `starlightSidebarTopics` middleware that powers `WarpTopicNav.astro`.

### Visual treatment
- Font: `var(--sl-text-xs)` (13px), weight 600, uppercase, 0.08em letter-spacing
- Color: `var(--sl-color-text-accent)` (accent blue, theme-aware)
- Matches the sidebar tier-1 section label treatment
- Only renders when a topic is matched (graceful fallback)

### Layout
- Eyebrow sits above the H1, replacing the H1's top margin
- Page header now reads: eyebrow -> H1 -> subtitle (description)

## Context

Part of the docs v2 bug bash follow-up work. Tracks to Notion item: [Migration FF: page headers](https://www.notion.so/35943263616d815a9a7ce0368be5383c).

Co-Authored-By: Oz <oz-agent@warp.dev>
