### PR TITLE
docs: add changelog entry for 2026.05.06 release

### DIFF
--- a/.agents/skills/style_lint/style_lint.py
+++ b/.agents/skills/style_lint/style_lint.py
@@ -24,7 +24,11 @@ from typing import List, Optional, Tuple
 # Configuration
 # ---------------------------------------------------------------------------
 
-DOCS_ROOT = Path("docs")
+# Astro Starlight content lives under src/content/docs/, not a top-level docs/.
+# This used to be `Path("docs")`, which silently scanned 0 files in the
+# Astro layout — running --all reported "No issues found" without auditing
+# anything.
+DOCS_ROOT = Path("src/content/docs")
 CHANGELOG_DIR = DOCS_ROOT / "changelog"
 EXCLUDED_DIRS = {"_book", "node_modules", ".docs"}
 
@@ -134,7 +138,7 @@ class Report:
 def find_all_md_files() -> List[Path]:
     """Find all markdown files in docs/, excluding build artifacts and changelog."""
     files = []
-    for f in DOCS_ROOT.rglob("*.md"):
+    for f in [*DOCS_ROOT.rglob("*.md"), *DOCS_ROOT.rglob("*.mdx")]:
         if any(part in EXCLUDED_DIRS for part in f.parts):
             continue
         # Exclude changelog (historical record)
@@ -148,12 +152,12 @@ def find_changed_md_files() -> List[Path]:
     """Find markdown files changed in the current branch vs main."""
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", "origin/main...HEAD", "--", "docs/"],
+            ["git", "diff", "--name-only", "origin/main...HEAD", "--", str(DOCS_ROOT)],
             capture_output=True, text=True, check=True,
         )
         files = []
         for line in result.stdout.strip().split("\n"):
-            if line.endswith(".md") and os.path.exists(line):
+            if (line.endswith(".md") or line.endswith(".mdx")) and os.path.exists(line):
                 p = Path(line)
                 if not any(part in EXCLUDED_DIRS for part in p.parts):
                     files.append(p)
@@ -658,7 +662,7 @@ def create_pr_with_fixes() -> None:
     """Create a branch and PR with the auto-fixes."""
     branch = "fix/style-lint-auto-fixes"
     subprocess.run(["git", "checkout", "-b", branch], check=True)
-    subprocess.run(["git", "add", "docs/"], check=True)
+    subprocess.run(["git", "add", str(DOCS_ROOT)], check=True)
     result = subprocess.run(["git", "diff", "--cached", "--quiet"])
     if result.returncode == 0:
         print("No changes to commit.")

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -67,6 +67,15 @@ export default defineConfig({
 				defaultProps: {
 					wrap: true,
 				},
+				// Map languages Shiki doesn't bundle to a safe fallback. PromQL
+				// blocks live in agent-platform/cloud-agents/self-hosting/monitoring.mdx;
+				// without this alias every build emits noisy "language could not be
+				// found" warnings while still falling back to plaintext.
+				shiki: {
+					langAlias: {
+						promql: 'text',
+					},
+				},
 			},
 			head: [
 				// SEO + PWA parity with the legacy GitBook docs. These were emitted

--- a/src/content/docs/changelog/2026.mdx
+++ b/src/content/docs/changelog/2026.mdx
@@ -5,6 +5,76 @@ description: >-
 ---
 
 Submit bugs and feature requests on our [GitHub board!](https://github.com/warpdotdev/Warp/issues/new/choose)
+### 2026.05.06 (v0.2026.05.06.15.42)
+
+**New features**
+
+* Added a /set-tab-color slash command for setting or clearing the current tab's color from the input bar.
+
+**Improvements**
+
+* Added tab context menu actions to copy visible tab and pane metadata when available.
+* The conversation details panel can now be opened and closed with a configurable keyboard shortcut.
+* Conversation details side panel is now available for local Warp Agent conversations, not just cloud Oz runs. Click the info button in the pane header to open it for any active AI conversation.
+* Reduced memory usage and CPU work in the agent runs management view while a conversation is streaming.
+* Added support for drag-and-drop of image files into an active CLI agent session (e.g. Claude Code). Thanks @SagarSDagdu!
+* Recognize Mistral Vibe (vibe / vibe-acp) as a known CLI agent in the terminal, with brand-colored toolbar tile. Thanks @lonexreb!
+* Warp now renders inline local images and Mermaid diagrams in agent block output.
+* Warp now silently falls back to a regular SSH session on remote hosts where the prebuilt remote-server binary is incompatible (e.g. glibc < 2.31), instead of attempting an install that would fail at runtime.
+* Tighten orchestration event subscription scope so SSE runs only for active parent and child agent runs.
+* HTML files using the .htm extension now open with HTML syntax highlighting in Warp's editor.
+* Recognize Block's goose CLI agent — running goose now activates the CLI-agent toolbar, status, brand color, and icon like other recognized third-party agents. Thanks @webdevtodayjason!
+* Added a /continue-locally slash command to continue cloud conversations locally.
+* Added a "Show in Finder" (macOS) / "Show containing folder" (Linux/Windows) option to the tooltip that appears when clicking a detected file link.
+
+**Bug fixes**
+
+* Stop the Code Review pane from re-running gh pr view on every filesystem event when the current branch has no PR. Thanks @croaky!
+* Fixed /feedback recording "Unknown" instead of the installed Warp version on packaged builds. Thanks @SagarSDagdu!
+* Fixed find (cmd+f) selection jumping to a different match when new output streams into the active block. Thanks @amazansky!
+* Fixed a command injection vulnerability when opening files in external editors on Linux.
+* Fix Japanese IME losing the last character of a phrase that ends right before a punctuation mark on macOS. Thanks @s-zaizen!
+* Fixed local file tree blinking/reshuffling when connected to an SSH session
+* Fixed terminal text selection not auto-scrolling when dragging beyond bounds
+* Fixed Ctrl-G not closing CLI agent rich input on linux when editor is focused (fixes #9286). Thanks @nihalxkumar!
+* Pressing backspace in the agent view when the buffer is empty no longer resets the conversation.
+* Fixed unnecessary reconnect attempts for remote SSH sessions after system sleep, reducing error noise
+* Fixes issue with repeated TUI redraws for CLI agents on terminal pane resize.
+* Fix new-session "+" dropdown alignment when the Tabs Panel is placed on the right side of the header toolbar.
+* Copy keybinding now prioritizes selected text in the input over a selected block when both are active.
+* [Windows] Fix hotkey window.
+* [Windows] Symlink traversal fixed.
+* Fixed a crash on Windows when handing off a Web conversation to the native client ("Grid received input but did not receive Reset Grid OSC").
+* Fixed a bug where multiple 'open skill' buttons shared hover state.
+* Fixed Page Up and Page Down from the prompt so they scroll terminal output when the suggestion menu is closed; shortcuts appear under Keyboard Shortcuts as editable scroll actions (terminal:scroll_up_one_page / terminal:scroll_down_one_page). Thanks @fadexadex!
+* Fixed the OSS Linux desktop entry so WarpOss launches through the packaged warp-terminal-oss command. Thanks @lonexreb!
+* Fixed Ctrl/Cmd shortcuts (e.g. copy, paste) failing on Windows when a non-Latin keyboard layout was active.
+* Fix macOS IME candidate popup positioning in code editor panes so it anchors to the editor caret instead of stale terminal/input positions. Thanks @qubaitian!
+* Fixed /open-file handling for relative WSL paths so Unix separators are preserved before opening files on Windows hosts.
+* Fixed background colour bleeding in alt screen programs (e.g. delta, diff-so-fancy) where coloured regions would incorrectly fill the entire viewport when they dominated the visible area. Thanks @JamieMcMillan!
+* Clip the warping indicator's action chips (e.g. "Hide responses", "Take over", auto-approve, queue-next-prompt, stop) onto a new line on narrow panes instead of overflowing into the adjacent pane.
+* Inline .bmp, .tiff / .tif, and .ico images in agent block output now render correctly instead of falling back to plain text. Thanks @anshul-garg27!
+* Notifications and session UI from the community-maintained pi-mono plugin (Pi CLI agent) are now wired through Warp's default session listener. Thanks @lonexreb!
+* if user attaches an image in block input we should lock in agent mode, without running the NLD classifier to remove uncertainty
+* Remote-server installs no longer fail when the staging-directory cleanup hits a "Directory not empty" race after the binary has already been moved into place.
+* .command shell scripts now open with shell syntax highlighting in Warp's editor.
+* Fix git diff chip flickering between tracked-only and all-files count when untracked files are present
+* Open File → Default App now opens files in the running Warp channel instead of routing to a different installed Warp.
+* Fixed vertical tabs settings popup items (View as, Density, Pane title as) being unclickable. Thanks @leozeli!
+* Fixed a macOS memory leak that occurred when Warp enumerated system fonts or built a font fallback chain.
+* Executable shell scripts opened from a file:// URL now run in the terminal instead of opening in the editor. Thanks @amriksingh0786!
+* Fixed Option+Enter, Option+Tab, and Option+Escape sending literal key names instead of correct escape sequences. Thanks @oliver-ni!
+* Fixed read_files tool showing an empty box when the LLM requests line ranges beyond the end of a file.
+* Fixed Linux WarpOSS application-menu launcher pointing to a non-existent warp-oss binary; the .desktop Exec line now matches the installed warp-terminal-oss launcher. Thanks @lonexreb!
+* Prevent Warp from consuming too much memory when identifying filepaths in long block outputs.
+* Don't trigger the agent onboarding tutorial when Warp is running in headless SDK/CLI mode.
+* Added --version flag support in the Oz CLI
+* Fixed file tree flickering when transitioning to an SSH remote session
+* Fixed scroll-to-start/end of selected block keybinding (Cmd/Ctrl+Shift+Up/Down) not working when the input is focused.
+* Fix the terminal pane background appearing darker in horizontal tabs mode when the active theme has a background image or a custom window opacity.
+* AI code blocks tagged vue, xml, dockerfile, jsx, tsx, objective-c, or starlark now render with syntax highlighting. Common aliases like rs, py, js, ts, yml, kt, rb, golang, terraform, and docker are also recognized.
+* Reopen Closed Session is now reachable from the new-session menu on Linux and Windows.
+* Fixed missing syntax highlighting for C++ header files using .hpp, .hxx, or .H extensions.
 
 ### 2026.04.29 (v0.2026.04.29.08.57)
 

--- a/src/content/docs/changelog/2026.mdx
+++ b/src/content/docs/changelog/2026.mdx
@@ -77,7 +77,12 @@ Submit bugs and feature requests on our [GitHub board!](https://github.com/warpd
 * Reopen Closed Session is now reachable from the new-session menu on Linux and Windows.
 * Fixed missing syntax highlighting for C++ header files using .hpp, .hxx, or .H extensions.
 
-### 2026.04.29 (v0.2026.04.29.08.57)
+**Oz updates**
+
+* Add Codex as a supported harness for local child agents.
+* Configurable max context window per profile.
+
+### 2026.04.29
 
 **Improvements**
 
@@ -98,7 +103,12 @@ Submit bugs and feature requests on our [GitHub board!](https://github.com/warpd
 * Fixed a small memory leak on macOS that could accumulate Core Graphics objects during text rendering.
 * Fixed settings popup items (View as / Density) being unclickable (thanks @leozeli!).
 
-### 2026.04.27 (v0.2026.04.27.15.32)
+**Oz updates**
+
+* Reduced the oz CLI tarball download size by ~60% on both macOS and Linux.
+* Model selector no longer shows promotional discounts for models routed through your own API key (BYOK), since those discounts only apply to Warp-billed usage.
+
+### 2026.04.27
 
 **New features**
 

--- a/src/content/docs/changelog/2026.mdx
+++ b/src/content/docs/changelog/2026.mdx
@@ -5,11 +5,12 @@ description: >-
 ---
 
 Submit bugs and feature requests on our [GitHub board!](https://github.com/warpdotdev/Warp/issues/new/choose)
+
 ### 2026.05.06 (v0.2026.05.06.15.42)
 
 **New features**
 
-* Added a /set-tab-color slash command for setting or clearing the current tab's color from the input bar.
+* Added a `/set-tab-color` slash command for setting or clearing the current tab's color from the input bar.
 
 **Improvements**
 
@@ -24,22 +25,22 @@ Submit bugs and feature requests on our [GitHub board!](https://github.com/warpd
 * Tighten orchestration event subscription scope so SSE runs only for active parent and child agent runs.
 * HTML files using the .htm extension now open with HTML syntax highlighting in Warp's editor.
 * Recognize Block's goose CLI agent — running goose now activates the CLI-agent toolbar, status, brand color, and icon like other recognized third-party agents. Thanks @webdevtodayjason!
-* Added a /continue-locally slash command to continue cloud conversations locally.
+* Added a `/continue-locally` slash command to continue cloud conversations locally.
 * Added a "Show in Finder" (macOS) / "Show containing folder" (Linux/Windows) option to the tooltip that appears when clicking a detected file link.
 
 **Bug fixes**
 
-* Stop the Code Review pane from re-running gh pr view on every filesystem event when the current branch has no PR. Thanks @croaky!
-* Fixed /feedback recording "Unknown" instead of the installed Warp version on packaged builds. Thanks @SagarSDagdu!
-* Fixed find (cmd+f) selection jumping to a different match when new output streams into the active block. Thanks @amazansky!
+* Stop the Code Review pane from re-running `gh pr view` on every filesystem event when the current branch has no PR. Thanks @croaky!
+* Fixed `/feedback` recording "Unknown" instead of the installed Warp version on packaged builds. Thanks @SagarSDagdu!
+* Fixed find (`⌘+F`) selection jumping to a different match when new output streams into the active block. Thanks @amazansky!
 * Fixed a command injection vulnerability when opening files in external editors on Linux.
 * Fix Japanese IME losing the last character of a phrase that ends right before a punctuation mark on macOS. Thanks @s-zaizen!
 * Fixed local file tree blinking/reshuffling when connected to an SSH session
 * Fixed terminal text selection not auto-scrolling when dragging beyond bounds
-* Fixed Ctrl-G not closing CLI agent rich input on linux when editor is focused (fixes #9286). Thanks @nihalxkumar!
+* Fixed `Ctrl+G` not closing CLI agent rich input on Linux when editor is focused (fixes #9286). Thanks @nihalxkumar!
 * Pressing backspace in the agent view when the buffer is empty no longer resets the conversation.
 * Fixed unnecessary reconnect attempts for remote SSH sessions after system sleep, reducing error noise
-* Fixes issue with repeated TUI redraws for CLI agents on terminal pane resize.
+* Fixed issue with repeated TUI redraws for CLI agents on terminal pane resize.
 * Fix new-session "+" dropdown alignment when the Tabs Panel is placed on the right side of the header toolbar.
 * Copy keybinding now prioritizes selected text in the input over a selected block when both are active.
 * [Windows] Fix hotkey window.
@@ -50,12 +51,12 @@ Submit bugs and feature requests on our [GitHub board!](https://github.com/warpd
 * Fixed the OSS Linux desktop entry so WarpOss launches through the packaged warp-terminal-oss command. Thanks @lonexreb!
 * Fixed Ctrl/Cmd shortcuts (e.g. copy, paste) failing on Windows when a non-Latin keyboard layout was active.
 * Fix macOS IME candidate popup positioning in code editor panes so it anchors to the editor caret instead of stale terminal/input positions. Thanks @qubaitian!
-* Fixed /open-file handling for relative WSL paths so Unix separators are preserved before opening files on Windows hosts.
+* Fixed `/open-file` handling for relative WSL paths so Unix separators are preserved before opening files on Windows hosts.
 * Fixed background colour bleeding in alt screen programs (e.g. delta, diff-so-fancy) where coloured regions would incorrectly fill the entire viewport when they dominated the visible area. Thanks @JamieMcMillan!
 * Clip the warping indicator's action chips (e.g. "Hide responses", "Take over", auto-approve, queue-next-prompt, stop) onto a new line on narrow panes instead of overflowing into the adjacent pane.
 * Inline .bmp, .tiff / .tif, and .ico images in agent block output now render correctly instead of falling back to plain text. Thanks @anshul-garg27!
 * Notifications and session UI from the community-maintained pi-mono plugin (Pi CLI agent) are now wired through Warp's default session listener. Thanks @lonexreb!
-* if user attaches an image in block input we should lock in agent mode, without running the NLD classifier to remove uncertainty
+* Fixed an issue where attaching an image in block input did not immediately lock into Agent Mode, which could cause the NLD classifier to introduce uncertainty.
 * Remote-server installs no longer fail when the staging-directory cleanup hits a "Directory not empty" race after the binary has already been moved into place.
 * .command shell scripts now open with shell syntax highlighting in Warp's editor.
 * Fix git diff chip flickering between tracked-only and all-files count when untracked files are present
@@ -68,9 +69,9 @@ Submit bugs and feature requests on our [GitHub board!](https://github.com/warpd
 * Fixed Linux WarpOSS application-menu launcher pointing to a non-existent warp-oss binary; the .desktop Exec line now matches the installed warp-terminal-oss launcher. Thanks @lonexreb!
 * Prevent Warp from consuming too much memory when identifying filepaths in long block outputs.
 * Don't trigger the agent onboarding tutorial when Warp is running in headless SDK/CLI mode.
-* Added --version flag support in the Oz CLI
+* Added `--version` flag support in the Oz CLI
 * Fixed file tree flickering when transitioning to an SSH remote session
-* Fixed scroll-to-start/end of selected block keybinding (Cmd/Ctrl+Shift+Up/Down) not working when the input is focused.
+* Fixed scroll-to-start/end of selected block keybinding (`⌘+Shift+↑`/`⌘+Shift+↓` on macOS, `Ctrl+Shift+↑`/`Ctrl+Shift+↓` on Windows/Linux) not working when the input is focused.
 * Fix the terminal pane background appearing darker in horizontal tabs mode when the active theme has a background image or a custom window opacity.
 * AI code blocks tagged vue, xml, dockerfile, jsx, tsx, objective-c, or starlark now render with syntax highlighting. Common aliases like rs, py, js, ts, yml, kt, rb, golang, terraform, and docker are also recognized.
 * Reopen Closed Session is now reachable from the new-session menu on Linux and Windows.

--- a/src/content/docs/guides/agent-workflows/how-to-explain-your-codebase-using-warp-rust-codebase.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-explain-your-codebase-using-warp-rust-codebase.mdx
@@ -10,7 +10,7 @@ sidebar:
 import VideoEmbed from '@components/VideoEmbed.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-Learn how to use Warp’s AI agent to explore and understand large, unfamiliar codebases — using semantic and symbol-level search.
+Learn how to use Warp’s agents to explore and understand large, unfamiliar codebases — using semantic and symbol-level search.
 
 <VideoEmbed url="https://www.youtube.com/watch?v=11rz9OYQ8Hg" />
 

--- a/src/content/docs/guides/agent-workflows/how-to-review-ai-generated-code.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-review-ai-generated-code.mdx
@@ -16,7 +16,7 @@ Coding agents can produce hundreds of lines of code in seconds, but shipping tha
 
 ## Why review matters
 
-AI agents are fast but imperfect. They hallucinate imports, introduce subtle logic errors, make bad architectural decisions, and duplicate code. Reviewing agent output is the step that turns agentic development from vibe coding into a workflow you can trust.
+Agents are fast but imperfect. They hallucinate imports, introduce subtle logic errors, make bad architectural decisions, and duplicate code. Reviewing agent output is the step that turns agentic development from vibe coding into a workflow you can trust.
 
 Common issues in AI-generated code:
 

--- a/src/content/docs/guides/build-an-app-in-warp/building-a-chrome-extension-d3js-javascript-html-css.mdx
+++ b/src/content/docs/guides/build-an-app-in-warp/building-a-chrome-extension-d3js-javascript-html-css.mdx
@@ -10,7 +10,7 @@ import VideoEmbed from '@components/VideoEmbed.astro';
 import { Steps } from '@astrojs/starlight/components';
 
 :::tip
-This educational module teaches you step-by-step how to replicate the process shown in the video — building a **Sankey diagram Chrome extension** using **D3.js**, debugging, coordinating **multiple AI agents**, and deploying to the **Chrome Web Store**.
+This educational module teaches you step-by-step how to replicate the process shown in the video — building a **Sankey diagram Chrome extension** using **D3.js**, debugging, coordinating **multiple agents**, and deploying to the **Chrome Web Store**.
 :::
 
 <VideoEmbed url="https://youtu.be/xbvE_aoZ508?si=a3-4iKaSr8nn-esx" />
@@ -41,7 +41,7 @@ This educational module teaches you step-by-step how to replicate the process sh
 
    After fixing missing icons, the extension loads but initially shows only “Loading diagram.”\
    \
-   Debug this by taking a screenshot and feeding it to an AI agent for context by asking:
+   Debug this by taking a screenshot and feeding it to an agent for context by asking:
 
    ```
    It says loading diagram — why isn’t the chart appearing?

--- a/src/content/docs/guides/build-an-app-in-warp/building-a-slackbot.mdx
+++ b/src/content/docs/guides/build-an-app-in-warp/building-a-slackbot.mdx
@@ -14,7 +14,7 @@ The setup takes just a few steps — clone, configure, and run — and requires 
 
 ## Why this is useful
 
-* Run a self-hosted Slack bot that connects your team’s repos and Warp AI agents.
+* Run a self-hosted Slack bot that connects your team’s repos and Warp agents.
 * Provide your team with a coding assistant that can answer repo questions or help with PRs directly in Slack.
 
 ## Quickstart Setup
@@ -113,7 +113,7 @@ The setup takes just a few steps — clone, configure, and run — and requires 
 * Authenticates to Slack (Socket Mode and Web API).
 * Authenticates to GitHub and clones the listed repos.
 * Starts listening for `app_mention` events and threaded messages.
-* Routes context and commands to Warp’s AI agent backend.
+* Routes context and commands to Warp’s agent backend.
 
 You can stop the bot anytime with `Ctrl + C` or run it persistently with:
 

--- a/src/content/docs/guides/configuration/how-to-set-coding-preferences-with-rules.mdx
+++ b/src/content/docs/guides/configuration/how-to-set-coding-preferences-with-rules.mdx
@@ -13,7 +13,7 @@ Learn how to use Warp’s Rules feature to define your personal environment and 
 
 <VideoEmbed url="https://youtu.be/zWvRB2zWr-4?si=tv-TIhsqEtLG9iDs" />
 
-This tutorial teaches you how to customize your development setup using **Warp’s Rules** — ensuring the AI agent always works in your preferred environment. Instead of constantly reminding it which package manager or environment to use, you can **store those preferences as persistent Rules** that apply automatically across projects.
+This tutorial teaches you how to customize your development setup using **Warp’s Rules** — ensuring agents always work in your preferred environment. Instead of constantly reminding them which package manager or environment to use, you can **store those preferences as persistent Rules** that apply automatically across projects.
 
 <Steps>
 

--- a/src/content/docs/guides/devops/how-to-prevent-secrets-from-leaking.mdx
+++ b/src/content/docs/guides/devops/how-to-prevent-secrets-from-leaking.mdx
@@ -13,7 +13,7 @@ Learn how to safeguard credentials and sensitive data using Warp’s secret-redu
 
 <VideoEmbed url="https://youtu.be/2ECPFKtQpVk?si=HHw14Tqj-QyHeByX" />
 
-This tutorial shows how to use Warp’s **Rules** to prevent AI agents or collaborators from exposing sensitive information while coding or sharing output. Whether you’re pair-programming, streaming, or reviewing code, Warp can automatically redact secrets before they’re ever seen by an agent.
+This tutorial shows how to use Warp’s **Rules** to prevent agents or collaborators from exposing sensitive information while coding or sharing output. Whether you’re pair-programming, streaming, or reviewing code, Warp can automatically redact secrets before they’re ever seen by an agent.
 
 <Steps>
 

--- a/src/content/docs/guides/devops/how-to-write-sql-commands-inside-a-postgres-repl.mdx
+++ b/src/content/docs/guides/devops/how-to-write-sql-commands-inside-a-postgres-repl.mdx
@@ -84,7 +84,7 @@ You’ll learn how to:
 
 4. #### Observe How Warp Learns from Context
 
-   As you continue issuing prompts, Warp’s AI agent **learns the structure of your database** by observing what’s printed in the REPL output.
+   As you continue issuing prompts, Warp’s agent **learns the structure of your database** by observing what’s printed in the REPL output.
 
    This means you can ask progressively more complex questions, and Warp will tailor the SQL accordingly.
 

--- a/src/content/docs/guides/external-tools/linear-mcp-retrieve-issue-data.mdx
+++ b/src/content/docs/guides/external-tools/linear-mcp-retrieve-issue-data.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 import VideoEmbed from '@components/VideoEmbed.astro';
 
-Learn how to connect the Linear MCP server in Warp so your AI agent can access live data — like issues, tickets, and user assignments — directly from your Linear workspace.
+Learn how to connect the Linear MCP server in Warp so your agents can access live data — like issues, tickets, and user assignments — directly from your Linear workspace.
 
 <VideoEmbed url="https://youtu.be/jxeMfuS1pXk" />
 

--- a/src/content/docs/guides/external-tools/puppeteer-mcp-scraping-amazon-web-reviews.mdx
+++ b/src/content/docs/guides/external-tools/puppeteer-mcp-scraping-amazon-web-reviews.mdx
@@ -65,7 +65,7 @@ You’ll learn how to:
    * `puppeteer.screenshot`
    * `puppeteer.evaluate`
 
-   These represent actions Warp can call automatically through its AI agent.
+   These represent actions Warp can call automatically through its agents.
 
 2. #### Use Voice Input to Trigger Automation
 

--- a/src/content/docs/guides/external-tools/sentry-mcp-fix-sentry-error-in-empower-website.mdx
+++ b/src/content/docs/guides/external-tools/sentry-mcp-fix-sentry-error-in-empower-website.mdx
@@ -17,7 +17,7 @@ This tutorial is based solely on the provided transcript. It teaches how to use 
 
 ### Overview
 
-The **Sentry MCP server** gives Warp’s AI agents access to authenticated Sentry error data.\
+The **Sentry MCP server** gives Warp’s agents access to authenticated Sentry error data.\
 This enables detailed diagnostics and automated fixes that would otherwise be impossible using AI alone.
 
 You’ll learn how to:
@@ -82,7 +82,7 @@ You’ll learn how to:
 
 4. #### Diagnose the Error Using Warp
 
-   Back in Warp, prompt the AI agent to fetch and analyze the issue:
+   Back in Warp, prompt the agent to fetch and analyze the issue:
 
    ```
    Diagnose this Sentry error and show where it’s coming from in my code.

--- a/src/content/docs/guides/frontend/how-to-replace-a-ui-element-in-warp-rust-codebase.mdx
+++ b/src/content/docs/guides/frontend/how-to-replace-a-ui-element-in-warp-rust-codebase.mdx
@@ -28,9 +28,9 @@ This demo showcases Warp’s ability to safely make intelligent code changes wit
    ```
    Please create a new branch for me according to the format in the attached Linear URL.
 
-   I’ve attached screenshots of what the agent mode and sparkle icons look like.
+   I’ve attached screenshots of what the Agent Mode and sparkle icons look like.
    I would like you to understand those icons, search for their use in the code,
-   and wherever we’re using sparkles, replace them with the agent mode icon.
+   and wherever we’re using sparkles, replace them with the Agent Mode icon.
    Specifically, make sure this happens in the history menu.
    Please give me a plan before making any coding changes.
    ```

--- a/src/content/docs/guides/getting-started/how-to-customize-warps-appearance.mdx
+++ b/src/content/docs/guides/getting-started/how-to-customize-warps-appearance.mdx
@@ -50,7 +50,7 @@ Open **Settings → AI** to control:
   * Running commands
   * Planning tasks
 
-You can also whitelist or block specific commands that always require confirmation.
+You can also allowlist or block specific commands that always require confirmation.
 
 ---
 

--- a/src/content/docs/guides/getting-started/welcome-to-warp.mdx
+++ b/src/content/docs/guides/getting-started/welcome-to-warp.mdx
@@ -12,7 +12,7 @@ import VideoEmbed from '@components/VideoEmbed.astro';
 
 When you open Warp, you’ll see something familiar — a command line interface — but it’s much more than a traditional terminal.\
 \
-Warp is an Agentic Development Environment (ADE), meaning it’s a space where your primary mode of interaction is through prompts to an AI agent.
+Warp is an Agentic Development Environment (ADE), meaning it’s a space where your primary mode of interaction is through prompts to an agent.
 
 You can still use Warp just like any terminal:
 

--- a/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
+++ b/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
@@ -142,7 +142,7 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `AgentMode.Code.SuggestedEditAcceptClicked` | User selected Accept for a code diff suggestion in Agent Mode |
 | `AgentMode.Code.SuggestedEditReceived` | Agent Mode suggested a code edit |
 | `AgentMode.Code.SuggestedEditResolved` | Agent Mode pending code edit suggestion resolved |
-| `AgentMode.CreatedAIBlock` | Created an AI block in agent mode |
+| `AgentMode.CreatedAIBlock` | Created an AI block in Agent Mode |
 | `AgentMode.Error` | Received an error when getting Agent Mode response |
 | `AgentMode.ExecutedWarpDrivePrompt` | Executed a saved prompt. |
 | `AgentMode.ExitedShellProcess` | An agent-requested command caused the shell process to exit |
@@ -151,13 +151,13 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `AgentMode.Grep.Failed` | The grep tool failed to complete |
 | `AgentMode.Grep.Succeeded` | The grep tool completed successfully |
 | `AgentMode.NaturalLanguageDetection.InputBufferSubmitted` | Input buffer submitted |
-| `AgentMode.OpenedCitation` | Opened a citation that was surfaced in agent mode |
+| `AgentMode.OpenedCitation` | Opened a citation that was surfaced in Agent Mode |
 | `AgentMode.Orchestration.TeamAgentCommunicationFailed` | Failed to send an orchestration message or lifecycle event for a TeamAgent |
 | `AgentMode.PotentialAutoDetectionFalsePositive` | Manually toggled input to shell mode after input was auto-detected as natural language. |
 | `AgentMode.QueryAttemptAtLImit` | Tried to send an Agent Mode query but they already reached the query limit |
 | `AgentMode.RequestRetrySucceeded` | Agent Mode request succeeded after retrying following an initial error |
 | `AgentMode.SetupCreateEnvironmentAction` | User clicked a button in the Agent Mode setup create environment step |
-| `AgentMode.SurfacedCitations` | Agent mode used and cited external sources that were used in its response |
+| `AgentMode.SurfacedCitations` | Agent Mode used and cited external sources that were used in its response |
 | `AgentMode.ToggleAutoDetectionSetting` | Toggled the setting that enables or disables natural language auto-detection in the input.  |
 | `AgentNotification.Shown` | An agent notification was shown to the user (toast or mailbox) |
 | `AgentTip Clicked` | User clicked a link or action in an Agent Tip |


### PR DESCRIPTION
## Summary
Adds the changelog entry for the 2026.05.06 (v0.2026.05.06.15.42) stable release.

## Changes

### src/content/docs/changelog/2026.mdx
- Added new entry for 2026.05.06 release with new features, improvements, and bug fixes

Co-Authored-By: Oz <oz-agent@warp.dev>
