### PR TITLE
docs: fix API docs sidebar overscroll from topbar offset

### DIFF
--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -292,6 +292,14 @@ const specJson = JSON.stringify(specObject);
             --scalar-sidebar-item-active-background: #fafafa;
             --scalar-sidebar-item-hover-background: #fafafa;
           }
+          /* Fix sidebar height: Scalar's --scalar-y-offset shifts the
+             sidebar's top position below the topbar, but doesn't reduce
+             the sidebar's total height. Without this, the sidebar extends
+             past the viewport bottom by the topbar height, causing a
+             slight overscroll at the top and bottom. */
+          .sidebar {
+            max-height: calc(100vh - var(--warp-topbar-height)) !important;
+          }
           /* Hide Developer Tools toolbar */
           .references-developer-tools,
           .api-reference-toolbar { display: none !important; }


### PR DESCRIPTION
## Summary

Fix the API docs sidebar overscroll caused by the WarpTopbar offset.

## Problem

The `/api` page's Scalar sidebar appeared taller than needed and scrolled slightly at the top and bottom of the main scroll area. This happened because Scalar's `--scalar-y-offset` shifts the sidebar's `top` position below the WarpTopbar, but doesn't reduce the sidebar's total height. The sidebar was extending past the viewport bottom by exactly the topbar height (3.5rem on mobile, 4rem on desktop).

## Fix

Added `max-height: calc(100vh - var(--warp-topbar-height))` to the `.sidebar` class in the Scalar `customCss` block in `src/pages/api.astro`. This constrains the sidebar to the visible viewport area below the topbar, eliminating the overscroll.

## Context

Part of the docs v2 bug bash follow-up work. Tracks to Notion item: [Migration FF: API docs sidebar scrolling issue](https://www.notion.so/35943263616d81478918c5e67eccbccc).

Co-Authored-By: Oz <oz-agent@warp.dev>
