### PR TITLE
fix: replace blog.warp.dev/how-warp-works redirect with canonical URL

### DIFF
--- a/src/content/docs/support-and-community/troubleshooting-and-support/known-issues.mdx
+++ b/src/content/docs/support-and-community/troubleshooting-and-support/known-issues.mdx
@@ -105,7 +105,7 @@ If you comment out the rc files (i.e. `~/.zshrc`, `~/.bashrc`, `~/.config/fish/c
 
 ### Configuring and debugging your RC files
 
-To support Blocks ([custom hooks](https://blog.warp.dev/how-warp-works/#implementing-blocks)), a native Input Editor experience, AI blocks, etc. we have built custom support for a subset of shell functionality (decouple functionality from the shell and move to the terminal). This leads to Warp being incompatible with various tools and plugins. Please see the [list of incompatible](/support-and-community/troubleshooting-and-support/known-issues/#list-of-incompatible-tools) tools to find the tools that are known not to work with Warp.
+To support Blocks ([custom hooks](https://www.warp.dev/blog/how-warp-works/#implementing-blocks)), a native Input Editor experience, AI blocks, etc. we have built custom support for a subset of shell functionality (decouple functionality from the shell and move to the terminal). This leads to Warp being incompatible with various tools and plugins. Please see the [list of incompatible](/support-and-community/troubleshooting-and-support/known-issues/#list-of-incompatible-tools) tools to find the tools that are known not to work with Warp.
 
 Unlike typical terminals which are essentially continuous character grids, each section of Warp is its own (separate) UI element. Please see our [Prompt](/terminal/appearance/prompt/) page for more information on custom prompts.
 

--- a/src/content/docs/terminal/blocks/index.mdx
+++ b/src/content/docs/terminal/blocks/index.mdx
@@ -17,7 +17,7 @@ Blocks enable us to easily:
 * Bookmark commands
 
 :::note
-Interested in how we differentiate input and output, or how we implement blocks? Check out our blog post: [How Warp Works.](https://blog.warp.dev/how-warp-works/#implementing-blocks)
+Interested in how we differentiate input and output, or how we implement blocks? Check out our blog post: [How Warp Works.](https://www.warp.dev/blog/how-warp-works/#implementing-blocks)
 :::
 
 <VideoEmbed url="https://youtu.be/PH1u0TZ5Lf0" title="Intro to Blocks" />


### PR DESCRIPTION
## What

Replace `https://blog.warp.dev/how-warp-works` with `https://www.warp.dev/blog/how-warp-works` in two doc pages. The old `blog.warp.dev` subdomain redirects to `www.warp.dev/blog`, so these links cause an unnecessary redirect hop.

## Changes
- `terminal/blocks/index.mdx` — updated blog link in the Blocks note callout
- `support-and-community/troubleshooting-and-support/known-issues.mdx` — updated blog link in the RC files section

---
[Oz conversation](https://staging.warp.dev/conversation/aaa905a1-bc37-4f4b-8fdd-c8d6d3d053ed)

Co-Authored-By: Oz <oz-agent@warp.dev>