### PR TITLE
fix: add redirects for 6 broken internal links from warp.dev

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9487,6 +9487,36 @@
       "source": "/warp/terminal/editor",
       "destination": "/terminal/editor/",
       "statusCode": 308
+    },
+    {
+      "source": "/features/ai-command-search",
+      "destination": "/terminal/entry/command-search/",
+      "statusCode": 308
+    },
+    {
+      "source": "/features/entry/ai-command-search",
+      "destination": "/terminal/entry/command-search/",
+      "statusCode": 308
+    },
+    {
+      "source": "/features/network-log",
+      "destination": "/support-and-community/privacy-and-security/network-log/",
+      "statusCode": 308
+    },
+    {
+      "source": "/features/warp-ai/ai-command-suggestions",
+      "destination": "/agent-platform/local-agents/generate/",
+      "statusCode": 308
+    },
+    {
+      "source": "/help/plans-subscriptions-and-pricing",
+      "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
+      "statusCode": 308
+    },
+    {
+      "source": "/integrations/integrations-overview/integrations-and-environments",
+      "destination": "/reference/cli/integration-setup/",
+      "statusCode": 308
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fix broken internal links from warp.dev by adding redirect entries in `vercel.json`.

## Changes

### vercel.json
- Added 6 redirect entries for broken internal links identified from a warp.dev crawl

---
[Warp conversation](https://staging.warp.dev/conversation/70aa290f-04eb-4b2f-b62c-70bb863cfabf)

Co-Authored-By: Oz <oz-agent@warp.dev>
