### PR TITLE
fix: add wildcard redirects for old /errors/ permalinks

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1614,6 +1614,16 @@
       "statusCode": 308
     },
     {
+      "source": "/errors",
+      "destination": "/reference/api-and-sdk/troubleshooting/errors/",
+      "statusCode": 308
+    },
+    {
+      "source": "/errors/:code",
+      "destination": "/reference/api-and-sdk/troubleshooting/errors/:code/",
+      "statusCode": 308
+    },
+    {
       "source": "/features",
       "destination": "/",
       "statusCode": 308
@@ -5701,6 +5711,16 @@
     {
       "source": "/configuration/",
       "destination": "/terminal/more-features/settings-sync/",
+      "statusCode": 308
+    },
+    {
+      "source": "/errors/",
+      "destination": "/reference/api-and-sdk/troubleshooting/errors/",
+      "statusCode": 308
+    },
+    {
+      "source": "/errors/:code/",
+      "destination": "/reference/api-and-sdk/troubleshooting/errors/:code/",
       "statusCode": 308
     },
     {


### PR DESCRIPTION
## Summary

Add wildcard redirects to preserve old `/errors/:code` permalinks that were not carried over to the new docs site.

## Changes

### vercel.json
- Added wildcard redirects (`/errors` and `/errors/:code`) to map legacy error page URLs to their new locations at `/reference/api-and-sdk/troubleshooting/errors/:code/`
  - Uses Vercel `:param` wildcards so new error codes are covered automatically
  - Both trailing-slash and non-trailing-slash variants included

---
[Warp conversation](https://staging.warp.dev/conversation/70aa290f-04eb-4b2f-b62c-70bb863cfabf)

Co-Authored-By: Oz <oz-agent@warp.dev>
