### PR TITLE
fix: use npm ci on Vercel so patch-package runs against pristine node_modules

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "astro",
-  "installCommand": "npm install",
+  "installCommand": "npm ci",
   "buildCommand": "npm run build",
   "devCommand": "npm run dev",
   "headers": [


### PR DESCRIPTION
## Summary
Switch the Vercel `installCommand` from `npm install` to `npm ci` so `patch-package` always runs against a pristine `node_modules`. Production deploys have been failing for ~40 minutes (all Production builds since `7d6185a`); this unblocks them.

## Root cause
Every Production deploy after `7d6185a` (#51 — `Improve llms.txt aggregate coverage`) fails at the `npm install` postinstall step with:

```
**ERROR** Failed to apply patch for package starlight-llms-txt at path
  node_modules/starlight-llms-txt
```

Vercel restores `node_modules` from the previous build cache before running `npm install` (visible in the build log: `Restored build cache from previous deployment ...`). The previous successful Production deploy (`202eeb3`) shipped with the older `patches/starlight-llms-txt+0.8.1.patch`, which modified `llms-custom.txt.ts` and `llms-full.txt.ts` to forward `exclude` to all generated llms outputs.

#51 regenerated that patch so it also patches `generator.ts` with a `Canonical page:` line via a new `getDocUrl` helper. The regenerated patch is correct against the pristine upstream `0.8.1` tarball (verified by downloading the tarball directly), but the cached `node_modules` already had the *old* patch's edits to `llms-custom.txt.ts` and `llms-full.txt.ts`. Because the lockfile is satisfied, `npm install` is a no-op for those files — so `patch-package` runs against pre-patched sources and `git apply` fails at the file level:

```
error: patch failed: node_modules/starlight-llms-txt/llms-custom.txt.ts:30
error: patch failed: node_modules/starlight-llms-txt/llms-full.txt.ts:1
```

`generator.ts` (the only genuinely new edit in #51) applies fine in isolation. The breakage is entirely on the two files whose hunks overlap the historical patch.

## Why `npm ci`
`npm ci` deletes `node_modules` before installing (per npm docs), so `patch-package` always sees the pristine npm tarball — exactly the state the patch was authored against. `npm ci` is also the standard install command for CI environments: deterministic, lockfile-strict, and won't mutate the lockfile out from under us.

Trade-off: `npm ci` errors if `package.json` and `package-lock.json` ever drift. That's a desirable property for CI and we're already in sync today (the local `npm ci` succeeded).

## Why not just clear the Vercel build cache
Clearing it via the dashboard would unblock the next deploy, but the underlying fragility (`npm install` + `patch-package` against a cache that may or may not be pre-patched) would resurface the next time anyone edits the patch. `npm ci` fixes the root cause once.

## Validation
- `rm -rf node_modules && npm ci` succeeds locally; `patch-package` reports `starlight-llms-txt@0.8.1 ✔`.
- `npm run build` finishes with 316 pages in ~92s.

Co-Authored-By: Oz <oz-agent@warp.dev>
