### PR TITLE
docs: embed social engineering videos

### DIFF
--- a/src/content/docs/agent-platform/capabilities/agent-notifications.mdx
+++ b/src/content/docs/agent-platform/capabilities/agent-notifications.mdx
@@ -4,8 +4,11 @@ description: >-
   Warp surfaces notifications from coding agents, both in-app and via desktop
   alerts, so you know exactly when an agent needs your attention.
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 Warp delivers notifications from any supported coding agent so you always know when an agent finishes a task, encounters an error, or needs your input. Notifications work whether you're in a different tab or a different app.
+
+<VideoEmbed url="https://youtu.be/0l-7fZJClkE" title="Agent notifications in Warp" />
 
 ## Notification types
 

--- a/src/content/docs/agent-platform/cli-agents/remote-control.mdx
+++ b/src/content/docs/agent-platform/cli-agents/remote-control.mdx
@@ -4,10 +4,13 @@ description: >-
   Publish any third-party agent session to the cloud so you can monitor
   progress, steer the agent, and check in from your phone or another computer.
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 Remote Control lets you publish a running third-party agent session — such as Claude Code, Codex, or OpenCode — to the cloud with a single click. Once published, you can monitor progress, review output, and steer the agent from your phone, a web browser, or another computer without staying at the original machine. See [Third-Party CLI Agents](/agent-platform/cli-agents/overview/) for the full list of supported agents.
 
 This is especially useful for long-running agent tasks. Start a coding agent, publish the session, and check back whenever you want.
+
+<VideoEmbed url="https://youtu.be/6xsngiSX2KQ" title="Remote Control for coding agent sessions" />
 
 :::note
 Remote Control is built on top of [Agent Session Sharing](/agent-platform/local-agents/session-sharing/). It uses the same underlying infrastructure to publish sessions and generate shareable links.

--- a/src/content/docs/agent-platform/cli-agents/rich-input.mdx
+++ b/src/content/docs/agent-platform/cli-agents/rich-input.mdx
@@ -4,8 +4,11 @@ description: >-
   Warp's rich input editor gives you IDE-style editing, voice input, context
   attachment, and slash commands for any supported CLI coding agent.
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 Warp's rich input editor lets you write prompts for any CLI coding agent with the same editing experience you'd expect from an IDE — mouse support, context attachment, voice, and more. Press `Ctrl-G` (configurable) or click the **Rich Input** button in the agent utility bar to open it.
+
+<VideoEmbed url="https://youtu.be/f1MqXDv0gFM" title="Rich input editor for CLI agents" />
 
 ## Key capabilities
 

--- a/src/content/docs/terminal/windows/tab-configs.mdx
+++ b/src/content/docs/terminal/windows/tab-configs.mdx
@@ -4,8 +4,11 @@ description: >-
   Tab Configs let you define reusable tab setups — including directory,
   startup commands, pane layout, shell, and theme — in a simple TOML file.
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 Tab Configs let you define reusable tab setups — including directory, startup commands, pane layout, shell, and theme — in a simple TOML file. Select a Tab Config from the `+` menu to open a fully configured tab with a single click.
+
+<VideoEmbed url="https://youtu.be/Bq30S3wIpOU" title="Tab Configs in Warp" />
 
 ## How Tab Configs work
 

--- a/src/content/docs/terminal/windows/vertical-tabs.mdx
+++ b/src/content/docs/terminal/windows/vertical-tabs.mdx
@@ -7,10 +7,13 @@ description: >-
 sidebar:
   label: "Vertical Tabs"
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 The vertical tabs panel is a sidebar that replaces the traditional horizontal tab bar with a richer, more powerful tab management surface. Instead of a single row of tab titles, the panel displays every tab and pane with contextual metadata — Git branch, working directory, agent conversation status, diff stats, and more. Scan and switch between workstreams without losing context.
 
 Vertical tabs are especially useful when running multiple coding agents side by side, giving you a clear overview of each session's state without switching tabs.
+
+<VideoEmbed url="https://youtu.be/tqVl4Id3aao" title="Vertical tabs in Warp" />
 
 ## Key features
 


### PR DESCRIPTION
## Summary
Embeds social engineering demo videos into the most relevant docs pages so readers can see each feature in context.

## Changes
- Added the Agent notifications video to `agent-notifications.mdx`.
- Added the Remote Control video to `remote-control.mdx`.
- Added the rich input editor video to `rich-input.mdx`.
- Added the Tab Configs video to `tab-configs.mdx`.
- Added the vertical tabs video to `vertical-tabs.mdx`.

## Validation
- `npm ci`
- `npm run build`

Conversation: https://staging.warp.dev/conversation/6a973331-335f-4595-8658-affe6cb4620f

Co-Authored-By: Oz <oz-agent@warp.dev>
