### PR TITLE
fix: replace broken images on Universal Input (Legacy) page

### DIFF
--- a/src/content/docs/terminal/input/universal-input.mdx
+++ b/src/content/docs/terminal/input/universal-input.mdx
@@ -72,9 +72,15 @@ _Indicator_: Neither mode highlighted.
 
 When Warp detects an input type, the input switcher softly highlights the corresponding mode.
 
-| Agent (natural language) mode detected                                                          | Terminal (shell) mode detected                                                                 |
-| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| <img src="../../../../assets/terminal/auto-detection-agent-mode-1.png" alt="Universal Input auto-detecting a natural-language Agent prompt." data-size="original" /> | <img src="../../../../assets/terminal/auto-detection-terminal-mode.png" alt="Universal Input auto-detecting a shell command." data-size="original" /> |
+<figure>
+![Universal Input auto-detecting a natural-language Agent prompt.](../../../../assets/terminal/auto-detection-agent-mode-1.png)
+<figcaption>Agent (natural language) mode detected.</figcaption>
+</figure>
+
+<figure>
+![Universal Input auto-detecting a shell command.](../../../../assets/terminal/auto-detection-terminal-mode.png)
+<figcaption>Terminal (shell) mode detected.</figcaption>
+</figure>
 
 :::note
 The model Warp uses to detect natural language automatically is completely local.
@@ -89,9 +95,15 @@ By default, auto-detection is enabled. This means Warp decides whether to treat 
   * `CMD+I` (macOS)
   * `CTRL+I` (Windows/Linux)
 
-| Agent (natural language) mode enabled                                                              | Terminal (shell) mode enabled                                                                   |
-| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| <img src="../../../../assets/terminal/auto-detection-off-terminal-mode.png" alt="" data-size="original" /> | <img src="../../../../assets/terminal/auto-detection-off-agent-mode.png" alt="" data-size="original" /> |
+<figure>
+![Universal Input with auto-detection off in Agent Mode.](../../../../assets/terminal/auto-detection-off-agent-mode.png)
+<figcaption>Agent (natural language) mode enabled.</figcaption>
+</figure>
+
+<figure>
+![Universal Input with auto-detection off in Terminal Mode.](../../../../assets/terminal/auto-detection-off-terminal-mode.png)
+<figcaption>Terminal (shell) mode enabled.</figcaption>
+</figure>
 
 ### Entering Agent Mode
 


### PR DESCRIPTION
## Summary

Fix 4 broken images (404s) on the Universal Input (Legacy) page flagged by Ahrefs.

## Changes

### src/content/docs/terminal/input/universal-input.mdx
- Replaced 2 markdown tables containing raw `<img src>` tags with standard markdown image syntax
- Astro's image pipeline doesn't process `<img src>` with relative paths to `src/assets/`, so the 4 auto-detection images were returning 404
- Added descriptive alt text to 2 images that previously had empty `alt=""` attributes

**Broken images fixed:**
- `auto-detection-off-terminal-mode.png`
- `auto-detection-terminal-mode.png`
- `auto-detection-agent-mode-1.png`
- `auto-detection-off-agent-mode.png`

---
[Warp conversation](https://staging.warp.dev/conversation/81069cdc-4460-448b-8e84-b1cb11718cdf)

Co-Authored-By: Oz <oz-agent@warp.dev>
