### PR TITLE
fix: add 7 redirects for broken external links to docs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9537,6 +9537,41 @@
       "source": "/integrations/integrations-overview/integrations-and-environments",
       "destination": "/reference/cli/integration-setup/",
       "statusCode": 308
+    },
+    {
+      "source": "/features/editor/autosuggestions",
+      "destination": "/terminal/command-completions/autosuggestions/",
+      "statusCode": 308
+    },
+    {
+      "source": "/code/code-permissions",
+      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
+      "statusCode": 308
+    },
+    {
+      "source": "/getting-started/refer-a-friend",
+      "destination": "/support-and-community/community/refer-a-friend/",
+      "statusCode": 308
+    },
+    {
+      "source": "/help/using-warp-offline",
+      "destination": "/support-and-community/troubleshooting-and-support/using-warp-offline/",
+      "statusCode": 308
+    },
+    {
+      "source": "/features/secret-redaction",
+      "destination": "/support-and-community/privacy-and-security/secret-redaction/",
+      "statusCode": 308
+    },
+    {
+      "source": "/features/warp-ai/active-ai",
+      "destination": "/agent-platform/local-agents/active-ai/",
+      "statusCode": 308
+    },
+    {
+      "source": "/oz",
+      "destination": "/agent-platform/cloud-agents/overview/",
+      "statusCode": 308
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add 7 redirect entries in `vercel.json` for broken external links to docs.warp.dev flagged by Ahrefs. These are old paths from before the docs reorganization that were never redirected.

## Changes

### vercel.json
Added 7 redirect entries:
- `/features/editor/autosuggestions` → `/terminal/command-completions/autosuggestions/`
- `/code/code-permissions` → `/agent-platform/capabilities/agent-profiles-permissions/`
- `/getting-started/refer-a-friend` → `/support-and-community/community/refer-a-friend/`
- `/help/using-warp-offline` → `/support-and-community/troubleshooting-and-support/using-warp-offline/`
- `/features/secret-redaction` → `/support-and-community/privacy-and-security/secret-redaction/`
- `/features/warp-ai/active-ai` → `/agent-platform/local-agents/active-ai/`
- `/oz` → `/agent-platform/cloud-agents/overview/`

---
[Warp conversation](https://staging.warp.dev/conversation/81069cdc-4460-448b-8e84-b1cb11718cdf)

Co-Authored-By: Oz <oz-agent@warp.dev>
