### PR TITLE
Link OpenAPI spec from llms.txt and robots.txt

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -148,6 +148,13 @@ export default defineConfig({
 				// widely consumed by AI agents.
 				starlightLlmsTxt({
 					projectName: 'Warp',
+					optionalLinks: [
+						{
+							label: 'Oz Agent API (OpenAPI spec)',
+							url: 'https://docs.warp.dev/openapi.yaml',
+							description: 'Machine-readable OpenAPI 3.0 specification for the Oz Agent API.',
+						},
+					],
 				// Excludes pages that cause a stack overflow in hast-util-to-text
 				// due to their size. The upstream plugin only applies `exclude` to
 				// llms-small.txt; our patch (patches/starlight-llms-txt+0.8.1.patch)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,3 +5,5 @@ Disallow: /*?*ask=*
 Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 Sitemap: https://docs.warp.dev/sitemap-index.xml
+Llms-Txt: https://docs.warp.dev/llms.txt
+OpenAPI: https://docs.warp.dev/openapi.yaml

--- a/src/pages/openapi.yaml.ts
+++ b/src/pages/openapi.yaml.ts
@@ -1,0 +1,18 @@
+import type { APIRoute } from 'astro';
+import fs from 'node:fs';
+
+export const prerender = true;
+
+/**
+ * Serves the raw Oz Agent API OpenAPI spec at /openapi.yaml so LLMs, crawlers,
+ * and developer tooling can consume the machine-readable definition directly.
+ *
+ * The spec source of truth is `developers/agent-api-openapi.yaml` (same file
+ * that `src/pages/api.astro` reads at build time for the Scalar reference).
+ */
+export const GET: APIRoute = async () => {
+	const yaml = fs.readFileSync('developers/agent-api-openapi.yaml', 'utf-8');
+	return new Response(yaml, {
+		headers: { 'Content-Type': 'text/yaml; charset=utf-8' },
+	});
+};


### PR DESCRIPTION
## Summary
Makes the Oz Agent API OpenAPI spec discoverable by AI agents, crawlers, and developer tooling by linking it from `llms.txt` and `robots.txt`.

## Changes
- **`src/pages/openapi.yaml.ts`** — New prerendered Astro endpoint serving the raw spec at `/openapi.yaml` (single source of truth, no file duplication)
- **`astro.config.mjs`** — Added `optionalLinks` to the `starlight-llms-txt` plugin config so `/llms.txt` includes an `## Optional` section with the spec URL
- **`public/robots.txt`** — Added `Llms-Txt` directive (per [llmstxt.org](https://llmstxt.org/) recommendation) and `OpenAPI` directive pointing to the spec

## Context
- [Plan](https://staging.warp.dev/drive/notebook/gjjEq9DemrNbIbKjE6DbCG)
- [Conversation](https://staging.warp.dev/conversation/b4d1233b-218e-457e-9fc3-f766601fe581)

Co-Authored-By: Oz <oz-agent@warp.dev>