### PR TITLE
May 2026 pricing: user-scoped Reload credits + service-account billing

### DIFF
--- a/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
@@ -17,7 +17,9 @@ Add-on credits extend your AI usage beyond the included monthly quota in your pl
 
 If you’ve enabled **Auto reload**, new credits will be added automatically and billed based on your selected configuration of monthly spending limit and selected purchase amount.
 
-Add-on credits are available for Build, Max, Business, and Enterprise plans (with custom pricing for Enterprise). These credits **roll over across billing cycles** and remain valid for **12 months from the purchase date**.
+Add-on credits are available for Build, Max, Business, and Enterprise plans (with custom pricing for Enterprise). On self-serve plans (Build, Max, and Business), Reload credits are scoped to each individual user; Enterprise uses a team-pooled model. These credits **roll over across billing cycles** and remain valid for **12 months from the purchase date**.
+
+Reload credits draw from the same pool as [platform credits](/support-and-community/plans-and-billing/platform-credits/) and compute credits, so a single balance covers all three credit types.
 
 :::caution
 **Legacy plans (Pro, Turbo, Lightspeed) do not support Add-on Credits.** If you're on a legacy plan, you cannot purchase or auto-reload Add-on Credits. To access Add-on Credits, upgrade to the [Build plan](https://app.warp.dev/upgrade). For additional usage on legacy plans, see [Overages (Legacy)](/support-and-community/plans-and-billing/overages-legacy/).
@@ -85,12 +87,20 @@ Team admins manage Reload credit settings for the team in **Settings** > **Billi
 
 **Service account and team-scoped API key requests**
 
-When a request can't be attributed to an individual user — for example, one driven by a service account or a team-scoped API key — Warp bills the usage to the team admin:
+Some AI requests on Warp can't be tied to an individual user — for example, those made through team-scoped API keys, scheduled agents, agent identities, or other service accounts. For these requests, Warp needs a **task billing principal** to charge usage to. On self-serve plans (Build, Max, and Business), that principal is the **team owner**. Usage attribution stays on the service account, but billing rolls up to the team owner.
 
-1. Warp first consumes the admin's included monthly credits.
-2. After those are used, Warp draws from the admin's Reload credits.
-3. If auto-reload is enabled, service-account usage can trigger auto-reload for the admin's Reload pool, subject to the team-wide spend cap.
-4. If the admin has no available credits and auto-reload is off, the request is blocked.
+**When auto-reload is off:**
+
+1. Warp first consumes the team owner's included monthly plan credits.
+2. After those are used, Warp draws from the team owner's Reload credits.
+3. If both are exhausted, the request is blocked.
+
+**When auto-reload is on:**
+
+1. Warp first consumes the team owner's included monthly plan credits.
+2. After those are used, Warp draws from the team owner's Reload credits.
+3. Service-account usage can trigger auto-reload on the team owner's pool — subject to the team-wide monthly spend cap. Once auto-reload tops up the team owner's pool, further service-account requests deplete that reloaded balance.
+4. If the team-wide spend cap is reached and no credits remain, the request is blocked.
 
 :::caution
 **Grandfathering for pre-May 2026 pooled credits**
@@ -104,10 +114,19 @@ Any purchased Add-on Credits remain in your account and can continue to be used 
 
 If you move to the Free plan, you'll lose access to any previously purchased Add-on Credits and won't be able to use them. You also can't buy additional Add-on Credits until you're subscribed again.
 
-**Leaving a paid team**
+:::caution
+Reload credits require an active subscription. If your subscription lapses, ends, or you're no longer a member of a paying team, you lose access to your Reload credits until you reactivate or rejoin.
+:::
 
-If you leave a paid team, you lose access to the Reload credits attributed to you under that team. If you later rejoin the same paid team, you regain access to any non-expired Reload credits that were attributed to you.
+#### When membership or subscription changes
+
+Your access to Reload credits depends on your subscription status and team membership. The flows below describe what happens in common scenarios:
+
+* **A user leaves a paid team** - When you leave a team, you lose access to any remaining Reload credits tied to it. If you rejoin the same team later, you regain access to any unused, non-expired Reload credits. The admin pays a prorated rate for your seat on rejoin.
+* **An admin removes a member** - When an admin removes a member from the team, the member loses access to any remaining Reload credits tied to that team. If they rejoin later, they regain access to any unused, non-expired Reload credits.
+* **An admin deletes the team** - Deleting a team removes access to any remaining Reload credits tied to it. Team members can no longer use those credits.
+* **A user downgrades to Free** - Downgrading to Free forfeits access to Reload credits tied to your previous team. Reload credits require an active subscription.
 
 :::note
-All unused Add-on Credits remain valid for 12 months from purchase, as long as you have an active subscription.&#x20;
+All unused Reload credits remain valid for 12 months from purchase, as long as you have an active subscription.
 :::

--- a/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
@@ -47,10 +47,6 @@ Auto reload uses the same denominations and discounts as manual purchases. The d
 You can opt in and choose your reload amount when subscribing to a paid plan at [app.warp.dev/upgrade](https://app.warp.dev/upgrade), or change your configuration anytime in **Settings** > **Billing and usage**.
 :::
 
-:::caution
-Add-on credit auto reload will be enabled by default for some legacy plan users when they transition to the Build plan. Please see more in our [Pricing FAQs](/support-and-community/plans-and-billing/pricing-faqs/#what-happens-to-my-current-plan-pro-turbo-lightspeed).
-:::
-
 #### **Configuring a monthly spend limit**
 
 Your monthly spend limit sets the maximum amount you can spend on Add-on credits in a single calendar month. This ensures you have full control over your AI usage costs while still allowing flexibility for automatic top-ups when needed, keeping your workflow uninterrupted.

--- a/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
@@ -17,7 +17,7 @@ Add-on credits extend your AI usage beyond the included monthly quota in your pl
 
 If you’ve enabled **Auto reload**, new credits will be added automatically and billed based on your selected configuration of monthly spending limit and selected purchase amount.
 
-Add-on credits are available for Build, Business, and Enterprise plans (with custom pricing for Enterprise). These credits **roll over across billing cycles** and remain valid for **12 months from the purchase date**.
+Add-on credits are available for Build, Max, Business, and Enterprise plans (with custom pricing for Enterprise). These credits **roll over across billing cycles** and remain valid for **12 months from the purchase date**.
 
 :::caution
 **Legacy plans (Pro, Turbo, Lightspeed) do not support Add-on Credits.** If you're on a legacy plan, you cannot purchase or auto-reload Add-on Credits. To access Add-on Credits, upgrade to the [Build plan](https://app.warp.dev/upgrade). For additional usage on legacy plans, see [Overages (Legacy)](/support-and-community/plans-and-billing/overages-legacy/).
@@ -79,27 +79,38 @@ You can track your remaining credits and spending in the credits transparency fo
 
 #### Teams using Add-on Credits
 
-For teams on Build or Business plans, **Add-on Credits are shared across all members.** All team credit settings can be managed in `Settings → Billing and usage` by the admin of the team.
+On Build, Max, and Business self-serve plans, Reload credits are tied to individual users — they are no longer pooled across the team. Each team member's Reload credits draw down only for their own usage.
 
-Team admins can manage:
+Team admins manage Reload credit settings for the team in **Settings** > **Billing and usage**:
 
-* Enabling or disabling Auto reload
-* Adjusting monthly spend limits
-* Choosing Add-on credit increments
-* Viewing usage and spending breakdowns
+* **Team-wide spend cap** — Sets the maximum amount the team can spend on Reload credits per calendar month, applied across all members.
+* **Auto-reload** — When enabled, the admin selects a Reload denomination for the team. Warp automatically purchases that denomination for any user whose Reload balance drops below 100 credits, subject to the team-wide spend cap. While auto-reload is on, individual users cannot purchase Reload credits manually.
+* **Manual purchases** — When auto-reload is off, eligible team members can purchase Reload credits for themselves, as long as the team stays below the team-wide spend cap.
 
-Each user on the team has their own monthly credit limit, **but any usage beyond that personal quota draws from the shared team credits**. These shared credits are tracked and billed collectively at the team level.
+**Service account and team-scoped API key requests**
 
-For example, if your plan includes 1,500 credits per team member:
+When a request can't be attributed to an individual user — for example, one driven by a service account or a team-scoped API key — Warp bills the usage to the team admin:
 
-* If **User A** reaches their 1,500 limit, any further usage will draw from shared Add-on Credits.
-* If **User B** has only used 200 credits, their remaining quota is unaffected, but User A will consume the team's shared credits.
+1. Warp first consumes the admin's included monthly credits.
+2. After those are used, Warp draws from the admin's Reload credits.
+3. If auto-reload is enabled, service-account usage can trigger auto-reload for the admin's Reload pool, subject to the team-wide spend cap.
+4. If the admin has no available credits and auto-reload is off, the request is blocked.
+
+:::caution
+**Grandfathering for pre-May 2026 pooled credits**
+
+Pooled Add-on credits purchased before May 14, 2026 remain available to the team and are consumed first when team members exceed their included monthly credits. No new pooled credits will be added — Reload credit purchases on or after May 14, 2026 are attributed to individual users.
+:::
 
 ### Plan changes and cancellations
 
 Any purchased Add-on Credits remain in your account and can continue to be used for up to 12 months after purchase, as long as you have an active subscription.
 
 If you move to the Free plan, you'll lose access to any previously purchased Add-on Credits and won't be able to use them. You also can't buy additional Add-on Credits until you're subscribed again.
+
+**Leaving a paid team**
+
+If you leave a paid team, you lose access to the Reload credits attributed to you under that team. If you later rejoin the same paid team, you regain access to any non-expired Reload credits that were attributed to you.
 
 :::note
 All unused Add-on Credits remain valid for 12 months from purchase, as long as you have an active subscription.&#x20;

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -133,19 +133,21 @@ The following scenarios do **not** use Cloud Agent Credits:
 
 ### Service account and team-scoped API key billing
 
-When a request can't be attributed to an individual user — for example, one driven by a service account or a team-scoped API key — Warp bills the usage to the team admin's account.
+When a request can't be attributed to an individual user — i.e. it has no individual task billing principal — Warp needs another principal to charge the usage to. This applies to team-scoped API keys, scheduled agents, agent identities, and other service accounts.
 
 #### Self-serve plans
 
-On Build, Max, and Business plans, the billing waterfall for service-account and team-scoped API key requests is:
+On Build, Max, and Business plans, the team owner is the task billing principal for these requests. Attribution stays on the service account, but billing rolls up to the team owner:
 
-1. Warp first consumes the admin's included monthly credits.
-2. After those are used, Warp draws from the admin's Reload credits.
-3. If auto-reload is enabled for the team, service-account usage can trigger auto-reload for the admin's Reload pool, subject to the team-wide spend cap.
-4. If the admin has no available credits and auto-reload is off, the request is blocked.
+1. Warp first consumes the team owner's included monthly credits.
+2. After those are used, Warp draws from the team owner's Reload credits.
+3. If auto-reload is enabled for the team, service-account usage can trigger auto-reload for the team owner's Reload pool, subject to the team-wide spend cap.
+4. If the team owner has no available credits and auto-reload is off, the request is blocked.
+
+[Platform credits](/support-and-community/plans-and-billing/platform-credits/) and compute credits charges also drain through the same Reload credits pool when the team owner is the billing principal — a single balance covers AI credits, platform credits, and compute credits.
 
 For details on auto-reload, manual purchases, and the team-wide spend cap, see [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/).
 
 #### Enterprise plans
 
-On Enterprise plans, service-account and team-scoped API key usage draws from the team's Enterprise credit pool. Overage and pay-as-you-go behavior follows the terms of your Enterprise contract.
+On Enterprise plans, service-account and team-scoped API key usage draws from the team's Enterprise credit pool. When the pool is depleted, traffic falls to pay-as-you-go (PAYG) if enabled in the contract; otherwise the request is blocked. Overage behavior follows your Enterprise contract terms.

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -130,3 +130,22 @@ The following scenarios do **not** use Cloud Agent Credits:
 
 * **Local agent runs** — Using `oz agent run` on your local machine
 * **Self-hosted compute** — Using `oz agent run` on GitHub Actions, CI/CD pipelines, or other self-hosted infrastructure
+
+### Service account and team-scoped API key billing
+
+When a request can't be attributed to an individual user — for example, one driven by a service account or a team-scoped API key — Warp bills the usage to the team admin's account.
+
+#### Self-serve plans
+
+On Build, Max, and Business plans, the billing waterfall for service-account and team-scoped API key requests is:
+
+1. Warp first consumes the admin's included monthly credits.
+2. After those are used, Warp draws from the admin's Reload credits.
+3. If auto-reload is enabled for the team, service-account usage can trigger auto-reload for the admin's Reload pool, subject to the team-wide spend cap.
+4. If the admin has no available credits and auto-reload is off, the request is blocked.
+
+For details on auto-reload, manual purchases, and the team-wide spend cap, see [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/).
+
+#### Enterprise plans
+
+On Enterprise plans, service-account and team-scoped API key usage draws from the team's Enterprise credit pool. Overage and pay-as-you-go behavior follows the terms of your Enterprise contract.


### PR DESCRIPTION
Part of the May 2026 Warp pricing docs overhaul. Targets the umbrella branch `hyc/plan-updates`.

## Summary
- **`add-on-credits.mdx`**
  - Adds Max to the plan eligibility list (Build, Max, Business, Enterprise).
  - Rewrites the `Teams using Add-on Credits` section: Reload credits are now tied to individual users on Build/Max/Business self-serve plans, with an admin-managed team-wide spend cap and auto-reload (admin selects the denomination; fires when any user drops below 100 credits, subject to the spend cap; disables individual purchases when on).
  - Documents the service-account / team-scoped API key billing waterfall to the team admin (included credits → admin's Reload credits → blocked if the admin has none and auto-reload is off; can trigger auto-reload subject to the cap when on).
  - Adds a `:::caution` "Grandfathering for pre-May 2026 pooled credits" callout: existing pooled credits drain first, no new pooled credits are added.
  - Adds a "Leaving a paid team" paragraph under "Plan changes and cancellations" (user loses access to team-attributed Reload credits; rejoining restores any non-expired credits).
  - Strips the legacy `1,500 credits per team member` example and User A/User B framing.

- **`credits.mdx`**
  - Adds a new `### Service account and team-scoped API key billing` section after Cloud Agent Credits, with self-serve (Build/Max/Business waterfall) and Enterprise (draws from the team's Enterprise pool, per custom contract terms) subsections. Links back to `add-on-credits.mdx` for auto-reload/spend-cap details.
  - Model examples left as-is (per the agent task — current list isn't outright wrong).

## Editorial rule compliance
- No per-plan monthly credit counts anywhere in either file.
- Reload denomination SKU prices ($10/400 … $100/6,500) preserved — these are endpoint SKU prices, not plan-included counts.
- 100-credit auto-reload threshold preserved — it's a mechanic, not a plan-included count.

## Plan / context
- Plan artifact (umbrella plan): https://staging.warp.dev/conversation/86bef8eb-7ca7-49d3-a570-91ef0bb57ce6
- Target branch: `hyc/plan-updates` (umbrella)
- Agent ownership: Agent 3 — Reload credits + credits page (`add-on-credits.mdx`, `credits.mdx`)

Co-Authored-By: Oz <oz-agent@warp.dev>