### PR TITLE
BYOK rewrite + new Custom inference endpoint page + sidebar entry

### DIFF
--- a/src/content/docs/support-and-community/plans-and-billing/bring-your-own-api-key.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/bring-your-own-api-key.mdx
@@ -1,14 +1,18 @@
 ---
 title: Bring your own API key
 description: >-
-  Use your own OpenAI, Anthropic, or Google API keys with Warp's agents.
-  BYOK is available on the Free plan and all eligible paid plans, and never
-  consumes Warp credits.
+  Use your own OpenAI, Anthropic, or Google API keys. Never consumes AI
+  credits — on Business and Enterprise, platform credits may apply for
+  local agent runs.
 ---
 
 Warp supports **Bring your own API key (BYOK)** for users who want to connect Warp's agents to their own Anthropic, OpenAI, or Google API accounts.
 
 BYOK gives you full control over model selection, billing, and data routing. See [Model Choice](/agent-platform/capabilities/model-choice/) for the full list of supported models. When you route a request through your own key, Warp **never consumes your** [credits](/support-and-community/plans-and-billing/credits/) for that request.
+
+:::note
+On the Business and Enterprise plans, local agent runs that use BYOK still consume platform credits for Warp's platform infrastructure (run lifecycle, integrations, observability). See [platform credits](/support-and-community/plans-and-billing/platform-credits/) for what's covered.
+:::
 
 :::note
 BYOK is available on the Free plan and on all eligible paid plans. See [warp.dev/pricing](https://www.warp.dev/pricing) for the current list of eligible plans.
@@ -29,6 +33,8 @@ Warp offers three ways to bring your own AI infrastructure. Use this table to pi
 | **[Bring your own LLM](/enterprise/enterprise-features/bring-your-own-llm/)** (BYOLLM) | Enterprise-managed inference through your cloud provider (AWS Bedrock, Azure Foundry, Google Vertex) or approved internal infrastructure, with Warp handling routing, orchestration, governance, and observability. | Enterprise only |
 
 See [warp.dev/pricing](https://www.warp.dev/pricing) for current plan availability.
+
+Platform credits may apply for local agent runs on Business and Enterprise when using BYOK, CIE, or BYOLLM. See [platform credits](/support-and-community/plans-and-billing/platform-credits/).
 
 ## How BYOK works
 

--- a/src/content/docs/support-and-community/plans-and-billing/bring-your-own-api-key.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/bring-your-own-api-key.mdx
@@ -1,25 +1,36 @@
 ---
-title: Bring Your Own API Key
+title: Bring your own API key
 description: >-
-  Warp's paid plans include the ability to bring your own API keys (BYOK) for
-  OpenAI, Anthropic, and Google AI models.
+  Use your own OpenAI, Anthropic, or Google API keys with Warp's agents.
+  BYOK is available on the Free plan and all eligible paid plans, and never
+  consumes Warp credits.
 ---
 
-Warp supports **Bring Your Own Key (BYOK)** for users who want to connect Warp’s agent to their own Anthropic, OpenAI, or Google API accounts.
+Warp supports **Bring your own API key (BYOK)** for users who want to connect Warp's agents to their own Anthropic, OpenAI, or Google API accounts.
 
-This lets you use your own API keys to access models directly, giving you full control over model selection, billing, and data routing. See [Model Choice](/agent-platform/capabilities/model-choice/) for a list of supported models.
-
-BYOK provides greater flexibility in model access and ensures Warp **never consumes your** [credits](/support-and-community/plans-and-billing/credits/) for requests routed through your own keys.
+BYOK gives you full control over model selection, billing, and data routing. See [Model Choice](/agent-platform/capabilities/model-choice/) for the full list of supported models. When you route a request through your own key, Warp **never consumes your** [credits](/support-and-community/plans-and-billing/credits/) for that request.
 
 :::note
-BYOK is currently only available on Warp's paid plans, starting with Build. Learn more about plans and pricing [warp.dev/pricing](https://www.warp.dev/pricing).
+BYOK is available on the Free plan and on all eligible paid plans. See [warp.dev/pricing](https://www.warp.dev/pricing) for the current list of eligible plans.
 :::
 
-## How does BYOK work?
+## How BYOK differs from Custom inference endpoint and BYOLLM
+
+Warp offers three ways to bring your own AI infrastructure. Use this table to pick the right one, and follow the links for full details.
+
+| Name | Meaning | Plans |
+| --- | --- | --- |
+| **Bring your own API key** (BYOK) | Use your own API key for OpenAI, Anthropic, or Google models. Keys are stored locally on your device. | Free and all eligible paid plans |
+| **[Custom inference endpoint](/support-and-community/plans-and-billing/custom-inference-endpoint/)** (CIE) | Connect Warp to an OpenAI-compatible endpoint such as OpenRouter, LiteLLM, z.ai, or an internal gateway. | Free and all eligible paid plans |
+| **[Bring your own LLM](/enterprise/enterprise-features/bring-your-own-llm/)** (BYOLLM) | Enterprise-managed inference through your cloud provider (AWS Bedrock, Azure Foundry, Google Vertex) or approved internal infrastructure, with Warp handling routing, orchestration, governance, and observability. | Enterprise only |
+
+See [warp.dev/pricing](https://www.warp.dev/pricing) for current plan availability.
+
+## How BYOK works
 
 When you add your own model API keys in Warp, those keys are stored **locally on your device** and are **never synced to the cloud**.
 
-Warp uses these API keys to directly route your agent requests to the model provider you've configured.
+Warp uses these API keys to route your agent requests directly to the model provider you've configured.
 
 :::caution
 BYOK does not apply to [Oz Cloud Agents](/agent-platform/cloud-agents/overview/). Because your API keys are stored locally on your device, they are not available to cloud-hosted agent runs. Cloud agent runs always consume [Warp credits](/support-and-community/plans-and-billing/credits/).
@@ -53,9 +64,9 @@ When you explicitly select a model with a key icon, Warp routes requests through
 
 ### Auto Model
 
-Warp's **Auto** models dynamically route requests across different models based on context and performance. Because this routing logic depends on Warp’s infrastructure, **Auto always consumes Warp's credits**, even if you’ve configured your own API keys.
+Warp's **Auto** models dynamically route requests across different models based on context and performance. Because this routing logic depends on Warp's infrastructure, **Auto always consumes Warp's credits**, even if you've configured your own API keys.
 
-To use your own key, select a specific provider model (for example, Claude Sonnet 4.5, GPT-5, or Gemini 2.5 Pro) directly from the model picker with a key icon.
+To use your own key, select a specific provider model (for example, Claude Opus 4.7, Claude Sonnet 4.6, GPT-5.5, or Gemini 3.1 Pro) directly from the model picker with a key icon.
 
 ### Credit usage
 
@@ -93,7 +104,7 @@ If your key:
 
 **Failover and fallback:**
 
-By default, Warp does not fall back to your credits when a BYOK (Bring Your Own Key) request fails.
+By default, Warp does not fall back to your credits when a BYOK request fails.
 
 You can choose to enable **Warp credit fallback**. When enabled, if an agent request fails with your BYOK model (for example, due to an API error or quota limit), Warp will automatically route the request to one of Warp’s provided models. Warp always prioritizes your API keys first and only uses Warp credits when necessary.
 
@@ -113,10 +124,17 @@ Warp itself never stores your LLM API keys.
 
 ### BYOK on Enterprise and Business plans
 
-Currently, BYOK is configured at the **user level**, not the team or admin level:
+Today, BYOK is configured at the **user level** on every plan, including Enterprise and Business:
 
-* Each team member can add and manage their own API keys locally.
-* Team admins cannot yet enforce or share API keys across members.
-* There is currently no organization-level Admin Panel for BYOK management.
+* Each team member can add and manage their own API keys locally on their device.
+* Centrally configured, admin-managed BYOK is not yet available — admins cannot enforce or share API keys across team members from a single place.
+* There is no organization-level Admin Panel for BYOK management today.
 
-If your organization has specific needs for managed keys or enterprise-level control, please contact us at [warp.dev/contact-sales](https://warp.dev/contact-sales).
+If your organization needs centrally managed model routing now, see [Bring your own LLM](/enterprise/enterprise-features/bring-your-own-llm/) for the Enterprise-managed option. To discuss a fit, contact us at [warp.dev/contact-sales](https://warp.dev/contact-sales).
+
+## Related resources
+
+* [Custom inference endpoint](/support-and-community/plans-and-billing/custom-inference-endpoint/) — Route Warp through any OpenAI-compatible endpoint, such as OpenRouter, LiteLLM, z.ai, or an internal gateway.
+* [Bring your own LLM](/enterprise/enterprise-features/bring-your-own-llm/) — Enterprise-managed inference through your cloud provider or approved infrastructure.
+* [Model Choice](/agent-platform/capabilities/model-choice/) — Full list of supported models and `model_id` values.
+* [Credits](/support-and-community/plans-and-billing/credits/) — How Warp credits work and when they're consumed.

--- a/src/content/docs/support-and-community/plans-and-billing/bring-your-own-api-key.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/bring-your-own-api-key.mdx
@@ -14,6 +14,10 @@ BYOK gives you full control over model selection, billing, and data routing. See
 BYOK is available on the Free plan and on all eligible paid plans. See [warp.dev/pricing](https://www.warp.dev/pricing) for the current list of eligible plans.
 :::
 
+:::note
+BYOK and custom inference endpoint support are available for individual users and organizations with 10 or fewer employees, subject to Warp's Terms of Service. Companies or organizations with more than 10 employees require a Warp Business or Enterprise plan to use BYOK.
+:::
+
 ## How BYOK differs from Custom inference endpoint and BYOLLM
 
 Warp offers three ways to bring your own AI infrastructure. Use this table to pick the right one, and follow the links for full details.
@@ -123,6 +127,8 @@ However, when you use your own API key:
 Warp itself never stores your LLM API keys.
 
 ### BYOK on Enterprise and Business plans
+
+BYOK is available to individual users and to organizations with 10 or fewer employees, subject to Warp's Terms of Service. Companies or organizations with more than 10 employees need a Warp Business or Enterprise plan to use BYOK.
 
 Today, BYOK is configured at the **user level** on every plan, including Enterprise and Business:
 

--- a/src/content/docs/support-and-community/plans-and-billing/custom-inference-endpoint.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/custom-inference-endpoint.mdx
@@ -1,9 +1,9 @@
 ---
 title: Custom inference endpoint
 description: >-
-  Connect Warp to any OpenAI-compatible custom inference endpoint, such as
-  OpenRouter, LiteLLM, z.ai, or an internal gateway. Available on the Free
-  plan and all eligible paid plans.
+  Connect Warp to OpenAI-compatible endpoints (OpenRouter, LiteLLM, z.ai,
+  internal gateways). On Business and Enterprise, platform credits may
+  apply for local runs.
 ---
 
 A **Custom inference endpoint (CIE)** lets you connect Warp's agents to any OpenAI-compatible inference endpoint, so you can route AI requests through your preferred model router, hosted gateway, or internal infrastructure.
@@ -69,6 +69,10 @@ When you select a CIE-routed model from the model picker:
 * Inference is billed directly by your endpoint provider, according to their pricing.
 * The credit transparency footer will show "0 credits used" for CIE-routed requests.
 
+:::note
+On Business and Enterprise plans, local agent runs that use a custom inference endpoint still consume platform credits for Warp's platform infrastructure. See [platform credits](/support-and-community/plans-and-billing/platform-credits/) for the full breakdown.
+:::
+
 ### Auto routing still uses Warp credits
 
 Warp's **Auto** models dynamically route across providers using Warp's infrastructure. Because Auto routing depends on Warp, **Auto always consumes Warp's credits**, even if you've configured a custom inference endpoint.
@@ -108,6 +112,8 @@ Warp offers three ways to bring your own AI infrastructure. Use this table to pi
 | **[Bring your own API key](/support-and-community/plans-and-billing/bring-your-own-api-key/)** (BYOK) | Use your own API key for OpenAI, Anthropic, or Google models. Keys are stored locally on your device. | Free and all eligible paid plans |
 | **Custom inference endpoint** (CIE) | Connect Warp to an OpenAI-compatible endpoint such as OpenRouter, LiteLLM, z.ai, or an internal gateway. | Free and all eligible paid plans |
 | **[Bring your own LLM](/enterprise/enterprise-features/bring-your-own-llm/)** (BYOLLM) | Enterprise-managed inference through your cloud provider (AWS Bedrock, Azure Foundry, Google Vertex) or approved internal infrastructure, with Warp handling routing, orchestration, governance, and observability. | Enterprise only |
+
+Platform credits may apply for local agent runs on Business and Enterprise when using BYOK, CIE, or BYOLLM. See [platform credits](/support-and-community/plans-and-billing/platform-credits/).
 
 ## Related resources
 

--- a/src/content/docs/support-and-community/plans-and-billing/custom-inference-endpoint.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/custom-inference-endpoint.mdx
@@ -1,0 +1,111 @@
+---
+title: Custom inference endpoint
+description: >-
+  Connect Warp to any OpenAI-compatible custom inference endpoint, such as
+  OpenRouter, LiteLLM, z.ai, or an internal gateway. Available on the Free
+  plan and all eligible paid plans.
+---
+
+A **Custom inference endpoint (CIE)** lets you connect Warp's agents to any OpenAI-compatible inference endpoint, so you can route AI requests through your preferred model router, hosted gateway, or internal infrastructure.
+
+CIE is the right fit when you want to choose your provider, consolidate billing through a third-party router, or run inference behind your own gateway — without giving up the agent experience inside Warp. When a CIE is configured and selected, Warp **never consumes your** [credits](/support-and-community/plans-and-billing/credits/) for the request.
+
+:::note
+CIE is available on the Free plan and on all eligible paid plans. See [warp.dev/pricing](https://www.warp.dev/pricing) for the current list of eligible plans.
+:::
+
+## Key features
+
+* **OpenAI-compatible** - Works with any endpoint that implements the OpenAI Chat Completions API.
+* **Provider flexibility** - Use a model router (OpenRouter, LiteLLM), a model provider with an OpenAI-compatible surface (z.ai), or your own internal gateway.
+* **No Warp credits consumed** - Inference is billed directly by your endpoint provider; Warp's metered features remain unaffected.
+* **Local configuration** - Endpoint URLs and credentials are stored locally on your device and never synced to the cloud.
+
+## How it works
+
+CIE expects your endpoint to implement the **OpenAI Chat Completions API** (`POST /v1/chat/completions`). Any service that exposes a compatible surface can be used as a CIE target:
+
+* **OpenRouter** - Aggregates many model providers behind a single OpenAI-compatible API and consolidated billing.
+* **LiteLLM** - A self-hosted proxy that exposes a unified, OpenAI-compatible API across providers.
+* **z.ai** - A model provider with an OpenAI-compatible API surface for its models.
+* **Internal gateways** - Any in-house service that fronts model providers behind an OpenAI-compatible endpoint (for example, a corporate AI gateway with logging, redaction, or access control).
+
+When you configure a CIE, Warp stores the endpoint URL, model identifiers, and credentials **locally on your device**. They are never synced to Warp's servers.
+
+:::caution
+CIE does not apply to [Oz Cloud Agents](/agent-platform/cloud-agents/overview/). Because CIE configuration is stored locally, it is not available to cloud-hosted agent runs. Cloud agent runs always consume [Warp credits](/support-and-community/plans-and-billing/credits/).
+:::
+
+When a CIE-routed model is selected:
+
+* Warp **does not consume** any of your [credits](/support-and-community/plans-and-billing/credits/).
+* Costs are billed directly by your endpoint provider.
+* Warp does not retain or store your endpoint credentials on any of its servers.
+
+## Enabling a custom inference endpoint
+
+To enable and configure a custom inference endpoint:
+
+1. In Warp, open **Settings** and search for `custom inference endpoint` to jump to the configuration.
+2. Add your endpoint URL (the base URL that exposes `/v1/chat/completions`) and any required credentials (typically an API key).
+3. Specify the model identifier(s) you want to route through this endpoint.
+4. Save the configuration. Once added, you'll see your custom models appear in the model picker.
+
+When you explicitly select a CIE-routed model from the model picker, Warp routes the request through your endpoint instead of consuming Warp's credits.
+
+The CIE configuration flow mirrors the [Bring your own API key](/support-and-community/plans-and-billing/bring-your-own-api-key/) setup, so the steps will feel familiar if you've already configured BYOK.
+
+## Billing behavior
+
+### Warp credits
+
+When you select a CIE-routed model from the model picker:
+
+* No Warp credits are consumed for that request.
+* Inference is billed directly by your endpoint provider, according to their pricing.
+* The credit transparency footer will show "0 credits used" for CIE-routed requests.
+
+### Auto routing still uses Warp credits
+
+Warp's **Auto** models dynamically route across providers using Warp's infrastructure. Because Auto routing depends on Warp, **Auto always consumes Warp's credits**, even if you've configured a custom inference endpoint.
+
+To use your endpoint, select the specific CIE-backed model from the model picker rather than an Auto option.
+
+### Other AI features in Warp
+
+Some AI-powered features rely on Warp's infrastructure and are unaffected by CIE configuration. These continue to consume credits according to your plan; see [Credits](/support-and-community/plans-and-billing/credits/) for details.
+
+## Zero Data Retention (ZDR)
+
+Warp is **SOC 2 compliant** and has **Zero Data Retention (ZDR)** agreements with all of its contracted LLM providers.
+
+When you use a custom inference endpoint:
+
+* Data retention is determined by **your endpoint provider** and any upstream model providers they route to.
+* Warp **cannot enforce ZDR** for requests sent through a custom inference endpoint.
+* If your endpoint provider does not have ZDR with the underlying model provider, your requests may be retained according to their terms.
+
+Review your endpoint provider's data handling and retention policies before routing sensitive prompts through a CIE.
+
+## Plan availability
+
+CIE is available on the Free plan and on all eligible paid plans. See [warp.dev/pricing](https://www.warp.dev/pricing) for the current list of eligible plans and any plan-specific limits.
+
+Centrally configured, admin-managed CIE for teams is not yet available. Each user configures their own endpoint locally. Enterprise teams that need centrally managed model routing today should see [Bring your own LLM](/enterprise/enterprise-features/bring-your-own-llm/).
+
+## How CIE differs from BYOK and BYOLLM
+
+Warp offers three ways to bring your own AI infrastructure. Use this table to pick the right one, and follow the links for full details.
+
+| Name | Meaning | Plans |
+| --- | --- | --- |
+| **[Bring your own API key](/support-and-community/plans-and-billing/bring-your-own-api-key/)** (BYOK) | Use your own API key for OpenAI, Anthropic, or Google models. Keys are stored locally on your device. | Free and all eligible paid plans |
+| **Custom inference endpoint** (CIE) | Connect Warp to an OpenAI-compatible endpoint such as OpenRouter, LiteLLM, z.ai, or an internal gateway. | Free and all eligible paid plans |
+| **[Bring your own LLM](/enterprise/enterprise-features/bring-your-own-llm/)** (BYOLLM) | Enterprise-managed inference through your cloud provider (AWS Bedrock, Azure Foundry, Google Vertex) or approved internal infrastructure, with Warp handling routing, orchestration, governance, and observability. | Enterprise only |
+
+## Related resources
+
+* [Bring your own API key](/support-and-community/plans-and-billing/bring-your-own-api-key/) — Use your own OpenAI, Anthropic, or Google API keys.
+* [Bring your own LLM](/enterprise/enterprise-features/bring-your-own-llm/) — Enterprise-managed inference through your cloud provider or approved infrastructure.
+* [Model Choice](/agent-platform/capabilities/model-choice/) — Full list of supported models and `model_id` values.
+* [Credits](/support-and-community/plans-and-billing/credits/) — How Warp credits work and when they're consumed.

--- a/src/content/docs/support-and-community/plans-and-billing/custom-inference-endpoint.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/custom-inference-endpoint.mdx
@@ -14,6 +14,10 @@ CIE is the right fit when you want to choose your provider, consolidate billing 
 CIE is available on the Free plan and on all eligible paid plans. See [warp.dev/pricing](https://www.warp.dev/pricing) for the current list of eligible plans.
 :::
 
+:::note
+BYOK and custom inference endpoint support are available for individual users and organizations with 10 or fewer employees, subject to Warp's Terms of Service. Companies or organizations with more than 10 employees require a Warp Business or Enterprise plan to use custom inference endpoints.
+:::
+
 ## Key features
 
 * **OpenAI-compatible** - Works with any endpoint that implements the OpenAI Chat Completions API.
@@ -46,7 +50,7 @@ When a CIE-routed model is selected:
 
 To enable and configure a custom inference endpoint:
 
-1. In Warp, open **Settings** and search for `custom inference endpoint` to jump to the configuration.
+1. In Warp, open **Settings** and search for `inference endpoint` to jump to the configuration.
 2. Add your endpoint URL (the base URL that exposes `/v1/chat/completions`) and any required credentials (typically an API key).
 3. Specify the model identifier(s) you want to route through this endpoint.
 4. Save the configuration. Once added, you'll see your custom models appear in the model picker.
@@ -90,6 +94,8 @@ Review your endpoint provider's data handling and retention policies before rout
 ## Plan availability
 
 CIE is available on the Free plan and on all eligible paid plans. See [warp.dev/pricing](https://www.warp.dev/pricing) for the current list of eligible plans and any plan-specific limits.
+
+CIE is available to individual users and to organizations with 10 or fewer employees, subject to Warp's Terms of Service. Companies or organizations with more than 10 employees need a Warp Business or Enterprise plan to use custom inference endpoints.
 
 Centrally configured, admin-managed CIE for teams is not yet available. Each user configures their own endpoint locally. Enterprise teams that need centrally managed model routing today should see [Bring your own LLM](/enterprise/enterprise-features/bring-your-own-llm/).
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -502,6 +502,7 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 						'support-and-community/plans-and-billing/credits',
 						'support-and-community/plans-and-billing/add-on-credits',
 						'support-and-community/plans-and-billing/bring-your-own-api-key',
+						'support-and-community/plans-and-billing/custom-inference-endpoint',
 						'support-and-community/plans-and-billing/overages-legacy',
 						'support-and-community/plans-and-billing/pricing-faqs',
 					],


### PR DESCRIPTION
Part of the **May 2026 Warp pricing docs overhaul** on `hyc/plan-updates`. Agent 2 of the four-agent fan-out: BYOK + new CIE page + sidebar.

## Summary

- **Rewrite `bring-your-own-api-key.mdx`** to open BYOK to the Free plan + all eligible paid plans (previously gated to paid plans starting with Build).
- **Create `custom-inference-endpoint.mdx`** under `support-and-community/plans-and-billing/` documenting Warp's new OpenAI-compatible Custom inference endpoint feature.
- **Update `src/sidebar.ts`** to surface the new Custom inference endpoint page in the Plans and billing section, immediately after BYOK.

## Why

The May 2026 launch introduces a new Custom inference endpoint (CIE) feature and opens BYOK up to Free. We need clean, side-by-side docs that disambiguate three ways to bring your own AI infrastructure:

- **BYOK** — user-level API keys for OpenAI / Anthropic / Google (Free + paid)
- **CIE** — any OpenAI-compatible endpoint such as OpenRouter, LiteLLM, z.ai, or an internal gateway (Free + paid)
- **BYOLLM** — Enterprise-managed inference via Bedrock / Vertex / Foundry or approved internal infrastructure (Enterprise only)

Both pages include the same three-row comparison matrix so readers landing on either page can pick the right option.

## BYOK page changes

- Switched the eligibility callout from \"paid plans, starting with Build\" to \"Free plan and all eligible paid plans.\"
- Added a new top-level \"How BYOK differs from Custom inference endpoint and BYOLLM\" section with a Name / Meaning / Plans table.
- Refreshed model examples (Claude Sonnet 4.5 / GPT-5 / Gemini 2.5 Pro → Claude Opus 4.7 / Claude Sonnet 4.6 / GPT-5.5 / Gemini 3.1 Pro) for parity with the Model Choice page.
- Reframed the \"BYOK on Enterprise and Business plans\" subsection: BYOK is configured at the user level today, centrally configured admin-managed BYOK is not yet available, and Enterprise teams that need centrally managed routing should look at BYOLLM.
- Added a \"Related resources\" section linking to CIE, BYOLLM, Model Choice, and Credits.
- Switched the frontmatter title to sentence case (\"Bring your own API key\") for consistency with the BYOLLM page.

## CIE page

New page built from the feature-doc template at `.warp/templates/feature-doc.md` (mirrored in `.agents/templates/feature-doc.md`). Sections:

- Opening + plan-availability note
- Key features
- How it works (OpenAI Chat Completions requirement; OpenRouter / LiteLLM / z.ai / internal gateways as example targets)
- Enabling a custom inference endpoint (Settings search flow; cross-link to BYOK setup)
- Billing behavior (no Warp credits consumed; Auto still consumes credits; other Warp AI features unaffected)
- Zero Data Retention (ZDR depends on endpoint provider; Warp cannot enforce)
- Plan availability (Free + eligible paid plans; admin-managed CIE for teams not yet available)
- How CIE differs from BYOK and BYOLLM (same comparison matrix)
- Related resources

## Editorial rule

Per the May 2026 plan, neither page hard-codes per-plan monthly credit counts. Both link to [warp.dev/pricing](https://www.warp.dev/pricing) for current allowances.

## Files touched

- `src/content/docs/support-and-community/plans-and-billing/bring-your-own-api-key.mdx` — rewrite
- `src/content/docs/support-and-community/plans-and-billing/custom-inference-endpoint.mdx` — new
- `src/sidebar.ts` — single-line addition after the BYOK entry (line ~504)

## Coordination

- Targets the umbrella branch `hyc/plan-updates`, not `main`.
- Only this agent (Agent 2) touches `src/sidebar.ts` per the orchestration plan.
- No collisions with Agents 1, 3, or 4: this PR does not touch `pricing-faqs.mdx`, `add-on-credits.mdx`, `credits.mdx`, `bring-your-own-llm.mdx`, `plans-pricing-refunds.mdx`, `enterprise/support-and-resources/billing.mdx`, or `plans-and-billing/index.mdx`.

## Conversation

Drafted via Warp: https://staging.warp.dev/conversation/8f67eb03-74a7-4efe-9d60-7cd2ea7af40f

Co-Authored-By: Oz <oz-agent@warp.dev>