### PR TITLE
fix: update devalue to resolve CVE-2026-42570

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8232,9 +8232,9 @@
       "license": "MIT"
     },
     "node_modules/devalue": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
-      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {


### PR DESCRIPTION
## Summary
- Updates the transitive `devalue` npm dependency from `5.7.1` to `5.8.1` in `package-lock.json`.
- Resolves `CVE-2026-42570` / `GHSA-77vg-94rm-hx3p` for sparse array deserialization DoS in Svelte `devalue`.
- This is a lockfile-only transitive dependency update; no source changes or overrides were needed.

## Security context
- Advisory: https://github.com/sveltejs/devalue/security/advisories/GHSA-77vg-94rm-hx3p
- Release: https://github.com/sveltejs/devalue/releases/tag/v5.8.1
- Dependabot alert: https://github.com/warpdotdev/docs/security/dependabot/9
- Dependency relationship: transitive runtime dependency
- Manifest: `package-lock.json`

## Verification
- `npm audit --json` confirms `devalue_present=false`; remaining audit findings are unrelated existing alerts.
- `npm run build`
- `npm run typecheck` (0 errors; existing hints only)

_Conversation: https://staging.warp.dev/conversation/a53b4723-b805-4dc6-b28c-a0d226156c20_
_Run: https://oz.staging.warp.dev/runs/019e2c5d-c6c2-79b5-bc29-b0c2d63f16f6_
_This PR was generated with [Oz](https://warp.dev/oz)._
