### PR TITLE
docs: add Platform Credits page and three-bucket model

### DIFF
--- a/.agents/references/terminology.md
+++ b/.agents/references/terminology.md
@@ -231,10 +231,11 @@ For the summary of the most critical terms (core features, Oz terms, terms to av
 ## Billing and credits
 
 - **Add-on Credits** — capitalized as a product feature name
-- **Cloud Agent Credits** — capitalized as a billing feature name; the compute bucket, consumed when an agent run uses Warp-hosted compute
+- **Compute credits** — sentence case; the compute bucket, consumed when an agent run uses Warp-hosted compute. Use alongside AI credits and Platform Credits when describing credit types.
+- **Cloud agent credits** — sentence case ("Cloud" capitalized); credits consumed by cloud agents, in contrast with local agent credits. Refers to the same compute bucket as Compute credits; choose the term that fits the framing.
 - **Platform Credits** — capitalized as a billing feature name; the platform-infrastructure bucket
 - **credits** — the unit of usage for AI features in Warp (lowercase, not "AI credits")
-- **plan credits** — credits included with a subscription plan
+- **normal Warp credits** — credits included with a subscription plan. Use in user-facing copy rather than "plan credits."
 
 ## External product names
 

--- a/.agents/references/terminology.md
+++ b/.agents/references/terminology.md
@@ -231,9 +231,9 @@ For the summary of the most critical terms (core features, Oz terms, terms to av
 ## Billing and credits
 
 - **Add-on Credits** — capitalized as a product feature name
-- **Compute credits** — sentence case; the compute bucket, consumed when an agent run uses Warp-hosted compute. Use alongside AI credits and Platform Credits when describing credit types.
-- **cloud agent credits** — lowercase common noun; capitalize the first letter only at the start of a sentence or bullet. Credits consumed by cloud agents, in contrast with local agent credits. Refers to the same compute bucket as Compute credits; choose the term that fits the framing.
-- **Platform Credits** — capitalized as a billing feature name; the platform-infrastructure bucket
+- **compute credits** — lowercase common noun; capitalize the first letter only at the start of a sentence or bullet. The compute bucket, consumed when an agent run uses Warp-hosted compute. Use alongside AI credits and platform credits when describing credit types.
+- **cloud agent credits** — lowercase common noun; capitalize the first letter only at the start of a sentence or bullet. Credits consumed by cloud agents, in contrast with local agent credits. Refers to the same compute bucket as compute credits; choose the term that fits the framing.
+- **platform credits** — lowercase common noun; capitalize the first letter only at the start of a sentence or bullet. The platform-infrastructure bucket, consumed for every cloud agent run plus local runs with customer-supplied inference.
 - **credits** — the unit of usage for AI features in Warp (lowercase, not "AI credits")
 - **normal Warp credits** — credits included with a subscription plan. Use in user-facing copy rather than "plan credits."
 

--- a/.agents/references/terminology.md
+++ b/.agents/references/terminology.md
@@ -231,7 +231,8 @@ For the summary of the most critical terms (core features, Oz terms, terms to av
 ## Billing and credits
 
 - **Add-on Credits** — capitalized as a product feature name
-- **Cloud Agent Credits** — capitalized as a billing feature name
+- **compute credits** — lowercase; the compute bucket, consumed when an agent run uses Warp-hosted compute. Do not use the older name "Cloud Agent Credits."
+- **Platform Credits** — capitalized as a billing feature name; the platform-infrastructure bucket
 - **credits** — the unit of usage for AI features in Warp (lowercase, not "AI credits")
 - **plan credits** — credits included with a subscription plan
 

--- a/.agents/references/terminology.md
+++ b/.agents/references/terminology.md
@@ -232,7 +232,7 @@ For the summary of the most critical terms (core features, Oz terms, terms to av
 
 - **Add-on Credits** — capitalized as a product feature name
 - **Compute credits** — sentence case; the compute bucket, consumed when an agent run uses Warp-hosted compute. Use alongside AI credits and Platform Credits when describing credit types.
-- **Cloud agent credits** — sentence case ("Cloud" capitalized); credits consumed by cloud agents, in contrast with local agent credits. Refers to the same compute bucket as Compute credits; choose the term that fits the framing.
+- **cloud agent credits** — lowercase common noun; capitalize the first letter only at the start of a sentence or bullet. Credits consumed by cloud agents, in contrast with local agent credits. Refers to the same compute bucket as Compute credits; choose the term that fits the framing.
 - **Platform Credits** — capitalized as a billing feature name; the platform-infrastructure bucket
 - **credits** — the unit of usage for AI features in Warp (lowercase, not "AI credits")
 - **normal Warp credits** — credits included with a subscription plan. Use in user-facing copy rather than "plan credits."

--- a/.agents/references/terminology.md
+++ b/.agents/references/terminology.md
@@ -231,7 +231,7 @@ For the summary of the most critical terms (core features, Oz terms, terms to av
 ## Billing and credits
 
 - **Add-on Credits** — capitalized as a product feature name
-- **compute credits** — lowercase; the compute bucket, consumed when an agent run uses Warp-hosted compute. Do not use the older name "Cloud Agent Credits."
+- **Cloud Agent Credits** — capitalized as a billing feature name; the compute bucket, consumed when an agent run uses Warp-hosted compute
 - **Platform Credits** — capitalized as a billing feature name; the platform-infrastructure bucket
 - **credits** — the unit of usage for AI features in Warp (lowercase, not "AI credits")
 - **plan credits** — credits included with a subscription plan

--- a/.agents/references/terminology.md
+++ b/.agents/references/terminology.md
@@ -235,7 +235,7 @@ For the summary of the most critical terms (core features, Oz terms, terms to av
 - **cloud agent credits** — lowercase common noun; capitalize the first letter only at the start of a sentence or bullet. Credits consumed by cloud agents, in contrast with local agent credits. Refers to the same compute bucket as compute credits; choose the term that fits the framing.
 - **platform credits** — lowercase common noun; capitalize the first letter only at the start of a sentence or bullet. The platform-infrastructure bucket, consumed for every cloud agent run plus local runs with customer-supplied inference.
 - **credits** — the unit of usage for AI features in Warp (lowercase, not "AI credits")
-- **normal Warp credits** — credits included with a subscription plan. Use in user-facing copy rather than "plan credits."
+- **Warp credits** — credits included with a subscription plan. Use in user-facing copy rather than "plan credits."
 
 ## External product names
 

--- a/.agents/skills/style_lint/style_lint.py
+++ b/.agents/skills/style_lint/style_lint.py
@@ -35,7 +35,7 @@ EXCLUDED_DIRS = {"_book", "node_modules", ".docs"}
 # Feature names that are correctly Title Case (exceptions to sentence-case rule)
 PROPER_FEATURE_NAMES = {
     "Admin Panel", "Agent Management Panel", "Agent Mode", "Agent Profiles",
-    "Ambient Agents", "Auto-detection Mode", "Cloud Agent Credits",
+    "Ambient Agents", "Auto-detection Mode",
     "Codebase Context", "Code Review", "Command Palette", "Global Rules",
     "Oz CLI", "Oz Platform", "Platform Credits", "Project Rules",
     "Slash Commands", "Terminal Mode", "Universal Input", "Warp Drive",
@@ -45,6 +45,7 @@ PROPER_FEATURE_NAMES = {
 # Terminology: wrong → right (case-sensitive checks)
 PRODUCT_CASING = {
     "Warp Terminal": ("Warp", "Use 'Warp' unless specifically distinguishing from Oz"),
+    "Cloud Agent Credits": ("Cloud agent credits", "Use sentence case 'Cloud agent credits' (host-context) or 'compute credits' (bucket-context)"),
     "agent mode": ("Agent Mode", "Capitalize as a feature name"),
     "agent management panel": ("Agent Management Panel", "Capitalize as a UI surface name"),
     "warp drive": ("Warp Drive", "Capitalize as a feature name"),

--- a/.agents/skills/style_lint/style_lint.py
+++ b/.agents/skills/style_lint/style_lint.py
@@ -35,7 +35,7 @@ EXCLUDED_DIRS = {"_book", "node_modules", ".docs"}
 # Feature names that are correctly Title Case (exceptions to sentence-case rule)
 PROPER_FEATURE_NAMES = {
     "Admin Panel", "Agent Management Panel", "Agent Mode", "Agent Profiles",
-    "Ambient Agents", "Auto-detection Mode",
+    "Ambient Agents", "Auto-detection Mode", "Cloud Agent Credits",
     "Codebase Context", "Code Review", "Command Palette", "Global Rules",
     "Oz CLI", "Oz Platform", "Platform Credits", "Project Rules",
     "Slash Commands", "Terminal Mode", "Universal Input", "Warp Drive",
@@ -45,8 +45,6 @@ PROPER_FEATURE_NAMES = {
 # Terminology: wrong → right (case-sensitive checks)
 PRODUCT_CASING = {
     "Warp Terminal": ("Warp", "Use 'Warp' unless specifically distinguishing from Oz"),
-    "Cloud Agent Credits": ("compute credits", "Renamed in 2026; use lowercase 'compute credits'"),
-    "Cloud Agent Credit": ("compute credit", "Renamed in 2026; use lowercase 'compute credit'"),
     "agent mode": ("Agent Mode", "Capitalize as a feature name"),
     "agent management panel": ("Agent Management Panel", "Capitalize as a UI surface name"),
     "warp drive": ("Warp Drive", "Capitalize as a feature name"),

--- a/.agents/skills/style_lint/style_lint.py
+++ b/.agents/skills/style_lint/style_lint.py
@@ -45,7 +45,7 @@ PROPER_FEATURE_NAMES = {
 # Terminology: wrong → right (case-sensitive checks)
 PRODUCT_CASING = {
     "Warp Terminal": ("Warp", "Use 'Warp' unless specifically distinguishing from Oz"),
-    "Cloud Agent Credits": ("Cloud agent credits", "Use sentence case 'Cloud agent credits' (host-context) or 'compute credits' (bucket-context)"),
+    "Cloud Agent Credits": ("cloud agent credits", "Use lowercase 'cloud agent credits' (host-context) or 'compute credits' (bucket-context); capitalize first letter only at start of a sentence/bullet"),
     "agent mode": ("Agent Mode", "Capitalize as a feature name"),
     "agent management panel": ("Agent Management Panel", "Capitalize as a UI surface name"),
     "warp drive": ("Warp Drive", "Capitalize as a feature name"),

--- a/.agents/skills/style_lint/style_lint.py
+++ b/.agents/skills/style_lint/style_lint.py
@@ -35,15 +35,18 @@ EXCLUDED_DIRS = {"_book", "node_modules", ".docs"}
 # Feature names that are correctly Title Case (exceptions to sentence-case rule)
 PROPER_FEATURE_NAMES = {
     "Admin Panel", "Agent Management Panel", "Agent Mode", "Agent Profiles",
-    "Ambient Agents", "Auto-detection Mode", "Cloud Agent Credits",
+    "Ambient Agents", "Auto-detection Mode",
     "Codebase Context", "Code Review", "Command Palette", "Global Rules",
-    "Oz CLI", "Oz Platform", "Project Rules", "Slash Commands",
-    "Terminal Mode", "Universal Input", "Warp Drive", "Warp Platform",
+    "Oz CLI", "Oz Platform", "Platform Credits", "Project Rules",
+    "Slash Commands", "Terminal Mode", "Universal Input", "Warp Drive",
+    "Warp Platform",
 }
 
 # Terminology: wrong → right (case-sensitive checks)
 PRODUCT_CASING = {
     "Warp Terminal": ("Warp", "Use 'Warp' unless specifically distinguishing from Oz"),
+    "Cloud Agent Credits": ("compute credits", "Renamed in 2026; use lowercase 'compute credits'"),
+    "Cloud Agent Credit": ("compute credit", "Renamed in 2026; use lowercase 'compute credit'"),
     "agent mode": ("Agent Mode", "Capitalize as a feature name"),
     "agent management panel": ("Agent Management Panel", "Capitalize as a UI surface name"),
     "warp drive": ("Warp Drive", "Capitalize as a feature name"),

--- a/.agents/skills/style_lint/style_lint.py
+++ b/.agents/skills/style_lint/style_lint.py
@@ -37,7 +37,7 @@ PROPER_FEATURE_NAMES = {
     "Admin Panel", "Agent Management Panel", "Agent Mode", "Agent Profiles",
     "Ambient Agents", "Auto-detection Mode",
     "Codebase Context", "Code Review", "Command Palette", "Global Rules",
-    "Oz CLI", "Oz Platform", "Platform Credits", "Project Rules",
+    "Oz CLI", "Oz Platform", "Project Rules",
     "Slash Commands", "Terminal Mode", "Universal Input", "Warp Drive",
     "Warp Platform",
 }
@@ -46,6 +46,7 @@ PROPER_FEATURE_NAMES = {
 PRODUCT_CASING = {
     "Warp Terminal": ("Warp", "Use 'Warp' unless specifically distinguishing from Oz"),
     "Cloud Agent Credits": ("cloud agent credits", "Use lowercase 'cloud agent credits' (host-context) or 'compute credits' (bucket-context); capitalize first letter only at start of a sentence/bullet"),
+    "Platform Credits": ("platform credits", "Use lowercase 'platform credits'; capitalize first letter only at start of a sentence/bullet/heading"),
     "agent mode": ("Agent Mode", "Capitalize as a feature name"),
     "agent management panel": ("Agent Management Panel", "Capitalize as a UI surface name"),
     "warp drive": ("Warp Drive", "Capitalize as a feature name"),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -613,7 +613,7 @@ Product feature names retain their standard capitalization. Match the exact casi
 - **compute credits** (lowercase common noun; capitalize the first letter only at the start of a sentence or bullet) - the compute bucket; consumed when an agent run uses Warp-hosted compute. Used alongside AI credits and platform credits when describing credit types.
 - **cloud agent credits** (lowercase common noun; capitalize the first letter only at the start of a sentence or bullet) - credits consumed by cloud agents (in contrast with local agent credits). Refers to the same compute bucket as compute credits; pick the term that fits the framing.
 - **platform credits** (lowercase common noun; capitalize the first letter only at the start of a sentence or bullet) - the platform-infrastructure bucket
-- **normal Warp credits** - credits included with a subscription plan. Use in user-facing copy rather than "plan credits."
+- **Warp credits** - credits included with a subscription plan. Use in user-facing copy rather than "plan credits."
 - Use "credit" or "credits" without the "AI" prefix throughout documentation
 
 ### UI elements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -611,7 +611,7 @@ Product feature names retain their standard capitalization. Match the exact casi
 - **credits** (lowercase, not "AI credits") - the unit of usage for AI features in Warp
 - **Add-on Credits** (capitalized as a product feature name)
 - **Compute credits** (sentence case) - the compute bucket; consumed when an agent run uses Warp-hosted compute. Used alongside AI credits and Platform Credits when describing credit types.
-- **Cloud agent credits** (sentence case, "Cloud" capitalized) - credits consumed by cloud agents (in contrast with local agent credits). Refers to the same compute bucket as Compute credits; pick the term that fits the framing.
+- **cloud agent credits** (lowercase common noun; capitalize the first letter only at the start of a sentence or bullet) - credits consumed by cloud agents, in contrast with local agent credits. Refers to the same compute bucket as Compute credits; pick the term that fits the framing.
 - **Platform Credits** (capitalized as a billing feature name) - the platform-infrastructure bucket
 - **normal Warp credits** - credits included with a subscription plan. Use in user-facing copy rather than "plan credits."
 - Use "credit" or "credits" without the "AI" prefix throughout documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,7 +610,7 @@ Product feature names retain their standard capitalization. Match the exact casi
 ### Billing and credits
 - **credits** (lowercase, not "AI credits") - the unit of usage for AI features in Warp
 - **Add-on Credits** (capitalized as a product feature name)
-- **compute credits** (lowercase) - the compute bucket; consumed when an agent run uses Warp-hosted compute. Do not use the older name "Cloud Agent Credits."
+- **Cloud Agent Credits** (capitalized as a billing feature name) - the compute bucket; consumed when an agent run uses Warp-hosted compute
 - **Platform Credits** (capitalized as a billing feature name) - the platform-infrastructure bucket
 - **plan credits** - credits included with a subscription plan
 - Use "credit" or "credits" without the "AI" prefix throughout documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,9 +610,10 @@ Product feature names retain their standard capitalization. Match the exact casi
 ### Billing and credits
 - **credits** (lowercase, not "AI credits") - the unit of usage for AI features in Warp
 - **Add-on Credits** (capitalized as a product feature name)
-- **Cloud Agent Credits** (capitalized as a billing feature name) - the compute bucket; consumed when an agent run uses Warp-hosted compute
+- **Compute credits** (sentence case) - the compute bucket; consumed when an agent run uses Warp-hosted compute. Used alongside AI credits and Platform Credits when describing credit types.
+- **Cloud agent credits** (sentence case, "Cloud" capitalized) - credits consumed by cloud agents (in contrast with local agent credits). Refers to the same compute bucket as Compute credits; pick the term that fits the framing.
 - **Platform Credits** (capitalized as a billing feature name) - the platform-infrastructure bucket
-- **plan credits** - credits included with a subscription plan
+- **normal Warp credits** - credits included with a subscription plan. Use in user-facing copy rather than "plan credits."
 - Use "credit" or "credits" without the "AI" prefix throughout documentation
 
 ### UI elements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,9 +610,9 @@ Product feature names retain their standard capitalization. Match the exact casi
 ### Billing and credits
 - **credits** (lowercase, not "AI credits") - the unit of usage for AI features in Warp
 - **Add-on Credits** (capitalized as a product feature name)
-- **Compute credits** (sentence case) - the compute bucket; consumed when an agent run uses Warp-hosted compute. Used alongside AI credits and Platform Credits when describing credit types.
-- **cloud agent credits** (lowercase common noun; capitalize the first letter only at the start of a sentence or bullet) - credits consumed by cloud agents, in contrast with local agent credits. Refers to the same compute bucket as Compute credits; pick the term that fits the framing.
-- **Platform Credits** (capitalized as a billing feature name) - the platform-infrastructure bucket
+- **compute credits** (lowercase common noun; capitalize the first letter only at the start of a sentence or bullet) - the compute bucket; consumed when an agent run uses Warp-hosted compute. Used alongside AI credits and platform credits when describing credit types.
+- **cloud agent credits** (lowercase common noun; capitalize the first letter only at the start of a sentence or bullet) - credits consumed by cloud agents (in contrast with local agent credits). Refers to the same compute bucket as compute credits; pick the term that fits the framing.
+- **platform credits** (lowercase common noun; capitalize the first letter only at the start of a sentence or bullet) - the platform-infrastructure bucket
 - **normal Warp credits** - credits included with a subscription plan. Use in user-facing copy rather than "plan credits."
 - Use "credit" or "credits" without the "AI" prefix throughout documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,7 +610,8 @@ Product feature names retain their standard capitalization. Match the exact casi
 ### Billing and credits
 - **credits** (lowercase, not "AI credits") - the unit of usage for AI features in Warp
 - **Add-on Credits** (capitalized as a product feature name)
-- **Cloud Agent Credits** (capitalized as a billing feature name)
+- **compute credits** (lowercase) - the compute bucket; consumed when an agent run uses Warp-hosted compute. Do not use the older name "Cloud Agent Credits."
+- **Platform Credits** (capitalized as a billing feature name) - the platform-infrastructure bucket
 - **plan credits** - credits included with a subscription plan
 - Use "credit" or "credits" without the "AI" prefix throughout documentation
 

--- a/src/content/docs/agent-platform/cloud-agents/integrations/linear.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/integrations/linear.mdx
@@ -66,7 +66,7 @@ Because PRs are created as _you_, this makes code review, auditing, and team col
 ### Requirements
 
 * **Team membership** - The Linear integration requires you to be part of a [Warp team](/knowledge-and-collaboration/teams/). Teams can be created on any plan, including Free.
-* **Plan and credits** - Your team must be on a plan that supports integrations (Build, Max, or Business) and have at least 20 credits available (any type of Warp credits work). See [Access, Billing, and Identity](/agent-platform/cloud-agents/team-access-billing-and-identity/) for details.
+* **Plan and credits** - Your team must be on a plan that supports integrations (Build, Max, or Business) and have at least 20 credits available. See [Access, Billing, and Identity](/agent-platform/cloud-agents/team-access-billing-and-identity/) for details.
 * **Infrastructure** - By default, agents run on Warp-hosted infrastructure. Enterprise teams can [self-host agents](/agent-platform/cloud-agents/self-hosting/) on their own infrastructure.
 * **Identity** - You must be logged into Warp with the same email as your Linear workspace.
 * **GitHub authorization** - You must authorize the Warp GitHub app the first time you trigger an agent.

--- a/src/content/docs/agent-platform/cloud-agents/integrations/slack.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/integrations/slack.mdx
@@ -80,7 +80,7 @@ Because PRs are created as you, the workflow slots seamlessly into your team’s
 ### Requirements
 
 * **Team membership** - The Slack integration requires you to be part of a [Warp team](/knowledge-and-collaboration/teams/). Teams can be created on any plan, including Free.
-* **Plan and credits** - Your team must be on a plan that supports integrations (Build, Max, or Business) and have at least 20 credits available (any type of Warp credits work). See [Access, Billing, and Identity](/agent-platform/cloud-agents/team-access-billing-and-identity/) for details.
+* **Plan and credits** - Your team must be on a plan that supports integrations (Build, Max, or Business) and have at least 20 credits available. See [Access, Billing, and Identity](/agent-platform/cloud-agents/team-access-billing-and-identity/) for details.
 * **Infrastructure** - By default, agents run on Warp-hosted infrastructure. Enterprise teams can [self-host agents](/agent-platform/cloud-agents/self-hosting/) on their own infrastructure.
 * **Identity** - You must be logged into Warp with the same email used in your Slack workspace.
 * **GitHub authorization** - You must authorize the **Warp GitHub app** the first time you trigger a Slack integration request.

--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -117,7 +117,7 @@ Cloud agents and [integrations](/agent-platform/cloud-agents/integrations/) run 
 
 Individual users can run cloud agents without being on a team. Requirements:
 
-* You need at least 20 credits (any type works: plan credits, [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), or Build plan credits)
+* You need at least 20 credits (any type works: normal Warp credits, [Cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or Build plan credits)
 * Cloud agents run on Warp-hosted infrastructure
 * Self-hosted agents require a team subscription
 
@@ -132,7 +132,7 @@ Integrations require you to be part of a [Warp team](/knowledge-and-collaboratio
 * **Credit requirements**
   * Your team must have at least 20 credits available (any type of Warp credits work) to run cloud agents and integrations.
   * Usage is billed based on credit type and team configuration.
-  * Plan credits, [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
+  * Normal Warp credits, [Cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
 
 For more details, see [Access, Billing, and Identity Permissions](/agent-platform/cloud-agents/team-access-billing-and-identity/).
 

--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -117,7 +117,7 @@ Cloud agents and [integrations](/agent-platform/cloud-agents/integrations/) run 
 
 Individual users can run cloud agents without being on a team. Requirements:
 
-* You need at least 20 credits (any type works: Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/))
+* You need at least 20 credits available
 * Cloud agents run on Warp-hosted infrastructure
 * Self-hosted agents require a team subscription
 
@@ -130,9 +130,7 @@ Integrations require you to be part of a [Warp team](/knowledge-and-collaboratio
   * Not supported: Pro, Turbo, Lightspeed, legacy Business
   * Your plan must support Add-on Credits.
 * **Credit requirements**
-  * Your team must have at least 20 credits available (any type of Warp credits work) to run cloud agents and integrations.
-  * Usage is billed based on credit type and team configuration.
-  * Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
+  * Your team must have at least 20 credits available to run cloud agents and integrations.
 
 For more details, see [Access, Billing, and Identity Permissions](/agent-platform/cloud-agents/team-access-billing-and-identity/).
 

--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -117,7 +117,7 @@ Cloud agents and [integrations](/agent-platform/cloud-agents/integrations/) run 
 
 Individual users can run cloud agents without being on a team. Requirements:
 
-* You need at least 20 credits (any type works: plan credits, [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), or Build plan credits)
+* You need at least 20 credits (any type works: plan credits, [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), or Build plan credits)
 * Cloud agents run on Warp-hosted infrastructure
 * Self-hosted agents require a team subscription
 
@@ -132,7 +132,7 @@ Integrations require you to be part of a [Warp team](/knowledge-and-collaboratio
 * **Credit requirements**
   * Your team must have at least 20 credits available (any type of Warp credits work) to run cloud agents and integrations.
   * Usage is billed based on credit type and team configuration.
-  * Plan credits, [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
+  * Plan credits, [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
 
 For more details, see [Access, Billing, and Identity Permissions](/agent-platform/cloud-agents/team-access-billing-and-identity/).
 

--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -117,7 +117,7 @@ Cloud agents and [integrations](/agent-platform/cloud-agents/integrations/) run 
 
 Individual users can run cloud agents without being on a team. Requirements:
 
-* You need at least 20 credits (any type works: normal Warp credits, [Cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or Build plan credits)
+* You need at least 20 credits (any type works: normal Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or Build plan credits)
 * Cloud agents run on Warp-hosted infrastructure
 * Self-hosted agents require a team subscription
 
@@ -132,7 +132,7 @@ Integrations require you to be part of a [Warp team](/knowledge-and-collaboratio
 * **Credit requirements**
   * Your team must have at least 20 credits available (any type of Warp credits work) to run cloud agents and integrations.
   * Usage is billed based on credit type and team configuration.
-  * Normal Warp credits, [Cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
+  * Normal Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
 
 For more details, see [Access, Billing, and Identity Permissions](/agent-platform/cloud-agents/team-access-billing-and-identity/).
 

--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -117,7 +117,7 @@ Cloud agents and [integrations](/agent-platform/cloud-agents/integrations/) run 
 
 Individual users can run cloud agents without being on a team. Requirements:
 
-* You need at least 20 credits (any type: normal Warp credits, [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), or Build plan credits)
+* You need at least 20 credits (any type works: plan credits, [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), or Build plan credits)
 * Cloud agents run on Warp-hosted infrastructure
 * Self-hosted agents require a team subscription
 
@@ -132,7 +132,7 @@ Integrations require you to be part of a [Warp team](/knowledge-and-collaboratio
 * **Credit requirements**
   * Your team must have at least 20 credits available (any type of Warp credits work) to run cloud agents and integrations.
   * Usage is billed based on credit type and team configuration.
-  * Normal credits, [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
+  * Plan credits, [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
 
 For more details, see [Access, Billing, and Identity Permissions](/agent-platform/cloud-agents/team-access-billing-and-identity/).
 

--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -117,7 +117,7 @@ Cloud agents and [integrations](/agent-platform/cloud-agents/integrations/) run 
 
 Individual users can run cloud agents without being on a team. Requirements:
 
-* You need at least 20 credits (any type works: Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or Build plan credits)
+* You need at least 20 credits (any type works: Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/))
 * Cloud agents run on Warp-hosted infrastructure
 * Self-hosted agents require a team subscription
 

--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -117,7 +117,7 @@ Cloud agents and [integrations](/agent-platform/cloud-agents/integrations/) run 
 
 Individual users can run cloud agents without being on a team. Requirements:
 
-* You need at least 20 credits (any type works: normal Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or Build plan credits)
+* You need at least 20 credits (any type works: Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or Build plan credits)
 * Cloud agents run on Warp-hosted infrastructure
 * Self-hosted agents require a team subscription
 
@@ -132,7 +132,7 @@ Integrations require you to be part of a [Warp team](/knowledge-and-collaboratio
 * **Credit requirements**
   * Your team must have at least 20 credits available (any type of Warp credits work) to run cloud agents and integrations.
   * Usage is billed based on credit type and team configuration.
-  * Normal Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
+  * Warp credits, [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) all work.
 
 For more details, see [Access, Billing, and Identity Permissions](/agent-platform/cloud-agents/team-access-billing-and-identity/).
 

--- a/src/content/docs/agent-platform/cloud-agents/quickstart.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/quickstart.mdx
@@ -157,7 +157,7 @@ Use official Docker Hub images like `node`, `python`, or `rust` for best compati
 Warp prompts you to authorize GitHub when you create an environment or trigger your first agent. If authorization fails or needs updating, see [How GitHub Authorization works](/reference/cli/integration-setup/#how-github-authorization-works). For automated workflows using team API keys, make sure [team GitHub authorization](/agent-platform/cloud-agents/team-access-billing-and-identity/#team-github-authorization) is configured in the Admin Panel. Also verify that repos are correctly configured in your environment with `oz environment get <ENV_ID>`.
 
 **Not enough credits to run cloud agents**\
-Your team needs at least 20 credits available (any type of Warp credits work). Check your credit balance in Settings or see [Access, Billing, and Identity](/agent-platform/cloud-agents/team-access-billing-and-identity/) for details on credit requirements and which plans support cloud agents.
+Your team needs at least 20 credits available. Check your credit balance in Settings or see [Access, Billing, and Identity](/agent-platform/cloud-agents/team-access-billing-and-identity/) for details on credit requirements and which plans support cloud agents.
 
 **More resources**
 

--- a/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
@@ -27,7 +27,7 @@ Cloud agents can be used in two ways:
 * Can use integrations (Slack, Linear) to trigger agents
 * Can self-host agents on their own infrastructure (Enterprise only)
 * Share team-level configuration (environments, secrets, integrations)
-* Team must be on Build, Max, or Business plan with at least 20 credits (any type) for cloud agents and integrations
+* Team must be on Build, Max, or Business plan with at least 20 credits for cloud agents and integrations
 
 ---
 
@@ -79,7 +79,7 @@ Your team must meet the following requirements to run integrations:
 * You must be on a plan that supports **[Reload Credits (Add-on Credits)](/support-and-community/plans-and-billing/add-on-credits/)**.
   * Supported: **Build, Max, Business**
   * Not supported: Pro, Turbo, Lightspeed, legacy Business.
-* Your team needs at least **20 credits** available to run cloud agents and integrations (any type of Warp credits work)
+* Your team needs at least **20 credits** available to run cloud agents and integrations
 
 When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
 

--- a/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
@@ -18,7 +18,7 @@ Cloud agents can be used in two ways:
 
 **Individual users** (without a team):
 * Can run cloud agents via CLI or API
-* Can use plan credits, including [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), or a Build plan with available credits
+* Can use normal Warp credits, including [Cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or a Build plan with available credits
 * Agents run on Warp-hosted infrastructure
 * Cannot use integrations (Slack, Linear) or self-hosted agents
 
@@ -38,7 +38,7 @@ Individual users can run cloud agents via the CLI or API without being part of a
 **How it works:**
 
 * Run agents using `oz agent run-cloud` or the Oz API
-* Credits are drawn from your plan credits (including Cloud Agent Credits, when applicable) or Build plan credits
+* Credits are drawn from your normal Warp credits (including Cloud agent credits, when applicable) or Build plan credits
 * Agents execute on Warp-hosted infrastructure
 
 **What you can do:**
@@ -81,7 +81,7 @@ Your team must meet the following requirements to run integrations:
   * Not supported: Pro, Turbo, Lightspeed, legacy Business.
 * Your team needs at least **20 credits** available to run cloud agents and integrations (any type of Warp credits work)
 
-When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
+When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [Cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
 
 :::note
 If you're on an Enterprise plan, please reach out to [warp.dev/contact-sales](https://warp.dev/contact-sales) with any billing questions related to integrations.

--- a/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
@@ -18,7 +18,7 @@ Cloud agents can be used in two ways:
 
 **Individual users** (without a team):
 * Can run cloud agents via CLI or API
-* Can use normal Warp credits, [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), or a Build plan with available credits
+* Can use plan credits, including [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), or a Build plan with available credits
 * Agents run on Warp-hosted infrastructure
 * Cannot use integrations (Slack, Linear) or self-hosted agents
 
@@ -38,7 +38,7 @@ Individual users can run cloud agents via the CLI or API without being part of a
 **How it works:**
 
 * Run agents using `oz agent run-cloud` or the Oz API
-* Credits are drawn from your normal Warp credits, Cloud Agent Credits (if available), or Build plan credits
+* Credits are drawn from your plan credits (including compute credits, when applicable) or Build plan credits
 * Agents execute on Warp-hosted infrastructure
 
 **What you can do:**
@@ -81,7 +81,7 @@ Your team must meet the following requirements to run integrations:
   * Not supported: Pro, Turbo, Lightspeed, legacy Business.
 * Your team needs at least **20 credits** available to run cloud agents and integrations (any type of Warp credits work)
 
-When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
+When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
 
 :::note
 If you're on an Enterprise plan, please reach out to [warp.dev/contact-sales](https://warp.dev/contact-sales) with any billing questions related to integrations.

--- a/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
@@ -18,7 +18,7 @@ Cloud agents can be used in two ways:
 
 **Individual users** (without a team):
 * Can run cloud agents via CLI or API
-* Can use Warp credits, including [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or a Build plan with available credits
+* Can use Warp credits, including [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits)
 * Agents run on Warp-hosted infrastructure
 * Cannot use integrations (Slack, Linear) or self-hosted agents
 
@@ -38,7 +38,7 @@ Individual users can run cloud agents via the CLI or API without being part of a
 **How it works:**
 
 * Run agents using `oz agent run-cloud` or the Oz API
-* Credits are drawn from your Warp credits (including cloud agent credits, when applicable) or Build plan credits
+* Credits are drawn from your Warp credits (including cloud agent credits, when applicable)
 * Agents execute on Warp-hosted infrastructure
 
 **What you can do:**

--- a/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
@@ -18,7 +18,7 @@ Cloud agents can be used in two ways:
 
 **Individual users** (without a team):
 * Can run cloud agents via CLI or API
-* Can use plan credits, including [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), or a Build plan with available credits
+* Can use plan credits, including [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), or a Build plan with available credits
 * Agents run on Warp-hosted infrastructure
 * Cannot use integrations (Slack, Linear) or self-hosted agents
 
@@ -38,7 +38,7 @@ Individual users can run cloud agents via the CLI or API without being part of a
 **How it works:**
 
 * Run agents using `oz agent run-cloud` or the Oz API
-* Credits are drawn from your plan credits (including compute credits, when applicable) or Build plan credits
+* Credits are drawn from your plan credits (including Cloud Agent Credits, when applicable) or Build plan credits
 * Agents execute on Warp-hosted infrastructure
 
 **What you can do:**
@@ -81,7 +81,7 @@ Your team must meet the following requirements to run integrations:
   * Not supported: Pro, Turbo, Lightspeed, legacy Business.
 * Your team needs at least **20 credits** available to run cloud agents and integrations (any type of Warp credits work)
 
-When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
+When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
 
 :::note
 If you're on an Enterprise plan, please reach out to [warp.dev/contact-sales](https://warp.dev/contact-sales) with any billing questions related to integrations.

--- a/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
@@ -18,7 +18,7 @@ Cloud agents can be used in two ways:
 
 **Individual users** (without a team):
 * Can run cloud agents via CLI or API
-* Can use normal Warp credits, including [Cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or a Build plan with available credits
+* Can use normal Warp credits, including [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or a Build plan with available credits
 * Agents run on Warp-hosted infrastructure
 * Cannot use integrations (Slack, Linear) or self-hosted agents
 
@@ -38,7 +38,7 @@ Individual users can run cloud agents via the CLI or API without being part of a
 **How it works:**
 
 * Run agents using `oz agent run-cloud` or the Oz API
-* Credits are drawn from your normal Warp credits (including Cloud agent credits, when applicable) or Build plan credits
+* Credits are drawn from your normal Warp credits (including cloud agent credits, when applicable) or Build plan credits
 * Agents execute on Warp-hosted infrastructure
 
 **What you can do:**
@@ -81,7 +81,7 @@ Your team must meet the following requirements to run integrations:
   * Not supported: Pro, Turbo, Lightspeed, legacy Business.
 * Your team needs at least **20 credits** available to run cloud agents and integrations (any type of Warp credits work)
 
-When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [Cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
+When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
 
 :::note
 If you're on an Enterprise plan, please reach out to [warp.dev/contact-sales](https://warp.dev/contact-sales) with any billing questions related to integrations.

--- a/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
@@ -18,7 +18,7 @@ Cloud agents can be used in two ways:
 
 **Individual users** (without a team):
 * Can run cloud agents via CLI or API
-* Can use normal Warp credits, including [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or a Build plan with available credits
+* Can use Warp credits, including [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits), or a Build plan with available credits
 * Agents run on Warp-hosted infrastructure
 * Cannot use integrations (Slack, Linear) or self-hosted agents
 
@@ -38,7 +38,7 @@ Individual users can run cloud agents via the CLI or API without being part of a
 **How it works:**
 
 * Run agents using `oz agent run-cloud` or the Oz API
-* Credits are drawn from your normal Warp credits (including cloud agent credits, when applicable) or Build plan credits
+* Credits are drawn from your Warp credits (including cloud agent credits, when applicable) or Build plan credits
 * Agents execute on Warp-hosted infrastructure
 
 **What you can do:**

--- a/src/content/docs/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes.mdx
+++ b/src/content/docs/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes.mdx
@@ -123,7 +123,7 @@ To start a cloud agent conversation, press `⌥⌘↩` (Option+Command+Enter on 
 Cloud agent conversations have a few differences from local conversations:
 
 * **Environment selector** - Choose which [Warp Environment](/agent-platform/cloud-agents/environments/) to run in
-* **Credits indicator** - Shows your remaining cloud agent credits
+* **Credits indicator** - Shows your remaining credits
 * **Different zero state** - The conversation header indicates "New Oz cloud agent conversation"
 
 Cloud agent conversations are always stored in the cloud. For more details on accessing and sharing cloud conversations, see [Cloud-synced Conversations](/agent-platform/local-agents/cloud-conversations/).

--- a/src/content/docs/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes.mdx
+++ b/src/content/docs/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes.mdx
@@ -123,7 +123,7 @@ To start a cloud agent conversation, press `⌥⌘↩` (Option+Command+Enter on 
 Cloud agent conversations have a few differences from local conversations:
 
 * **Environment selector** - Choose which [Warp Environment](/agent-platform/cloud-agents/environments/) to run in
-* **Credits indicator** - Shows your remaining credits
+* **Credits indicator** - Shows your remaining cloud agent credits
 * **Different zero state** - The conversation header indicates "New Oz cloud agent conversation"
 
 Cloud agent conversations are always stored in the cloud. For more details on accessing and sharing cloud conversations, see [Cloud-synced Conversations](/agent-platform/local-agents/cloud-conversations/).

--- a/src/content/docs/enterprise/support-and-resources/billing.mdx
+++ b/src/content/docs/enterprise/support-and-resources/billing.mdx
@@ -31,11 +31,11 @@ Credit allocations vary by contract. Contact your account manager for details on
 
 ## Cloud agent billing
 
-Oz cloud agents consume AI credits for inference, compute credits for the sandbox they run in, and Platform Credits for the orchestration layer. See [Credits](/support-and-community/plans-and-billing/credits/) for the full breakdown of how each credit type is metered.
+Oz cloud agents consume AI credits for inference, Cloud Agent Credits for the sandbox they run in, and Platform Credits for the orchestration layer. See [Credits](/support-and-community/plans-and-billing/credits/) for the full breakdown of how each credit type is metered.
 
 ### How credits are consumed
 
-On Enterprise plans, local and cloud agent usage both draw from the same team credit pool across all three credit types (AI credits, compute credits, and Platform Credits). The credit type a run consumes depends on what infrastructure it uses, not on whether it's local or cloud.
+On Enterprise plans, local and cloud agent usage both draw from the same team credit pool across all three credit types (AI credits, Cloud Agent Credits, and Platform Credits). The credit type a run consumes depends on what infrastructure it uses, not on whether it's local or cloud.
 
 For team API key runs (e.g., CI/CD pipelines, scheduled tasks), credits also draw from the team's shared pool since these runs are not tied to any individual user.
 

--- a/src/content/docs/enterprise/support-and-resources/billing.mdx
+++ b/src/content/docs/enterprise/support-and-resources/billing.mdx
@@ -31,11 +31,11 @@ Credit allocations vary by contract. Contact your account manager for details on
 
 ## Cloud agent billing
 
-Oz cloud agents consume AI credits for inference, Cloud Agent Credits for the sandbox they run in, and Platform Credits for the orchestration layer. See [Credits](/support-and-community/plans-and-billing/credits/) for the full breakdown of how each credit type is metered.
+Oz cloud agents consume AI credits for inference, compute credits for the sandbox they run in, and Platform Credits for the orchestration layer. See [Credits](/support-and-community/plans-and-billing/credits/) for the full breakdown of how each credit type is metered.
 
 ### How credits are consumed
 
-On Enterprise plans, local and cloud agent usage both draw from the same team credit pool across all three credit types (AI credits, Cloud Agent Credits, and Platform Credits). The credit type a run consumes depends on what infrastructure it uses, not on whether it's local or cloud.
+On Enterprise plans, local and cloud agent usage both draw from the same team credit pool across all three credit types (AI credits, compute credits, and Platform Credits). The credit type a run consumes depends on what infrastructure it uses, not on whether it's local or cloud.
 
 For team API key runs (e.g., CI/CD pipelines, scheduled tasks), credits also draw from the team's shared pool since these runs are not tied to any individual user.
 

--- a/src/content/docs/enterprise/support-and-resources/billing.mdx
+++ b/src/content/docs/enterprise/support-and-resources/billing.mdx
@@ -31,11 +31,11 @@ Credit allocations vary by contract. Contact your account manager for details on
 
 ## Cloud agent billing
 
-Oz cloud agents consume AI credits for inference, compute credits for the sandbox they run in, and Platform Credits for the orchestration layer. See [Credits](/support-and-community/plans-and-billing/credits/) for the full breakdown of how each credit type is metered.
+Oz cloud agents consume AI credits for inference, compute credits for the sandbox they run in, and platform credits for the orchestration layer. See [Credits](/support-and-community/plans-and-billing/credits/) for the full breakdown of how each credit type is metered.
 
 ### How credits are consumed
 
-On Enterprise plans, local and cloud agent usage both draw from the same team credit pool across all three credit types (AI credits, compute credits, and Platform Credits). The credit type a run consumes depends on what infrastructure it uses, not on whether it's local or cloud.
+On Enterprise plans, local and cloud agent usage both draw from the same team credit pool across all three credit types (AI credits, compute credits, and platform credits). The credit type a run consumes depends on what infrastructure it uses, not on whether it's local or cloud.
 
 For team API key runs (e.g., CI/CD pipelines, scheduled tasks), credits also draw from the team's shared pool since these runs are not tied to any individual user.
 

--- a/src/content/docs/enterprise/support-and-resources/billing.mdx
+++ b/src/content/docs/enterprise/support-and-resources/billing.mdx
@@ -31,11 +31,11 @@ Credit allocations vary by contract. Contact your account manager for details on
 
 ## Cloud agent billing
 
-Oz cloud agents consume credits that include a small hosting fee in addition to AI usage costs.
+Oz cloud agents consume AI credits for inference, compute credits for the sandbox they run in, and Platform Credits for the orchestration layer. See [Credits](/support-and-community/plans-and-billing/credits/) for the full breakdown of how each credit type is metered.
 
 ### How credits are consumed
 
-On Enterprise plans, both local and cloud agent usage draw from the same team credit pool. There are no separate "cloud agent credits" or "local credits" — all agent usage consumes from your available credit sources.
+On Enterprise plans, local and cloud agent usage both draw from the same team credit pool across all three credit types (AI credits, compute credits, and Platform Credits). The credit type a run consumes depends on what infrastructure it uses, not on whether it's local or cloud.
 
 For team API key runs (e.g., CI/CD pipelines, scheduled tasks), credits also draw from the team's shared pool since these runs are not tied to any individual user.
 

--- a/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
@@ -71,7 +71,7 @@ The limit resets automatically at the start of each calendar month, so you can m
 
 When your monthly credit balance renews:
 
-1. Warp first consumes your included monthly normal Warp credits (e.g., Build plan credits).
+1. Warp first consumes your included monthly Warp credits (e.g., Build plan credits).
 2. After those are used, Warp continues to draw from any available Add-on Credits.
 3. If your Add-on Credits run out and Auto reload is enabled, Warp will automatically purchase more up to your monthly limit.
 

--- a/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
@@ -71,7 +71,7 @@ The limit resets automatically at the start of each calendar month, so you can m
 
 When your monthly credit balance renews:
 
-1. Warp first consumes your included monthly plan credits (e.g., Build plan credits).
+1. Warp first consumes your included monthly normal Warp credits (e.g., Build plan credits).
 2. After those are used, Warp continues to draw from any available Add-on Credits.
 3. If your Add-on Credits run out and Auto reload is enabled, Warp will automatically purchase more up to your monthly limit.
 

--- a/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
@@ -71,7 +71,7 @@ The limit resets automatically at the start of each calendar month, so you can m
 
 When your monthly credit balance renews:
 
-1. Warp first consumes your included monthly Warp credits (e.g., Build plan credits).
+1. Warp first consumes your included monthly credits (e.g., Build plan credits).
 2. After those are used, Warp continues to draw from any available Add-on Credits.
 3. If your Add-on Credits run out and Auto reload is enabled, Warp will automatically purchase more up to your monthly limit.
 

--- a/src/content/docs/support-and-community/plans-and-billing/bring-your-own-api-key.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/bring-your-own-api-key.mdx
@@ -15,6 +15,10 @@ BYOK provides greater flexibility in model access and ensures Warp **never consu
 BYOK is currently only available on Warp's paid plans, starting with Build. Learn more about plans and pricing [warp.dev/pricing](https://www.warp.dev/pricing).
 :::
 
+:::caution
+BYOK and customer-supplied inference (BYOLLM via Amazon Bedrock or Google Vertex, plus custom endpoints) are available to individual users and organizations with 10 or fewer employees or users on any plan. Organizations with more than 10 employees or users must be on a Warp Business or Enterprise plan to use BYOK or customer-supplied inference. See Warp's [Terms of Service](https://www.warp.dev/terms-of-service) for details.
+:::
+
 ## How does BYOK work?
 
 When you add your own model API keys in Warp, those keys are stored **locally on your device** and are **never synced to the cloud**.
@@ -112,6 +116,8 @@ However, when you use your own API key:
 Warp itself never stores your LLM API keys.
 
 ### BYOK on Enterprise and Business plans
+
+Organizations with more than 10 employees or users must be on a Warp Business or Enterprise plan to use BYOK or customer-supplied inference. See Warp's [Terms of Service](https://www.warp.dev/terms-of-service) for the full eligibility rule.
 
 Currently, BYOK is configured at the **user level**, not the team or admin level:
 

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -15,7 +15,7 @@ Credits also include a small hosting fee, charged only when running agents in th
 Warp meters credits across three types of infrastructure — inference, compute, and platform — each with its own bucket:
 
 * **AI credits** cover inference infrastructure that Warp pays for. Agent conversations and other AI features that route through Warp-managed model providers use AI credits.
-* **Cloud Agent Credits** cover compute infrastructure when cloud agents run on Warp-hosted compute. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Cloud Agent Credits** are the compute bucket. They cover Warp-hosted compute consumed by any agent run, local or cloud. In practice, cloud agents draw from this bucket because they run on Warp's compute; local agents typically don't, since they run on your own machine. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
 * **Platform Credits** cover Warp's platform infrastructure, including run lifecycle, integrations, dashboard, APIs, and observability. Platform Credits apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
 
 All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in the Warp app under **Settings** > **Billing and usage**.
@@ -121,7 +121,7 @@ These are the most common factors affecting credit usage, though there are other
 
 ### Cloud Agent Credits
 
-Cloud Agent Credits are a type of credit consumed only by cloud agent runs — AI requests that run on Warp-hosted compute.
+Cloud Agent Credits are the compute credits bucket — consumed when an agent run uses Warp-hosted compute. Both local and cloud agent runs can in principle draw from this pool, but in practice only runs that use Warp's compute do.
 
 #### Eligible for Cloud Agent Credits
 
@@ -134,7 +134,7 @@ The following scenarios use Cloud Agent Credits:
 
 #### Not eligible for Cloud Agent Credits
 
-The following scenarios do **not** use Cloud Agent Credits:
+The following scenarios don't use Cloud Agent Credits because they don't run on Warp-hosted compute:
 
 * **Local agent runs** — Using `oz agent run` on your local machine
 * **Self-hosted compute** — Using `oz agent run` on GitHub Actions, CI/CD pipelines, or other self-hosted infrastructure

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -14,7 +14,7 @@ Warp meters credits across three types of infrastructure — inference, compute,
 
 * **AI credits** cover inference: the LLM call itself. Consumed when Warp pays for the model call through Warp-managed providers.
 * **Compute credits** cover compute: the sandbox an agent runs in. Consumed when an agent run uses Warp-hosted compute. In practice this is cloud agent runs; local agent runs use your own machine and don't consume compute credits. See [Compute credits](/support-and-community/plans-and-billing/credits/#compute-credits).
-* **Platform Credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
+* **Platform credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [platform credits](/support-and-community/plans-and-billing/platform-credits/).
 
 All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in the Warp app under **Settings** > **Billing and usage**.
 
@@ -139,24 +139,24 @@ The following scenarios don't use compute credits because they don't run on Warp
 * **Local agent runs** - Using `oz agent run` on your local machine
 * **Self-hosted compute** - Using `oz agent run` on GitHub Actions, CI/CD pipelines, or other self-hosted infrastructure
 
-### Platform Credits
+### Platform credits
 
-Platform Credits cover Warp's platform infrastructure — run lifecycle, scheduling, integrations, dashboard, APIs, and observability — for every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
+Platform credits cover Warp's platform infrastructure — run lifecycle, scheduling, integrations, dashboard, APIs, and observability — for every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
-#### Eligible for Platform Credits
+#### Eligible for platform credits
 
-Platform Credits are used in the following scenarios:
+Platform credits are used in the following scenarios:
 
-* **Cloud agents on any plan** use Platform Credits for every cloud agent run, regardless of which agent runs the task or which inference source it uses.
-* **Local agents on Business or Enterprise with customer-supplied inference** use Platform Credits when the local agent run uses [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex.
+* **Cloud agents on any plan** use platform credits for every cloud agent run, regardless of which agent runs the task or which inference source it uses.
+* **Local agents on Business or Enterprise with customer-supplied inference** use platform credits when the local agent run uses [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex.
 
-#### Not eligible for Platform Credits
+#### Not eligible for platform credits
 
-The following scenarios do **not** use Platform Credits:
+The following scenarios do **not** use platform credits:
 
-* **Local agents on Free, Build, or Max plans** don't use Platform Credits, regardless of inference source.
-* **Local agents on Business or Enterprise using Warp-managed inference** don't use Platform Credits because Warp is already paying for the model call through AI credits.
-* **Regular terminal usage** doesn't use Platform Credits. Shell commands and non-AI Warp features don't consume credits.
-* **Third-party agent CLIs run directly** don't use Platform Credits when you run `claude`, `codex`, or another agent CLI outside of Oz.
+* **Local agents on Free, Build, or Max plans** don't use platform credits, regardless of inference source.
+* **Local agents on Business or Enterprise using Warp-managed inference** don't use platform credits because Warp is already paying for the model call through AI credits.
+* **Regular terminal usage** doesn't use platform credits. Shell commands and non-AI Warp features don't consume credits.
+* **Third-party agent CLIs run directly** don't use platform credits when you run `claude`, `codex`, or another agent CLI outside of Oz.
 
-For a full breakdown of how Platform Credits work, see [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
+For a full breakdown of how platform credits work, see [platform credits](/support-and-community/plans-and-billing/platform-credits/).

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -14,11 +14,11 @@ Credits also include a small hosting fee, charged only when running agents in th
 
 Warp meters credits across three types of infrastructure — inference, compute, and platform — each with its own bucket:
 
-* **AI credits** - Charged for inference infrastructure Warp pays for. Consumed by Agent conversations and other AI features that route through Warp-managed model providers.
-* **Cloud Agent Credits** - Charged for compute infrastructure when cloud agents run on Warp-hosted compute. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** - Charged for Warp's platform infrastructure (run lifecycle, integrations, dashboard, APIs, and observability). Applies to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
+* **AI credits** cover inference infrastructure that Warp pays for. Agent conversations and other AI features that route through Warp-managed model providers use AI credits.
+* **Cloud Agent Credits** cover compute infrastructure when cloud agents run on Warp-hosted compute. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Platform Credits** cover Warp's platform infrastructure, including run lifecycle, integrations, dashboard, APIs, and observability. Platform Credits apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
 
-All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in **Settings** > **Billing and usage**.
+All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in the Warp app under **Settings** > **Billing and usage**.
 
 Each interaction consumes **at least one credit**, though more complex interactions may use **multiple credits**. Because of factors such as codebase size, model choice, number of tool calls, and the nature of LLMs, credit usage is **non-deterministic** — two similar prompts can still use a different number of credits.
 
@@ -141,22 +141,22 @@ The following scenarios do **not** use Cloud Agent Credits:
 
 ### Platform Credits
 
-Platform Credits charge for Warp's platform infrastructure — run lifecycle, scheduling, integrations, dashboard, APIs, and observability — for every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
+Platform Credits cover Warp's platform infrastructure — run lifecycle, scheduling, integrations, dashboard, APIs, and observability — for every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
 #### Eligible for Platform Credits
 
-The following scenarios use Platform Credits:
+Platform Credits are used in the following scenarios:
 
-* **Cloud agents on any plan** — Every cloud agent run, regardless of harness or inference source
-* **Local agents on Business or Enterprise with customer-supplied inference** — Local agent runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex
+* **Cloud agents on any plan** use Platform Credits for every cloud agent run, regardless of which agent runs the task or which inference source it uses.
+* **Local agents on Business or Enterprise with customer-supplied inference** use Platform Credits when the local agent run uses [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex.
 
 #### Not eligible for Platform Credits
 
 The following scenarios do **not** use Platform Credits:
 
-* **Local agents on Free, Build, or Max plans** — Regardless of inference source
-* **Local agents on Business or Enterprise using Warp-managed inference** — AI credits already cover the cost
-* **Regular terminal usage** — Shell commands and non-AI features
-* **Third-party harnesses run directly** — Running `claude`, `codex`, or another CLI outside of Oz
+* **Local agents on Free, Build, or Max plans** don't use Platform Credits, regardless of inference source.
+* **Local agents on Business or Enterprise using Warp-managed inference** don't use Platform Credits because Warp is already paying for the model call through AI credits.
+* **Regular terminal usage** doesn't use Platform Credits. Shell commands and non-AI Warp features don't consume credits.
+* **Third-party agent CLIs run directly** don't use Platform Credits when you run `claude`, `codex`, or another agent CLI outside of Oz.
 
 For a full breakdown of how Platform Credits work, see [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -16,7 +16,7 @@ Warp meters credits across three types of infrastructure — inference, compute,
 * **Compute credits** cover compute: the sandbox an agent runs in. Consumed when an agent run uses Warp-hosted compute. In practice this is cloud agent runs; local agent runs use your own machine and don't consume compute credits. See [Compute credits](/support-and-community/plans-and-billing/credits/#compute-credits).
 * **Platform credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [platform credits](/support-and-community/plans-and-billing/platform-credits/).
 
-All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in the Warp app under **Settings** > **Billing and usage**.
+All three buckets draw from the same Warp credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in the Warp app under **Settings** > **Billing and usage**.
 
 Each interaction consumes **at least one credit**, though more complex interactions may use **multiple credits**. Because of factors such as codebase size, model choice, number of tool calls, and the nature of LLMs, credit usage is **non-deterministic** — two similar prompts can still use a different number of credits.
 

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -12,11 +12,11 @@ Any interaction with Warp's Agent consumes credits. Credits are primarily based 
 
 Credits also include a small hosting fee, charged only when running agents in the cloud, hosted on Warp's infrastructure. For details on cloud agent credits, see [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
 
-Warp meters usage in three buckets:
+Warp meters credits across three types of infrastructure — inference, compute, and platform — each with its own bucket:
 
-* **AI credits** - The primary bucket. Consumed by Agent conversations and other AI features whenever Warp pays for the model inference.
-* **Cloud Agent Credits** - Charged for cloud agent runs that execute on Warp-hosted compute. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** - Charged for the Oz orchestration layer that coordinates agent runs. Applies to every cloud agent run, plus local runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
+* **AI credits** - Charged for inference infrastructure Warp pays for. Consumed by Agent conversations and other AI features that route through Warp-managed model providers.
+* **Cloud Agent Credits** - Charged for compute infrastructure when cloud agents run on Warp-hosted compute. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Platform Credits** - Charged for platform infrastructure (run lifecycle, integrations, dashboard, APIs, and observability) when Warp isn't paying for inference or compute. Applies to every cloud agent run, plus local runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
 
 All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in **Settings** > **Billing and usage**.
 
@@ -141,7 +141,7 @@ The following scenarios do **not** use Cloud Agent Credits:
 
 ### Platform Credits
 
-Platform Credits charge for the Oz orchestration layer that coordinates agent runs — task lifecycle, scheduling, integrations, run history, and the rest of the platform.
+Platform Credits charge for Warp's platform infrastructure — run lifecycle, scheduling, integrations, dashboard, APIs, and observability — when Warp isn't paying for the inference or compute.
 
 #### Eligible for Platform Credits
 

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -121,7 +121,7 @@ These are the most common factors affecting credit usage, though there are other
 
 Compute credits cover Warp-hosted compute consumed by an agent run. In practice, cloud agent runs consume them because they run on Warp's compute; local agent runs typically don't, since they run on your own machine.
 
-Compute credits are sometimes referred to as **Cloud agent credits** when the conversation is framed around cloud agents vs local agents — they're the same bucket described from a different angle.
+Compute credits are sometimes referred to as **cloud agent credits** when the conversation is framed around cloud agents vs local agents — they're the same bucket described from a different angle.
 
 #### Eligible for compute credits
 

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -42,7 +42,7 @@ You can view your total credit usage, along with other billing details, in **Set
 #### Credit **limits and billing**
 
 * **Seat-level allocation**: On team plans, credit limits apply per seat — each team member has their own allowance. Individual users (not on a team) also have their own credit allocation.
-* **Cloud agents and integrations**: Individual users can run cloud agents via the CLI and API, drawing from their normal Warp credits. Slack and Linear integrations require team membership.
+* **Cloud agents and integrations**: Individual users can run cloud agents via the CLI and API, drawing from their Warp credits. Slack and Linear integrations require team membership.
 * **Hitting the credit limits**: Once you hit your monthly credit limit, your access will depend on your plan. On the Free plan, AI access stops until your next billing cycle. On paid plans, you can continue using AI with usage-based billing via [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/).
 
 #### **Other features that use credits**

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -13,7 +13,7 @@ Any interaction with Warp's Agent consumes credits. Credits are primarily based 
 Warp meters credits across three types of infrastructure — inference, compute, and platform — each with its own bucket. Credit types and where an agent runs (local or cloud) are independent: each agent run consumes from whichever credit types apply to it.
 
 * **AI credits** cover inference: the LLM call itself. Consumed when Warp pays for the model call through Warp-managed providers.
-* **compute credits** cover compute: the sandbox an agent runs in. Consumed when an agent run uses Warp-hosted compute. In practice this is cloud agent runs; local agent runs use your own machine and don't consume compute credits. See [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits).
+* **Cloud Agent Credits** cover Warp-hosted compute consumed by an agent run — the sandbox the agent runs in. Cloud agent runs consume them because they run on Warp's compute; local agent runs use your own machine and don't. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
 * **Platform Credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
 
 All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in the Warp app under **Settings** > **Billing and usage**.
@@ -117,22 +117,22 @@ Because cache results depend on model provider behavior and timing, two similar 
 
 These are the most common factors affecting credit usage, though there are others. Understanding them can help you manage your credits more efficiently and get the most from your plan.
 
-### Compute credits
+### Cloud Agent Credits
 
-Compute credits cover Warp-hosted compute consumed by an agent run. Cloud agent runs consume compute credits because they run on Warp's compute; local agent runs typically don't, since they run on your own machine.
+Cloud Agent Credits cover Warp-hosted compute consumed by an agent run. Cloud agent runs consume them because they run on Warp's compute; local agent runs typically don't, since they run on your own machine.
 
-#### Eligible for compute credits
+#### Eligible for Cloud Agent Credits
 
-The following scenarios use compute credits:
+The following scenarios use Cloud Agent Credits:
 
 * **First-party integrations** - Running agents through Slack or Linear integrations
 * **Cloud agent runs** - Using `oz agent run-cloud` via the CLI
 * **Oz API** - Running agents through Warp's Oz API
 * **Cloud Mode** - Running an agent from Cloud Mode in the Warp app
 
-#### Not eligible for compute credits
+#### Not eligible for Cloud Agent Credits
 
-The following scenarios don't use compute credits because they don't run on Warp-hosted compute:
+The following scenarios don't use Cloud Agent Credits because they don't run on Warp-hosted compute:
 
 * **Local agent runs** - Using `oz agent run` on your local machine
 * **Self-hosted compute** - Using `oz agent run` on GitHub Actions, CI/CD pipelines, or other self-hosted infrastructure

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -12,6 +12,14 @@ Any interaction with Warp's Agent consumes credits. Credits are primarily based 
 
 Credits also include a small hosting fee, charged only when running agents in the cloud, hosted on Warp's infrastructure. For details on cloud agent credits, see [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
 
+Warp meters usage in three buckets:
+
+* **AI credits** - The primary bucket. Consumed by Agent conversations and other AI features whenever Warp pays for the model inference.
+* **Cloud Agent Credits** - Charged for cloud agent runs that execute on Warp-hosted compute. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Platform Credits** - Charged for the Oz orchestration layer when an agent is actively working but Warp isn't paying for inference or compute (for example, BYOLLM via Amazon Bedrock or self-hosted cloud agents). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
+
+All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in **Settings** > **Billing and usage**.
+
 Each interaction consumes **at least one credit**, though more complex interactions may use **multiple credits**. Because of factors such as codebase size, model choice, number of tool calls, and the nature of LLMs, credit usage is **non-deterministic** — two similar prompts can still use a different number of credits.
 
 :::note
@@ -130,3 +138,25 @@ The following scenarios do **not** use Cloud Agent Credits:
 
 * **Local agent runs** — Using `oz agent run` on your local machine
 * **Self-hosted compute** — Using `oz agent run` on GitHub Actions, CI/CD pipelines, or other self-hosted infrastructure
+
+### Platform Credits
+
+Platform Credits cover the Oz orchestration layer when Warp isn't paying for inference or compute — for example, when you bring your own LLM provider (BYOLLM via Amazon Bedrock or Google Vertex), use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/), or run cloud agents on your own infrastructure.
+
+#### Eligible for Platform Credits
+
+The following scenarios use Platform Credits:
+
+* **Cloud agents on any plan** — Any cloud agent run, regardless of harness or where inference comes from
+* **Local agents on Business or Enterprise with customer-supplied inference** — Local Oz runs that use BYOK or BYOLLM (Amazon Bedrock, Google Vertex) on a Business or Enterprise plan
+
+#### Not eligible for Platform Credits
+
+The following scenarios do **not** use Platform Credits:
+
+* **Local agents on Free, Build, or Max plans** — Regardless of inference source
+* **Local agents on Business or Enterprise using Warp-managed inference** — AI credits already cover the cost
+* **Regular terminal usage** — Shell commands and non-AI features
+* **Third-party harnesses run directly** — Running `claude`, `codex`, or another CLI outside of Oz
+
+For a full breakdown of how Platform Credits work, see [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -10,8 +10,6 @@ description: >-
 
 Any interaction with Warp's Agent consumes credits. Credits are primarily based on AI usage — the number of credits a task consumes varies based on the size and complexity of your codebase, the size of the task, the model you're using, the amount of context the agent needs to gather, and more.
 
-Credits also include a small hosting fee, charged only when running agents in the cloud, hosted on Warp's infrastructure. For details on cloud agent credits, see [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-
 Warp meters credits across three types of infrastructure — inference, compute, and platform — each with its own bucket:
 
 * **AI credits** cover inference infrastructure that Warp pays for. Agent conversations and other AI features that route through Warp-managed model providers use AI credits.
@@ -44,7 +42,7 @@ You can view your total credit usage, along with other billing details, in **Set
 #### Credit **limits and billing**
 
 * **Seat-level allocation**: On team plans, credit limits apply per seat — each team member has their own allowance. Individual users (not on a team) also have their own credit allocation.
-* **Cloud Agent Credits**: Individual users can run cloud agents via CLI/API using their normal Warp credits, [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), or a Build plan with available credits. Integrations (Slack, Linear) require team membership.
+* **Cloud agents and integrations**: Individual users can run cloud agents via the CLI and API, drawing from their plan credits. Slack and Linear integrations require team membership.
 * **Hitting the credit limits**: Once you hit your monthly credit limit, your access will depend on your plan. On the Free plan, AI access stops until your next billing cycle. On paid plans, you can continue using AI with usage-based billing via [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/).
 
 #### **Other features that use credits**
@@ -121,7 +119,7 @@ These are the most common factors affecting credit usage, though there are other
 
 ### Cloud Agent Credits
 
-Cloud Agent Credits are the compute credits bucket — consumed when an agent run uses Warp-hosted compute. Both local and cloud agent runs can in principle draw from this pool, but in practice only runs that use Warp's compute do.
+Cloud Agent Credits are the compute credits bucket — consumed when an agent run uses Warp-hosted compute. Both local and cloud agent runs are eligible to draw from this pool, but in practice only runs that use Warp's compute do.
 
 #### Eligible for Cloud Agent Credits
 

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -16,7 +16,7 @@ Warp meters credits across three types of infrastructure — inference, compute,
 
 * **AI credits** - Charged for inference infrastructure Warp pays for. Consumed by Agent conversations and other AI features that route through Warp-managed model providers.
 * **Cloud Agent Credits** - Charged for compute infrastructure when cloud agents run on Warp-hosted compute. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** - Charged for platform infrastructure (run lifecycle, integrations, dashboard, APIs, and observability) when Warp isn't paying for inference or compute. Applies to every cloud agent run, plus local runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
+* **Platform Credits** - Charged for Warp's platform infrastructure (run lifecycle, integrations, dashboard, APIs, and observability). Applies to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
 
 All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in **Settings** > **Billing and usage**.
 
@@ -141,14 +141,14 @@ The following scenarios do **not** use Cloud Agent Credits:
 
 ### Platform Credits
 
-Platform Credits charge for Warp's platform infrastructure — run lifecycle, scheduling, integrations, dashboard, APIs, and observability — when Warp isn't paying for the inference or compute.
+Platform Credits charge for Warp's platform infrastructure — run lifecycle, scheduling, integrations, dashboard, APIs, and observability — for every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
 #### Eligible for Platform Credits
 
 The following scenarios use Platform Credits:
 
 * **Cloud agents on any plan** — Every cloud agent run, regardless of harness or inference source
-* **Local agents on Business or Enterprise with customer-supplied inference** — Local Oz runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex
+* **Local agents on Business or Enterprise with customer-supplied inference** — Local agent runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex
 
 #### Not eligible for Platform Credits
 

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -10,11 +10,11 @@ description: >-
 
 Any interaction with Warp's Agent consumes credits. Credits are primarily based on AI usage — the number of credits a task consumes varies based on the size and complexity of your codebase, the size of the task, the model you're using, the amount of context the agent needs to gather, and more.
 
-Warp meters credits across three types of infrastructure — inference, compute, and platform — each with its own bucket:
+Warp meters credits across three types of infrastructure — inference, compute, and platform — each with its own bucket. Credit types and where an agent runs (local or cloud) are independent: each agent run consumes from whichever credit types apply to it.
 
-* **AI credits** cover inference infrastructure that Warp pays for. Agent conversations and other AI features that route through Warp-managed model providers use AI credits.
-* **Cloud Agent Credits** are the compute bucket. They cover Warp-hosted compute consumed by any agent run, local or cloud. In practice, cloud agents draw from this bucket because they run on Warp's compute; local agents typically don't, since they run on your own machine. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** cover Warp's platform infrastructure, including run lifecycle, integrations, dashboard, APIs, and observability. Platform Credits apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
+* **AI credits** cover inference: the LLM call itself. Consumed when Warp pays for the model call through Warp-managed providers.
+* **compute credits** cover compute: the sandbox an agent runs in. Consumed when an agent run uses Warp-hosted compute. In practice this is cloud agent runs; local agent runs use your own machine and don't consume compute credits. See [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits).
+* **Platform Credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
 
 All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in the Warp app under **Settings** > **Billing and usage**.
 
@@ -117,22 +117,22 @@ Because cache results depend on model provider behavior and timing, two similar 
 
 These are the most common factors affecting credit usage, though there are others. Understanding them can help you manage your credits more efficiently and get the most from your plan.
 
-### Cloud Agent Credits
+### Compute credits
 
-Cloud Agent Credits are the compute credits bucket — consumed when an agent run uses Warp-hosted compute. Both local and cloud agent runs are eligible to draw from this pool, but in practice only runs that use Warp's compute do.
+Compute credits cover Warp-hosted compute consumed by an agent run. Cloud agent runs consume compute credits because they run on Warp's compute; local agent runs typically don't, since they run on your own machine.
 
-#### Eligible for Cloud Agent Credits
+#### Eligible for compute credits
 
-The following scenarios use Cloud Agent Credits:
+The following scenarios use compute credits:
 
 * **First-party integrations** — Running agents through Slack or Linear integrations
 * **Cloud agent runs** — Using `oz agent run-cloud` via the CLI
 * **Oz API** — Running agents through Warp's Oz API
 * **Cloud Mode** — Running an agent from Cloud Mode in the Warp app
 
-#### Not eligible for Cloud Agent Credits
+#### Not eligible for compute credits
 
-The following scenarios don't use Cloud Agent Credits because they don't run on Warp-hosted compute:
+The following scenarios don't use compute credits because they don't run on Warp-hosted compute:
 
 * **Local agent runs** — Using `oz agent run` on your local machine
 * **Self-hosted compute** — Using `oz agent run` on GitHub Actions, CI/CD pipelines, or other self-hosted infrastructure

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -16,7 +16,7 @@ Warp meters usage in three buckets:
 
 * **AI credits** - The primary bucket. Consumed by Agent conversations and other AI features whenever Warp pays for the model inference.
 * **Cloud Agent Credits** - Charged for cloud agent runs that execute on Warp-hosted compute. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** - Charged for the Oz orchestration layer when an agent is actively working but Warp isn't paying for inference or compute (for example, BYOLLM via Amazon Bedrock or self-hosted cloud agents). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
+* **Platform Credits** - Charged for the Oz orchestration layer that coordinates agent runs. Applies to every cloud agent run, plus local runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
 
 All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in **Settings** > **Billing and usage**.
 
@@ -141,14 +141,14 @@ The following scenarios do **not** use Cloud Agent Credits:
 
 ### Platform Credits
 
-Platform Credits cover the Oz orchestration layer when Warp isn't paying for inference or compute — for example, when you bring your own LLM provider (BYOLLM via Amazon Bedrock or Google Vertex), use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/), or run cloud agents on your own infrastructure.
+Platform Credits charge for the Oz orchestration layer that coordinates agent runs — task lifecycle, scheduling, integrations, run history, and the rest of the platform.
 
 #### Eligible for Platform Credits
 
 The following scenarios use Platform Credits:
 
-* **Cloud agents on any plan** — Any cloud agent run, regardless of harness or where inference comes from
-* **Local agents on Business or Enterprise with customer-supplied inference** — Local Oz runs that use BYOK or BYOLLM (Amazon Bedrock, Google Vertex) on a Business or Enterprise plan
+* **Cloud agents on any plan** — Every cloud agent run, regardless of harness or inference source
+* **Local agents on Business or Enterprise with customer-supplied inference** — Local Oz runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex
 
 #### Not eligible for Platform Credits
 

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -125,17 +125,17 @@ Compute credits cover Warp-hosted compute consumed by an agent run. Cloud agent 
 
 The following scenarios use compute credits:
 
-* **First-party integrations** — Running agents through Slack or Linear integrations
-* **Cloud agent runs** — Using `oz agent run-cloud` via the CLI
-* **Oz API** — Running agents through Warp's Oz API
-* **Cloud Mode** — Running an agent from Cloud Mode in the Warp app
+* **First-party integrations** - Running agents through Slack or Linear integrations
+* **Cloud agent runs** - Using `oz agent run-cloud` via the CLI
+* **Oz API** - Running agents through Warp's Oz API
+* **Cloud Mode** - Running an agent from Cloud Mode in the Warp app
 
 #### Not eligible for compute credits
 
 The following scenarios don't use compute credits because they don't run on Warp-hosted compute:
 
-* **Local agent runs** — Using `oz agent run` on your local machine
-* **Self-hosted compute** — Using `oz agent run` on GitHub Actions, CI/CD pipelines, or other self-hosted infrastructure
+* **Local agent runs** - Using `oz agent run` on your local machine
+* **Self-hosted compute** - Using `oz agent run` on GitHub Actions, CI/CD pipelines, or other self-hosted infrastructure
 
 ### Platform Credits
 

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -13,7 +13,7 @@ Any interaction with Warp's Agent consumes credits. Credits are primarily based 
 Warp meters credits across three types of infrastructure — inference, compute, and platform — each with its own bucket. Credit types and where an agent runs (local or cloud) are independent: each agent run consumes from whichever credit types apply to it.
 
 * **AI credits** cover inference: the LLM call itself. Consumed when Warp pays for the model call through Warp-managed providers.
-* **Cloud Agent Credits** cover Warp-hosted compute consumed by an agent run — the sandbox the agent runs in. Cloud agent runs consume them because they run on Warp's compute; local agent runs use your own machine and don't. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Compute credits** cover compute: the sandbox an agent runs in. Consumed when an agent run uses Warp-hosted compute. In practice this is cloud agent runs; local agent runs use your own machine and don't consume compute credits. See [Compute credits](/support-and-community/plans-and-billing/credits/#compute-credits).
 * **Platform Credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference (BYOK or BYOLLM via Amazon Bedrock or Google Vertex). See [Platform Credits](/support-and-community/plans-and-billing/platform-credits/).
 
 All three buckets draw from the same plan credit pool and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/), so you can manage them as a single balance in the Warp app under **Settings** > **Billing and usage**.
@@ -42,7 +42,7 @@ You can view your total credit usage, along with other billing details, in **Set
 #### Credit **limits and billing**
 
 * **Seat-level allocation**: On team plans, credit limits apply per seat — each team member has their own allowance. Individual users (not on a team) also have their own credit allocation.
-* **Cloud agents and integrations**: Individual users can run cloud agents via the CLI and API, drawing from their plan credits. Slack and Linear integrations require team membership.
+* **Cloud agents and integrations**: Individual users can run cloud agents via the CLI and API, drawing from their normal Warp credits. Slack and Linear integrations require team membership.
 * **Hitting the credit limits**: Once you hit your monthly credit limit, your access will depend on your plan. On the Free plan, AI access stops until your next billing cycle. On paid plans, you can continue using AI with usage-based billing via [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/).
 
 #### **Other features that use credits**
@@ -117,22 +117,24 @@ Because cache results depend on model provider behavior and timing, two similar 
 
 These are the most common factors affecting credit usage, though there are others. Understanding them can help you manage your credits more efficiently and get the most from your plan.
 
-### Cloud Agent Credits
+### Compute credits
 
-Cloud Agent Credits cover Warp-hosted compute consumed by an agent run. Cloud agent runs consume them because they run on Warp's compute; local agent runs typically don't, since they run on your own machine.
+Compute credits cover Warp-hosted compute consumed by an agent run. In practice, cloud agent runs consume them because they run on Warp's compute; local agent runs typically don't, since they run on your own machine.
 
-#### Eligible for Cloud Agent Credits
+Compute credits are sometimes referred to as **Cloud agent credits** when the conversation is framed around cloud agents vs local agents — they're the same bucket described from a different angle.
 
-The following scenarios use Cloud Agent Credits:
+#### Eligible for compute credits
+
+The following scenarios use compute credits:
 
 * **First-party integrations** - Running agents through Slack or Linear integrations
 * **Cloud agent runs** - Using `oz agent run-cloud` via the CLI
 * **Oz API** - Running agents through Warp's Oz API
 * **Cloud Mode** - Running an agent from Cloud Mode in the Warp app
 
-#### Not eligible for Cloud Agent Credits
+#### Not eligible for compute credits
 
-The following scenarios don't use Cloud Agent Credits because they don't run on Warp-hosted compute:
+The following scenarios don't use compute credits because they don't run on Warp-hosted compute:
 
 * **Local agent runs** - Using `oz agent run` on your local machine
 * **Self-hosted compute** - Using `oz agent run` on GitHub Actions, CI/CD pipelines, or other self-hosted infrastructure

--- a/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
@@ -20,7 +20,7 @@ Visit [warp.dev/pricing](https://warp.dev/pricing) to see the latest plans and w
 
 * [Credits](/support-and-community/plans-and-billing/credits/) — learn how credits are used and calculated across AI features.
 * [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) — purchase additional credits or enable automatic reloads at discounted rates.
-* [Platform Credits](/support-and-community/plans-and-billing/platform-credits/) — understand the third credit bucket that covers Oz orchestration for BYOLLM, BYOK, and self-hosted cloud agent scenarios.
+* [Platform Credits](/support-and-community/plans-and-billing/platform-credits/) — the third credit bucket, which covers Oz orchestration for every cloud agent run and for local Business and Enterprise runs that use customer-supplied inference.
 * [Bring Your Own API Key](/support-and-community/plans-and-billing/bring-your-own-api-key/) — connect your own model provider API keys for custom usage and billing.
 * [Overages (Legacy)](/support-and-community/plans-and-billing/overages-legacy/) — information for users on legacy plans with overages enabled.
 * [Pricing FAQs](/support-and-community/plans-and-billing/pricing-faqs/) — answers to common questions about plans, billing, and usage. Don’t have Warp yet? [Download Warp](https://warp.dev/download) and get started for free today.

--- a/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
@@ -20,7 +20,7 @@ Visit [warp.dev/pricing](https://warp.dev/pricing) to see the latest plans and w
 
 * [Credits](/support-and-community/plans-and-billing/credits/) — learn how credits are used and calculated across AI features.
 * [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) — purchase additional credits or enable automatic reloads at discounted rates.
-* [Platform Credits](/support-and-community/plans-and-billing/platform-credits/) — the third credit bucket, which covers Oz orchestration for every cloud agent run and for local Business and Enterprise runs that use customer-supplied inference.
+* [Platform Credits](/support-and-community/plans-and-billing/platform-credits/) — the third credit bucket, which covers Warp's platform infrastructure for every cloud agent run and for local Business and Enterprise runs that use customer-supplied inference.
 * [Bring Your Own API Key](/support-and-community/plans-and-billing/bring-your-own-api-key/) — connect your own model provider API keys for custom usage and billing.
 * [Overages (Legacy)](/support-and-community/plans-and-billing/overages-legacy/) — information for users on legacy plans with overages enabled.
 * [Pricing FAQs](/support-and-community/plans-and-billing/pricing-faqs/) — answers to common questions about plans, billing, and usage. Don’t have Warp yet? [Download Warp](https://warp.dev/download) and get started for free today.

--- a/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
@@ -20,7 +20,7 @@ Visit [warp.dev/pricing](https://warp.dev/pricing) to see the latest plans and w
 
 * [Credits](/support-and-community/plans-and-billing/credits/) — learn how credits are used and calculated across AI features.
 * [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) — purchase additional credits or enable automatic reloads at discounted rates.
-* [Platform Credits](/support-and-community/plans-and-billing/platform-credits/) — learn how Platform Credits cover Warp's platform infrastructure for cloud agent runs and local runs with customer-supplied inference.
+* [Platform credits](/support-and-community/plans-and-billing/platform-credits/) — learn how platform credits cover Warp's platform infrastructure for cloud agent runs and local runs with customer-supplied inference.
 * [Bring Your Own API Key](/support-and-community/plans-and-billing/bring-your-own-api-key/) — connect your own model provider API keys for custom usage and billing.
 * [Overages (Legacy)](/support-and-community/plans-and-billing/overages-legacy/) — information for users on legacy plans with overages enabled.
 * [Pricing FAQs](/support-and-community/plans-and-billing/pricing-faqs/) — answers to common questions about plans, billing, and usage. Don’t have Warp yet? [Download Warp](https://warp.dev/download) and get started for free today.

--- a/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
@@ -20,6 +20,7 @@ Visit [warp.dev/pricing](https://warp.dev/pricing) to see the latest plans and w
 
 * [Credits](/support-and-community/plans-and-billing/credits/) — learn how credits are used and calculated across AI features.
 * [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) — purchase additional credits or enable automatic reloads at discounted rates.
+* [Platform Credits](/support-and-community/plans-and-billing/platform-credits/) — understand the third credit bucket that covers Oz orchestration for BYOLLM, BYOK, and self-hosted cloud agent scenarios.
 * [Bring Your Own API Key](/support-and-community/plans-and-billing/bring-your-own-api-key/) — connect your own model provider API keys for custom usage and billing.
 * [Overages (Legacy)](/support-and-community/plans-and-billing/overages-legacy/) — information for users on legacy plans with overages enabled.
 * [Pricing FAQs](/support-and-community/plans-and-billing/pricing-faqs/) — answers to common questions about plans, billing, and usage. Don’t have Warp yet? [Download Warp](https://warp.dev/download) and get started for free today.

--- a/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx
@@ -20,7 +20,7 @@ Visit [warp.dev/pricing](https://warp.dev/pricing) to see the latest plans and w
 
 * [Credits](/support-and-community/plans-and-billing/credits/) — learn how credits are used and calculated across AI features.
 * [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) — purchase additional credits or enable automatic reloads at discounted rates.
-* [Platform Credits](/support-and-community/plans-and-billing/platform-credits/) — the third credit bucket, which covers Warp's platform infrastructure for every cloud agent run and for local Business and Enterprise runs that use customer-supplied inference.
+* [Platform Credits](/support-and-community/plans-and-billing/platform-credits/) — learn how Platform Credits cover Warp's platform infrastructure for cloud agent runs and local runs with customer-supplied inference.
 * [Bring Your Own API Key](/support-and-community/plans-and-billing/bring-your-own-api-key/) — connect your own model provider API keys for custom usage and billing.
 * [Overages (Legacy)](/support-and-community/plans-and-billing/overages-legacy/) — information for users on legacy plans with overages enabled.
 * [Pricing FAQs](/support-and-community/plans-and-billing/pricing-faqs/) — answers to common questions about plans, billing, and usage. Don’t have Warp yet? [Download Warp](https://warp.dev/download) and get started for free today.

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -5,7 +5,7 @@ description: >-
   and on local runs with customer-supplied inference. Learn when they apply.
 ---
 
-Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), and Platform Credits. Credit types and where an agent runs (local or cloud) are independent.
+Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and Platform Credits. Credit types and where an agent runs (local or cloud) are independent.
 
 Platform Credits cover Warp's platform infrastructure on every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference. Even when you bring your own model provider, connect your own LLM API keys, or run cloud agents on your own compute, Warp's platform still coordinates, observes, and integrates your agents — and Platform Credits cover that orchestration layer.
 
@@ -20,10 +20,10 @@ BYOK and customer-supplied inference (BYOLLM via Amazon Bedrock or Google Vertex
 Each credit bucket covers a different layer of the infrastructure Warp provides. Credit types and where an agent runs (local or cloud) are independent — each agent run consumes from whichever credit types apply to it.
 
 * **AI credits** cover inference: the LLM call itself. Consumed when Warp pays for the model call through Warp-managed providers. Used by agent conversations, [Generate](/agent-platform/local-agents/generate/), [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill), and other AI features. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
-* **compute credits** cover compute: the sandbox an agent runs in. Consumed when an agent run uses Warp-hosted compute. In practice this is cloud agent runs (Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app); local agent runs use your own machine and don't consume compute credits. See [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits).
+* **Cloud Agent Credits** cover Warp-hosted compute consumed by an agent run — the sandbox the agent runs in. Cloud agent runs consume them (Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app) because they run on Warp's compute; local agent runs use your own machine and don't. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
 * **Platform Credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
-The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, compute credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
+The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, Cloud Agent Credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
 
 ## How Platform Credits are measured
 
@@ -51,8 +51,8 @@ Whether Platform Credits apply depends on where the agent runs and who's paying 
 
 Platform Credits appear in the same billing views as your other credit usage.
 
-* **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes Platform Credits alongside AI credits and compute credits.
-* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI credits and compute credits segments.
+* **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes Platform Credits alongside AI credits and Cloud Agent Credits.
+* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI credits and Cloud Agent Credits segments.
 * **Add-on Credits and limits** - Platform Credits draw from the same plan credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly plan credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
 
 ## Related pages

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -12,12 +12,16 @@ Platform Credits cover Warp's platform infrastructure on every cloud agent run, 
 
 Customer-supplied inference covers [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) and BYOLLM via Amazon Bedrock or Google Vertex. Platform Credits don't apply to local runs on Free, Build, or Max plans, or to local Business and Enterprise runs where Warp pays for inference through AI credits.
 
+:::caution
+BYOK and customer-supplied inference (BYOLLM via Amazon Bedrock or Google Vertex, plus custom endpoints) are available to individual users and organizations with 10 or fewer employees or users on any plan. Organizations with more than 10 employees or users must be on a Warp Business or Enterprise plan to use BYOK or customer-supplied inference. See Warp's [Terms of Service](https://www.warp.dev/terms-of-service) for details.
+:::
+
 ## The three credit buckets
 
 Each credit bucket covers a different layer of the infrastructure Warp provides:
 
 * **AI credits** cover inference infrastructure that Warp pays for. Agent conversations, [Generate](/agent-platform/local-agents/generate/), [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill), and other AI features that route through Warp-managed model providers use AI credits. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
-* **Cloud Agent Credits** cover compute infrastructure when cloud agents run on Warp-hosted compute. Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app use Cloud Agent Credits. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Cloud Agent Credits** are the compute bucket. They cover Warp-hosted compute consumed by any agent run, local or cloud. In practice, cloud agents draw from this bucket because they run on Warp's compute; local agents typically don't, since they run on your own machine. Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app use Cloud Agent Credits. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
 * **Platform Credits** cover Warp's platform infrastructure, including run lifecycle, integrations, dashboard, APIs, and observability. Platform Credits apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
 The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, Cloud Agent Credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
@@ -35,7 +39,7 @@ Whether Platform Credits apply depends on where the agent runs and who's paying 
 ### Uses Platform Credits
 
 * **Cloud agents on any plan** use Platform Credits for every cloud agent run, regardless of which agent runs the task (Warp Agent, Claude Code, Codex, or Gemini), inference source (Warp-managed, BYOK, or BYOLLM), or compute source (Warp-hosted or self-hosted workers). Warp's platform infrastructure coordinates every cloud agent run.
-* **Local agents on Business or Enterprise with customer-supplied inference** use Platform Credits when the local agent run uses [BYOK](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent.
+* **Local agents on Business or Enterprise with customer-supplied inference** use Platform Credits when the local agent run uses [BYOK](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent. BYOK and customer-supplied inference are subject to plan-size eligibility — see the callout above.
 
 ### Doesn't use Platform Credits
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -1,16 +1,15 @@
 ---
 title: Platform Credits
 description: >-
-  Platform Credits cover Warp's platform infrastructure on every cloud
-  agent run, plus local agent runs on Business and Enterprise plans that use
-  customer-supplied inference. Learn when they apply and where they appear.
+  Platform Credits cover Warp's platform layer on every cloud agent run
+  and on local runs with customer-supplied inference. Learn when they apply.
 ---
 
 Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and Platform Credits.
 
 Platform Credits cover Warp's platform infrastructure on every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference. Even when you bring your own model provider, connect your own LLM API keys, or run cloud agents on your own compute, Warp's platform still coordinates, observes, and integrates your agents — and Platform Credits cover that orchestration layer.
 
-Customer-supplied inference covers [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) and BYOLLM via Amazon Bedrock or Google Vertex. Platform Credits don't apply to local runs on Free, Build, or Max plans, or to local Business and Enterprise runs where Warp pays for inference through AI credits.
+Customer-supplied inference covers [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) and BYOLLM via Amazon Bedrock or Google Vertex.
 
 :::caution
 BYOK and customer-supplied inference (BYOLLM via Amazon Bedrock or Google Vertex, plus custom endpoints) are available to individual users and organizations with 10 or fewer employees or users on any plan. Organizations with more than 10 employees or users must be on a Warp Business or Enterprise plan to use BYOK or customer-supplied inference. See Warp's [Terms of Service](https://www.warp.dev/terms-of-service) for details.
@@ -53,7 +52,7 @@ Whether Platform Credits apply depends on where the agent runs and who's paying 
 Platform Credits appear in the same billing views as your other credit usage.
 
 * **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes Platform Credits alongside AI and Cloud Agent Credits.
-* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI and Compute segments.
+* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI credits and Cloud Agent Credits segments.
 * **Add-on Credits and limits** - Platform Credits draw from the same plan credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly plan credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
 
 ## Related pages

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -5,7 +5,7 @@ description: >-
   and on local runs with customer-supplied inference. Learn when they apply.
 ---
 
-Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and Platform Credits.
+Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), and Platform Credits. Credit types and where an agent runs (local or cloud) are independent.
 
 Platform Credits cover Warp's platform infrastructure on every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference. Even when you bring your own model provider, connect your own LLM API keys, or run cloud agents on your own compute, Warp's platform still coordinates, observes, and integrates your agents — and Platform Credits cover that orchestration layer.
 
@@ -17,13 +17,13 @@ BYOK and customer-supplied inference (BYOLLM via Amazon Bedrock or Google Vertex
 
 ## The three credit buckets
 
-Each credit bucket covers a different layer of the infrastructure Warp provides:
+Each credit bucket covers a different layer of the infrastructure Warp provides. Credit types and where an agent runs (local or cloud) are independent — each agent run consumes from whichever credit types apply to it.
 
-* **AI credits** cover inference infrastructure that Warp pays for. Agent conversations, [Generate](/agent-platform/local-agents/generate/), [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill), and other AI features that route through Warp-managed model providers use AI credits. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
-* **Cloud Agent Credits** are the compute bucket. They cover Warp-hosted compute consumed by any agent run, local or cloud. In practice, cloud agents draw from this bucket because they run on Warp's compute; local agents typically don't, since they run on your own machine. Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app use Cloud Agent Credits. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** cover Warp's platform infrastructure, including run lifecycle, integrations, dashboard, APIs, and observability. Platform Credits apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
+* **AI credits** cover inference: the LLM call itself. Consumed when Warp pays for the model call through Warp-managed providers. Used by agent conversations, [Generate](/agent-platform/local-agents/generate/), [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill), and other AI features. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
+* **compute credits** cover compute: the sandbox an agent runs in. Consumed when an agent run uses Warp-hosted compute. In practice this is cloud agent runs (Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app); local agent runs use your own machine and don't consume compute credits. See [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits).
+* **Platform Credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
-The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, Cloud Agent Credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
+The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, compute credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
 
 ## How Platform Credits are measured
 
@@ -51,8 +51,8 @@ Whether Platform Credits apply depends on where the agent runs and who's paying 
 
 Platform Credits appear in the same billing views as your other credit usage.
 
-* **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes Platform Credits alongside AI and Cloud Agent Credits.
-* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI credits and Cloud Agent Credits segments.
+* **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes Platform Credits alongside AI credits and compute credits.
+* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI credits and compute credits segments.
 * **Add-on Credits and limits** - Platform Credits draw from the same plan credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly plan credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
 
 ## Related pages

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -1,23 +1,24 @@
 ---
 title: Platform Credits
 description: >-
-  Platform Credits charge for Warp's platform infrastructure when Warp isn't
-  paying for inference or compute. Learn when they apply and where they appear.
+  Platform Credits charge for Warp's platform infrastructure on every cloud
+  agent run, plus local agent runs on Business and Enterprise plans that use
+  customer-supplied inference. Learn when they apply and where they appear.
 ---
 
 Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and Platform Credits.
 
-Platform Credits charge for Warp's platform infrastructure when Warp isn't paying for the inference or compute. Customers who bring their own model provider (BYOLLM via Amazon Bedrock or Google Vertex), connect their own LLM API keys, or run cloud agents on their own compute still rely on Warp's platform to coordinate, observe, and integrate their agents — and Platform Credits charge for that.
+Platform Credits charge for Warp's platform infrastructure on every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference. Even when you bring your own model provider, connect your own LLM API keys, or run cloud agents on your own compute, Warp's platform still coordinates, observes, and integrates your agents — and Platform Credits charge for that.
 
-Platform Credits apply to every cloud agent run, and to local agent runs on Business and Enterprise plans that use customer-supplied inference — [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. They don't apply to local runs on Free, Build, or Max plans, or to local Business and Enterprise runs where Warp pays for inference through AI credits.
+Customer-supplied inference covers [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) and BYOLLM via Amazon Bedrock or Google Vertex. Platform Credits don't apply to local runs on Free, Build, or Max plans, or to local Business and Enterprise runs where Warp pays for inference through AI credits.
 
 ## The three credit buckets
 
 Each credit bucket charges for a different layer of the infrastructure Warp provides:
 
-* **AI credits** - Charged for inference infrastructure Warp pays for. Consumed by Agent conversations, [Generate](/agent-platform/local-agents/generate/), Workflow autofill, and other AI features that route through Warp-managed model providers. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
+* **AI credits** - Charged for inference infrastructure Warp pays for. Consumed by Agent conversations, [Generate](/agent-platform/local-agents/generate/), [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill), and other AI features that route through Warp-managed model providers. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
 * **Cloud Agent Credits** - Charged for compute infrastructure when cloud agents run on Warp-hosted compute. Consumed by Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** - Charged for platform infrastructure (run lifecycle, integrations, dashboard, APIs, and observability) when an agent is actively working but Warp isn't paying for inference or compute. Applies to every cloud agent run, plus local runs on Business and Enterprise plans that use customer-supplied inference.
+* **Platform Credits** - Charged for Warp's platform infrastructure (run lifecycle, integrations, dashboard, APIs, and observability). Applies to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
 The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, Cloud Agent Credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
 
@@ -33,8 +34,8 @@ Whether Platform Credits are charged depends on where the agent runs and who's p
 
 ### Charged
 
-* **Cloud agents on any plan** - Every cloud agent run charges Platform Credits, regardless of harness (Warp Agent, Claude Code, Codex, Gemini) or inference source (Warp-managed, BYOK, or BYOLLM). Warp's platform infrastructure is always running the agent.
-* **Local agents on Business or Enterprise with customer-supplied inference** - Local Oz runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM (Amazon Bedrock, Google Vertex). Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent.
+* **Cloud agents on any plan** - Every cloud agent run charges Platform Credits, regardless of harness (Warp Agent, Claude Code, Codex, Gemini), inference source (Warp-managed, BYOK, or BYOLLM), or compute source (Warp-hosted or self-hosted workers). Warp's platform infrastructure is always running the agent.
+* **Local agents on Business or Enterprise with customer-supplied inference** - Local agent runs on a Business or Enterprise plan that use [BYOK](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent.
 
 ### Not charged
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -1,29 +1,29 @@
 ---
 title: Platform Credits
 description: >-
-  Platform Credits cover Oz orchestration when Warp isn't paying for inference
-  or compute. Learn when they apply, when they don't, and where they appear.
+  Platform Credits charge for the Oz orchestration layer. Learn when they
+  apply, when they don't, and where they appear in your billing.
 ---
 
-Platform Credits are the third credit bucket in Warp, alongside [AI credits](/support-and-community/plans-and-billing/credits/) and [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits). They cover the orchestration layer that Oz provides — task lifecycle, scheduling, integrations, run history, and the rest of the platform — for the cases where Warp isn't already paying for inference or compute.
+Platform Credits are the third credit bucket in Warp, alongside [AI credits](/support-and-community/plans-and-billing/credits/) and [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits). They charge for the Oz orchestration layer — task lifecycle, scheduling, integrations, run history, and the rest of the platform that coordinates your agent runs.
 
-Platform Credits exist so that customers who bring their own model provider (BYOLLM via Amazon Bedrock or Google Vertex), connect their own LLM API keys, or run cloud agents on their own infrastructure can still use Oz as the orchestration platform. AI credits and Cloud Agent Credits don't apply in those cases — but Warp is still hosting, coordinating, and tracking the work, and Platform Credits charge for that.
+Platform Credits apply to every cloud agent run, and to local agent runs on Business and Enterprise plans that use customer-supplied inference — [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. They don't apply to local runs on Free, Build, or Max plans, or to local Business and Enterprise runs where Warp pays for inference through AI credits.
 
 ## The three credit buckets
 
 Warp meters AI and agent usage in three buckets. Each bucket charges for a different part of the system:
 
-* **AI credits** - Charged for inference Warp pays for. Consumed by Agent conversations, [Generate](/agent-platform/local-agents/overview/), Workflow autofill, and other AI features. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
+* **AI credits** - Charged for inference Warp pays for. Consumed by Agent conversations, [Generate](/agent-platform/local-agents/generate/), Workflow autofill, and other AI features. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
 * **Cloud Agent Credits** - Charged for cloud agent runs that execute on Warp-hosted compute. Consumed by Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** - Charged for the Oz orchestration layer when an agent is actively working but Warp isn't paying for inference or compute. Covers BYOLLM, BYOK, and self-hosted cloud agent scenarios.
+* **Platform Credits** - Charged for the Oz orchestration layer that coordinates agent runs. Applies to every cloud agent run, plus local runs on Business and Enterprise plans that use customer-supplied inference.
 
-The three buckets are independent. A single agent run can consume from more than one bucket — for example, a cloud agent run that uses Warp-managed inference consumes AI credits for the model call and Cloud Agent Credits for the hosted compute, with no Platform Credits charged.
+The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, Cloud Agent Credits for the hosted compute, and Platform Credits for the orchestration layer.
 
 ## How Platform Credits are measured
 
 Platform Credits accrue while an Oz agent is actively working on a task — from when the task starts running to when it finishes, fails, or is cancelled. Idle time, time spent waiting on user input, and time before the task starts don't accrue Platform Credits.
 
-The per-minute rate is published on [warp.dev/pricing](https://warp.dev/pricing). Enterprise plans can negotiate a custom rate as part of their contract.
+See [warp.dev/pricing](https://warp.dev/pricing) for current rates. Enterprise plans can negotiate a custom rate as part of their contract.
 
 ## When Platform Credits apply
 
@@ -31,12 +31,12 @@ Whether Platform Credits are charged depends on where the agent runs and who's p
 
 ### Charged
 
-* **Cloud agents on any plan** - Any cloud agent run, regardless of which harness (Warp Agent, Claude Code, Codex, Gemini) or where the inference comes from (Warp-managed, BYOK, or BYOLLM). Cloud agents always consume Platform Credits because Oz is orchestrating the run.
-* **Local agents on Business or Enterprise with customer-supplied inference** - Local Oz runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM (Amazon Bedrock, Google Vertex). In these cases Warp isn't paying for the model call, but Oz is still orchestrating the local agent, so Platform Credits apply.
+* **Cloud agents on any plan** - Every cloud agent run charges Platform Credits, regardless of harness (Warp Agent, Claude Code, Codex, Gemini) or inference source (Warp-managed, BYOK, or BYOLLM). Oz is always orchestrating the run.
+* **Local agents on Business or Enterprise with customer-supplied inference** - Local Oz runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM (Amazon Bedrock, Google Vertex). Warp isn't paying for the model call, but Oz is still orchestrating the local agent.
 
 ### Not charged
 
-* **Local agents on Free, Build, or Max plans** - Regardless of whether you're using Warp-managed inference or BYOK.
+* **Local agents on Free, Build, or Max plans** - No Platform Credits charge, regardless of whether you use Warp-managed inference or BYOK.
 * **Local agents on Business or Enterprise using Warp-managed inference** - Warp is already paying for the model call through AI credits, so no separate Platform Credits charge applies.
 * **Regular terminal usage** - Running shell commands and using non-AI Warp features never consumes Platform Credits.
 * **Third-party harnesses run directly** - Running `claude`, `codex`, or another harness as a standalone CLI without going through Oz. Oz isn't in the path, so there's nothing to charge.
@@ -46,8 +46,8 @@ Whether Platform Credits are charged depends on where the agent runs and who's p
 Platform Credits roll into the same surfaces as your other credit usage.
 
 * **Per-user credit totals** - Your total credit usage in **Settings** > **Billing and usage** in the Warp app includes Platform Credits alongside AI and Cloud Agent Credits.
-* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar with a `(Platform)` label in the tooltip, distinct from `(AI)` and `(Compute)` segments.
-* **Add-on Credits and limits** - Platform Credits draw from the same plan and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other credit usage. Once your monthly plan credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
+* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI and Compute segments.
+* **Add-on Credits and limits** - Platform Credits draw from the same plan credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly plan credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
 
 ## Related pages
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -5,9 +5,9 @@ description: >-
   and on local runs with customer-supplied inference. Learn when they apply.
 ---
 
-Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and Platform Credits. Credit types and where an agent runs (local or cloud) are independent.
+Platform Credits cover Warp's platform infrastructure for coordinating, observing, and integrating agent runs. They apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference such as BYOK, Amazon Bedrock, or Google Vertex.
 
-Platform Credits cover Warp's platform infrastructure on every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference. Even when you bring your own model provider, connect your own LLM API keys, or run cloud agents on your own compute, Warp's platform still coordinates, observes, and integrates your agents — and Platform Credits cover that orchestration layer.
+Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and Platform Credits. Credit types and where an agent runs (local or cloud) are independent.
 
 Customer-supplied inference covers [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) and BYOLLM via Amazon Bedrock or Google Vertex.
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -1,13 +1,13 @@
 ---
-title: Platform Credits
+title: Platform credits
 description: >-
-  Platform Credits cover Warp's platform layer on every cloud agent run
+  Platform credits cover Warp's platform layer on every cloud agent run
   and on local runs with customer-supplied inference. Learn when they apply.
 ---
 
-Platform Credits cover Warp's platform infrastructure for coordinating, observing, and integrating agent runs. They apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference such as BYOK, Amazon Bedrock, or Google Vertex.
+Platform credits cover Warp's platform infrastructure for coordinating, observing, and integrating agent runs. They apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference such as BYOK, Amazon Bedrock, or Google Vertex.
 
-Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), and Platform Credits. Credit types and where an agent runs (local or cloud) are independent.
+Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), and platform credits. Credit types and where an agent runs (local or cloud) are independent.
 
 Customer-supplied inference covers [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) and BYOLLM via Amazon Bedrock or Google Vertex.
 
@@ -21,39 +21,39 @@ Each credit bucket covers a different layer of the infrastructure Warp provides.
 
 * **AI credits** cover inference: the LLM call itself. Consumed when Warp pays for the model call through Warp-managed providers. Used by agent conversations, [Generate](/agent-platform/local-agents/generate/), [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill), and other AI features. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
 * **Compute credits** cover compute: the sandbox an agent runs in. Consumed when an agent run uses Warp-hosted compute. In practice this is cloud agent runs (Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app); local agent runs use your own machine and don't consume compute credits. See [Compute credits](/support-and-community/plans-and-billing/credits/#compute-credits).
-* **Platform Credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
+* **Platform credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
-The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, compute credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
+The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, compute credits for the hosted compute, and platform credits for the platform infrastructure that runs the agent.
 
-## How Platform Credits are measured
+## How platform credits are measured
 
-Platform Credits accrue while an Oz agent is actively working on a task — from when the task starts running to when it finishes, fails, or is cancelled. Idle time, time spent waiting on user input, and time before the task starts don't accrue Platform Credits.
+Platform credits accrue while an Oz agent is actively working on a task — from when the task starts running to when it finishes, fails, or is cancelled. Idle time, time spent waiting on user input, and time before the task starts don't accrue platform credits.
 
 See [warp.dev/pricing](https://warp.dev/pricing) for current rates.
 
-## When Platform Credits apply
+## When platform credits apply
 
-Whether Platform Credits apply depends on where the agent runs and who's paying for inference.
+Whether platform credits apply depends on where the agent runs and who's paying for inference.
 
-### Uses Platform Credits
+### Uses platform credits
 
-* **Cloud agents on any plan** use Platform Credits for every cloud agent run, regardless of which agent runs the task (Warp Agent, Claude Code, Codex, or Gemini), inference source (Warp-managed, BYOK, or BYOLLM), or compute source (Warp-hosted or self-hosted workers). Warp's platform infrastructure coordinates every cloud agent run.
-* **Local agents on Business or Enterprise with customer-supplied inference** use Platform Credits when the local agent run uses [BYOK](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent. BYOK and customer-supplied inference are subject to plan-size eligibility — see the callout above.
+* **Cloud agents on any plan** use platform credits for every cloud agent run, regardless of which agent runs the task (Warp Agent, Claude Code, Codex, or Gemini), inference source (Warp-managed, BYOK, or BYOLLM), or compute source (Warp-hosted or self-hosted workers). Warp's platform infrastructure coordinates every cloud agent run.
+* **Local agents on Business or Enterprise with customer-supplied inference** use platform credits when the local agent run uses [BYOK](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent. BYOK and customer-supplied inference are subject to plan-size eligibility — see the callout above.
 
-### Doesn't use Platform Credits
+### Doesn't use platform credits
 
-* **Local agents on Free, Build, or Max plans** don't use Platform Credits, regardless of whether you use Warp-managed inference or BYOK.
-* **Local agents on Business or Enterprise using Warp-managed inference** don't use Platform Credits because Warp is already paying for the model call through AI credits.
-* **Regular terminal usage** doesn't use Platform Credits. Shell commands and non-AI Warp features don't consume credits.
-* **Third-party agent CLIs run directly** don't use Platform Credits when you run `claude`, `codex`, or another agent CLI without going through Oz.
+* **Local agents on Free, Build, or Max plans** don't use platform credits, regardless of whether you use Warp-managed inference or BYOK.
+* **Local agents on Business or Enterprise using Warp-managed inference** don't use platform credits because Warp is already paying for the model call through AI credits.
+* **Regular terminal usage** doesn't use platform credits. Shell commands and non-AI Warp features don't consume credits.
+* **Third-party agent CLIs run directly** don't use platform credits when you run `claude`, `codex`, or another agent CLI without going through Oz.
 
-## Where Platform Credits appear
+## Where platform credits appear
 
-Platform Credits appear in the same billing views as your other credit usage.
+Platform credits appear in the same billing views as your other credit usage.
 
-* **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes Platform Credits alongside AI credits and compute credits.
-* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI credits and compute credits segments.
-* **Add-on Credits and limits** - Platform Credits draw from the same normal Warp credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly normal Warp credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
+* **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes platform credits alongside AI credits and compute credits.
+* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform credits appear as their own segment in the stacked usage bar, distinct from the AI credits and compute credits segments.
+* **Add-on Credits and limits** - Platform credits draw from the same normal Warp credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly normal Warp credits are exhausted, platform credits continue to consume from Add-on Credits if you have them.
 
 ## Related pages
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -46,9 +46,9 @@ Whether Platform Credits are charged depends on where the agent runs and who's p
 
 ## Where Platform Credits appear
 
-Platform Credits roll into the same surfaces as your other credit usage.
+Platform Credits appear in the same billing views as your other credit usage.
 
-* **Per-user credit totals** - Your total credit usage in **Settings** > **Billing and usage** in the Warp app includes Platform Credits alongside AI and Cloud Agent Credits.
+* **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes Platform Credits alongside AI and Cloud Agent Credits.
 * **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI and Compute segments.
 * **Add-on Credits and limits** - Platform Credits draw from the same plan credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly plan credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -1,0 +1,57 @@
+---
+title: Platform Credits
+description: >-
+  Platform Credits cover Oz orchestration when Warp isn't paying for inference
+  or compute. Learn when they apply, when they don't, and where they appear.
+---
+
+Platform Credits are the third credit bucket in Warp, alongside [AI credits](/support-and-community/plans-and-billing/credits/) and [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits). They cover the orchestration layer that Oz provides — task lifecycle, scheduling, integrations, run history, and the rest of the platform — for the cases where Warp isn't already paying for inference or compute.
+
+Platform Credits exist so that customers who bring their own model provider (BYOLLM via Amazon Bedrock or Google Vertex), connect their own LLM API keys, or run cloud agents on their own infrastructure can still use Oz as the orchestration platform. AI credits and Cloud Agent Credits don't apply in those cases — but Warp is still hosting, coordinating, and tracking the work, and Platform Credits charge for that.
+
+## The three credit buckets
+
+Warp meters AI and agent usage in three buckets. Each bucket charges for a different part of the system:
+
+* **AI credits** - Charged for inference Warp pays for. Consumed by Agent conversations, [Generate](/agent-platform/local-agents/overview/), Workflow autofill, and other AI features. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
+* **Cloud Agent Credits** - Charged for cloud agent runs that execute on Warp-hosted compute. Consumed by Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Platform Credits** - Charged for the Oz orchestration layer when an agent is actively working but Warp isn't paying for inference or compute. Covers BYOLLM, BYOK, and self-hosted cloud agent scenarios.
+
+The three buckets are independent. A single agent run can consume from more than one bucket — for example, a cloud agent run that uses Warp-managed inference consumes AI credits for the model call and Cloud Agent Credits for the hosted compute, with no Platform Credits charged.
+
+## How Platform Credits are measured
+
+Platform Credits accrue while an Oz agent is actively working on a task — from when the task starts running to when it finishes, fails, or is cancelled. Idle time, time spent waiting on user input, and time before the task starts don't accrue Platform Credits.
+
+The per-minute rate is published on [warp.dev/pricing](https://warp.dev/pricing). Enterprise plans can negotiate a custom rate as part of their contract.
+
+## When Platform Credits apply
+
+Whether Platform Credits are charged depends on where the agent runs and who's paying for inference.
+
+### Charged
+
+* **Cloud agents on any plan** - Any cloud agent run, regardless of which harness (Warp Agent, Claude Code, Codex, Gemini) or where the inference comes from (Warp-managed, BYOK, or BYOLLM). Cloud agents always consume Platform Credits because Oz is orchestrating the run.
+* **Local agents on Business or Enterprise with customer-supplied inference** - Local Oz runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM (Amazon Bedrock, Google Vertex). In these cases Warp isn't paying for the model call, but Oz is still orchestrating the local agent, so Platform Credits apply.
+
+### Not charged
+
+* **Local agents on Free, Build, or Max plans** - Regardless of whether you're using Warp-managed inference or BYOK.
+* **Local agents on Business or Enterprise using Warp-managed inference** - Warp is already paying for the model call through AI credits, so no separate Platform Credits charge applies.
+* **Regular terminal usage** - Running shell commands and using non-AI Warp features never consumes Platform Credits.
+* **Third-party harnesses run directly** - Running `claude`, `codex`, or another harness as a standalone CLI without going through Oz. Oz isn't in the path, so there's nothing to charge.
+
+## Where Platform Credits appear
+
+Platform Credits roll into the same surfaces as your other credit usage.
+
+* **Per-user credit totals** - Your total credit usage in **Settings** > **Billing and usage** in the Warp app includes Platform Credits alongside AI and Cloud Agent Credits.
+* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar with a `(Platform)` label in the tooltip, distinct from `(AI)` and `(Compute)` segments.
+* **Add-on Credits and limits** - Platform Credits draw from the same plan and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other credit usage. Once your monthly plan credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
+
+## Related pages
+
+* [Credits](/support-and-community/plans-and-billing/credits/) - How AI credits are measured and calculated.
+* [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) - Purchase additional credits or enable auto reload.
+* [Bring Your Own API Key](/support-and-community/plans-and-billing/bring-your-own-api-key/) - Connect your own model provider keys.
+* [Plans, pricing, and refunds](/support-and-community/plans-and-billing/plans-pricing-refunds/) - Compare plans and refund policies.

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -53,7 +53,7 @@ Platform credits appear in the same billing views as your other credit usage.
 
 * **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes platform credits alongside AI credits and compute credits.
 * **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform credits appear as their own segment in the stacked usage bar, distinct from the AI credits and compute credits segments.
-* **Add-on Credits and limits** - Platform credits draw from the same Warp credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly Warp credits are exhausted, platform credits continue to consume from Add-on Credits if you have them.
+* **Add-on Credits and limits** - Platform credits draw from the same pools as your other usage — your monthly Warp credits first, then [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) once those are exhausted.
 
 ## Related pages
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -7,7 +7,7 @@ description: >-
 
 Platform Credits cover Warp's platform infrastructure for coordinating, observing, and integrating agent runs. They apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference such as BYOK, Amazon Bedrock, or Google Vertex.
 
-Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and Platform Credits. Credit types and where an agent runs (local or cloud) are independent.
+Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Compute credits](/support-and-community/plans-and-billing/credits/#compute-credits), and Platform Credits. Credit types and where an agent runs (local or cloud) are independent.
 
 Customer-supplied inference covers [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) and BYOLLM via Amazon Bedrock or Google Vertex.
 
@@ -20,10 +20,10 @@ BYOK and customer-supplied inference (BYOLLM via Amazon Bedrock or Google Vertex
 Each credit bucket covers a different layer of the infrastructure Warp provides. Credit types and where an agent runs (local or cloud) are independent — each agent run consumes from whichever credit types apply to it.
 
 * **AI credits** cover inference: the LLM call itself. Consumed when Warp pays for the model call through Warp-managed providers. Used by agent conversations, [Generate](/agent-platform/local-agents/generate/), [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill), and other AI features. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
-* **Cloud Agent Credits** cover Warp-hosted compute consumed by an agent run — the sandbox the agent runs in. Cloud agent runs consume them (Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app) because they run on Warp's compute; local agent runs use your own machine and don't. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Compute credits** cover compute: the sandbox an agent runs in. Consumed when an agent run uses Warp-hosted compute. In practice this is cloud agent runs (Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app); local agent runs use your own machine and don't consume compute credits. See [Compute credits](/support-and-community/plans-and-billing/credits/#compute-credits).
 * **Platform Credits** cover Warp's platform layer: run lifecycle, integrations, dashboard, APIs, and observability. Apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
-The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, Cloud Agent Credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
+The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, compute credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
 
 ## How Platform Credits are measured
 
@@ -51,9 +51,9 @@ Whether Platform Credits apply depends on where the agent runs and who's paying 
 
 Platform Credits appear in the same billing views as your other credit usage.
 
-* **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes Platform Credits alongside AI credits and Cloud Agent Credits.
-* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI credits and Cloud Agent Credits segments.
-* **Add-on Credits and limits** - Platform Credits draw from the same plan credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly plan credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
+* **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes Platform Credits alongside AI credits and compute credits.
+* **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform Credits appear as their own segment in the stacked usage bar, distinct from the AI credits and compute credits segments.
+* **Add-on Credits and limits** - Platform Credits draw from the same normal Warp credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly normal Warp credits are exhausted, Platform Credits continue to consume from Add-on Credits if you have them.
 
 ## Related pages
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -8,17 +8,17 @@ description: >-
 
 Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and Platform Credits.
 
-Platform Credits charge for Warp's platform infrastructure on every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference. Even when you bring your own model provider, connect your own LLM API keys, or run cloud agents on your own compute, Warp's platform still coordinates, observes, and integrates your agents — and Platform Credits charge for that.
+Platform Credits cover Warp's platform infrastructure on every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference. Even when you bring your own model provider, connect your own LLM API keys, or run cloud agents on your own compute, Warp's platform still coordinates, observes, and integrates your agents — and Platform Credits cover that orchestration layer.
 
 Customer-supplied inference covers [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) and BYOLLM via Amazon Bedrock or Google Vertex. Platform Credits don't apply to local runs on Free, Build, or Max plans, or to local Business and Enterprise runs where Warp pays for inference through AI credits.
 
 ## The three credit buckets
 
-Each credit bucket charges for a different layer of the infrastructure Warp provides:
+Each credit bucket covers a different layer of the infrastructure Warp provides:
 
-* **AI credits** - Charged for inference infrastructure Warp pays for. Consumed by Agent conversations, [Generate](/agent-platform/local-agents/generate/), [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill), and other AI features that route through Warp-managed model providers. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
-* **Cloud Agent Credits** - Charged for compute infrastructure when cloud agents run on Warp-hosted compute. Consumed by Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** - Charged for Warp's platform infrastructure (run lifecycle, integrations, dashboard, APIs, and observability). Applies to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
+* **AI credits** cover inference infrastructure that Warp pays for. Agent conversations, [Generate](/agent-platform/local-agents/generate/), [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill), and other AI features that route through Warp-managed model providers use AI credits. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
+* **Cloud Agent Credits** cover compute infrastructure when cloud agents run on Warp-hosted compute. Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app use Cloud Agent Credits. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Platform Credits** cover Warp's platform infrastructure, including run lifecycle, integrations, dashboard, APIs, and observability. Platform Credits apply to every cloud agent run, plus local agent runs on Business and Enterprise plans that use customer-supplied inference.
 
 The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, Cloud Agent Credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
 
@@ -30,19 +30,19 @@ See [warp.dev/pricing](https://warp.dev/pricing) for current rates.
 
 ## When Platform Credits apply
 
-Whether Platform Credits are charged depends on where the agent runs and who's paying for inference.
+Whether Platform Credits apply depends on where the agent runs and who's paying for inference.
 
-### Charged
+### Uses Platform Credits
 
-* **Cloud agents on any plan** - Every cloud agent run charges Platform Credits, regardless of harness (Warp Agent, Claude Code, Codex, Gemini), inference source (Warp-managed, BYOK, or BYOLLM), or compute source (Warp-hosted or self-hosted workers). Warp's platform infrastructure is always running the agent.
-* **Local agents on Business or Enterprise with customer-supplied inference** - Local agent runs on a Business or Enterprise plan that use [BYOK](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent.
+* **Cloud agents on any plan** use Platform Credits for every cloud agent run, regardless of which agent runs the task (Warp Agent, Claude Code, Codex, or Gemini), inference source (Warp-managed, BYOK, or BYOLLM), or compute source (Warp-hosted or self-hosted workers). Warp's platform infrastructure coordinates every cloud agent run.
+* **Local agents on Business or Enterprise with customer-supplied inference** use Platform Credits when the local agent run uses [BYOK](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent.
 
-### Not charged
+### Doesn't use Platform Credits
 
-* **Local agents on Free, Build, or Max plans** - No Platform Credits charge, regardless of whether you use Warp-managed inference or BYOK.
-* **Local agents on Business or Enterprise using Warp-managed inference** - Warp is already paying for the model call through AI credits, so no separate Platform Credits charge applies.
-* **Regular terminal usage** - Running shell commands and using non-AI Warp features never consumes Platform Credits.
-* **Third-party harnesses run directly** - Running `claude`, `codex`, or another harness as a standalone CLI without going through Oz. Oz isn't in the path, so there's nothing to charge.
+* **Local agents on Free, Build, or Max plans** don't use Platform Credits, regardless of whether you use Warp-managed inference or BYOK.
+* **Local agents on Business or Enterprise using Warp-managed inference** don't use Platform Credits because Warp is already paying for the model call through AI credits.
+* **Regular terminal usage** doesn't use Platform Credits. Shell commands and non-AI Warp features don't consume credits.
+* **Third-party agent CLIs run directly** don't use Platform Credits when you run `claude`, `codex`, or another agent CLI without going through Oz.
 
 ## Where Platform Credits appear
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -53,7 +53,7 @@ Platform credits appear in the same billing views as your other credit usage.
 
 * **Per-user credit totals** - In the Warp app, **Settings** > **Billing and usage** includes platform credits alongside AI credits and compute credits.
 * **Admin usage breakdown** - For team admins, the Admin Panel billing view shows a per-bucket breakdown for each member and for the team as a whole. Platform credits appear as their own segment in the stacked usage bar, distinct from the AI credits and compute credits segments.
-* **Add-on Credits and limits** - Platform credits draw from the same normal Warp credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly normal Warp credits are exhausted, platform credits continue to consume from Add-on Credits if you have them.
+* **Add-on Credits and limits** - Platform credits draw from the same Warp credits and [Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/) pools as your other usage. Once your monthly Warp credits are exhausted, platform credits continue to consume from Add-on Credits if you have them.
 
 ## Related pages
 

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Platform Credits
 description: >-
-  Platform Credits charge for Warp's platform infrastructure on every cloud
+  Platform Credits cover Warp's platform infrastructure on every cloud
   agent run, plus local agent runs on Business and Enterprise plans that use
   customer-supplied inference. Learn when they apply and where they appear.
 ---

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -1,29 +1,31 @@
 ---
 title: Platform Credits
 description: >-
-  Platform Credits charge for the Oz orchestration layer. Learn when they
-  apply, when they don't, and where they appear in your billing.
+  Platform Credits charge for Warp's platform infrastructure when Warp isn't
+  paying for inference or compute. Learn when they apply and where they appear.
 ---
 
-Platform Credits are the third credit bucket in Warp, alongside [AI credits](/support-and-community/plans-and-billing/credits/) and [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits). They charge for the Oz orchestration layer — task lifecycle, scheduling, integrations, run history, and the rest of the platform that coordinates your agent runs.
+Warp meters credits across three types of infrastructure: **inference** (the model call), **compute** (the sandbox an agent runs in), and **platform** (everything that runs around the agent — run lifecycle, integrations, dashboard, APIs, and observability). Each type maps to one credit bucket: [AI credits](/support-and-community/plans-and-billing/credits/), [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits), and Platform Credits.
+
+Platform Credits charge for Warp's platform infrastructure when Warp isn't paying for the inference or compute. Customers who bring their own model provider (BYOLLM via Amazon Bedrock or Google Vertex), connect their own LLM API keys, or run cloud agents on their own compute still rely on Warp's platform to coordinate, observe, and integrate their agents — and Platform Credits charge for that.
 
 Platform Credits apply to every cloud agent run, and to local agent runs on Business and Enterprise plans that use customer-supplied inference — [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM via Amazon Bedrock or Google Vertex. They don't apply to local runs on Free, Build, or Max plans, or to local Business and Enterprise runs where Warp pays for inference through AI credits.
 
 ## The three credit buckets
 
-Warp meters AI and agent usage in three buckets. Each bucket charges for a different part of the system:
+Each credit bucket charges for a different layer of the infrastructure Warp provides:
 
-* **AI credits** - Charged for inference Warp pays for. Consumed by Agent conversations, [Generate](/agent-platform/local-agents/generate/), Workflow autofill, and other AI features. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
-* **Cloud Agent Credits** - Charged for cloud agent runs that execute on Warp-hosted compute. Consumed by Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
-* **Platform Credits** - Charged for the Oz orchestration layer that coordinates agent runs. Applies to every cloud agent run, plus local runs on Business and Enterprise plans that use customer-supplied inference.
+* **AI credits** - Charged for inference infrastructure Warp pays for. Consumed by Agent conversations, [Generate](/agent-platform/local-agents/generate/), Workflow autofill, and other AI features that route through Warp-managed model providers. See [credits](/support-and-community/plans-and-billing/credits/) for how AI credits are calculated.
+* **Cloud Agent Credits** - Charged for compute infrastructure when cloud agents run on Warp-hosted compute. Consumed by Slack and Linear integrations, `oz agent run-cloud`, the Oz API, and Cloud Mode in the Warp app. See [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits).
+* **Platform Credits** - Charged for platform infrastructure (run lifecycle, integrations, dashboard, APIs, and observability) when an agent is actively working but Warp isn't paying for inference or compute. Applies to every cloud agent run, plus local runs on Business and Enterprise plans that use customer-supplied inference.
 
-The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, Cloud Agent Credits for the hosted compute, and Platform Credits for the orchestration layer.
+The three buckets are independent and a single run can consume from more than one. A Warp-managed cloud agent run, for example, consumes AI credits for the model call, Cloud Agent Credits for the hosted compute, and Platform Credits for the platform infrastructure that runs the agent.
 
 ## How Platform Credits are measured
 
 Platform Credits accrue while an Oz agent is actively working on a task — from when the task starts running to when it finishes, fails, or is cancelled. Idle time, time spent waiting on user input, and time before the task starts don't accrue Platform Credits.
 
-See [warp.dev/pricing](https://warp.dev/pricing) for current rates. Enterprise plans can negotiate a custom rate as part of their contract.
+See [warp.dev/pricing](https://warp.dev/pricing) for current rates.
 
 ## When Platform Credits apply
 
@@ -31,8 +33,8 @@ Whether Platform Credits are charged depends on where the agent runs and who's p
 
 ### Charged
 
-* **Cloud agents on any plan** - Every cloud agent run charges Platform Credits, regardless of harness (Warp Agent, Claude Code, Codex, Gemini) or inference source (Warp-managed, BYOK, or BYOLLM). Oz is always orchestrating the run.
-* **Local agents on Business or Enterprise with customer-supplied inference** - Local Oz runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM (Amazon Bedrock, Google Vertex). Warp isn't paying for the model call, but Oz is still orchestrating the local agent.
+* **Cloud agents on any plan** - Every cloud agent run charges Platform Credits, regardless of harness (Warp Agent, Claude Code, Codex, Gemini) or inference source (Warp-managed, BYOK, or BYOLLM). Warp's platform infrastructure is always running the agent.
+* **Local agents on Business or Enterprise with customer-supplied inference** - Local Oz runs on a Business or Enterprise plan that use [Bring Your Own API Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) or BYOLLM (Amazon Bedrock, Google Vertex). Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent.
 
 ### Not charged
 

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -305,7 +305,7 @@ Add-on credits replace overages with a simpler, prepaid system. They’re up to 
 
 #### Do credits rollover?
 
-For existing users on legacy plans, plan credits on Pro, Turbo, and Lightspeed do not rollover.
+For existing users on legacy plans, normal Warp credits on Pro, Turbo, and Lightspeed do not rollover.
 
 For the Build plan, credits will not rollover but Add-on credits will rollover and be valid for 12 months from the date of purchase.
 
@@ -347,6 +347,6 @@ If you’re part of a larger team (up to 50 members) that needs advanced adminis
 For teams on the Build or Business plans, credits are managed at two levels:
 
 * **Included monthly credits**: Each seat on a paid plan receives 1,500 individual credits per month. These credits are tied to the user and reset every 30 days based on their subscription or renewal date.
-* **Add-on Credits**: Once individual plan credits are used up, team members draw from a shared Add-on Credit balance that can be topped up and managed by team admins.
+* **Add-on Credits**: Once individual normal Warp credits are used up, team members draw from a shared Add-on Credit balance that can be topped up and managed by team admins.
 
 This shared model gives teams the flexibility to handle variable AI usage – heavy users can consume more when needed, while the entire team benefits from shared value and volume-based discounts.

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -305,7 +305,7 @@ Add-on credits replace overages with a simpler, prepaid system. They’re up to 
 
 #### Do credits rollover?
 
-For existing users on legacy plans, normal Warp credits on Pro, Turbo, and Lightspeed do not rollover.
+For existing users on legacy plans, Warp credits on Pro, Turbo, and Lightspeed do not rollover.
 
 For the Build plan, credits will not rollover but Add-on credits will rollover and be valid for 12 months from the date of purchase.
 
@@ -347,6 +347,6 @@ If you’re part of a larger team (up to 50 members) that needs advanced adminis
 For teams on the Build or Business plans, credits are managed at two levels:
 
 * **Included monthly credits**: Each seat on a paid plan receives 1,500 individual credits per month. These credits are tied to the user and reset every 30 days based on their subscription or renewal date.
-* **Add-on Credits**: Once individual normal Warp credits are used up, team members draw from a shared Add-on Credit balance that can be topped up and managed by team admins.
+* **Add-on Credits**: Once individual Warp credits are used up, team members draw from a shared Add-on Credit balance that can be topped up and managed by team admins.
 
 This shared model gives teams the flexibility to handle variable AI usage – heavy users can consume more when needed, while the entire team benefits from shared value and volume-based discounts.

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -347,6 +347,6 @@ If you’re part of a larger team (up to 50 members) that needs advanced adminis
 For teams on the Build or Business plans, credits are managed at two levels:
 
 * **Included monthly credits**: Each seat on a paid plan receives 1,500 individual credits per month. These credits are tied to the user and reset every 30 days based on their subscription or renewal date.
-* **Add-on Credits**: Once individual Warp credits are used up, team members draw from a shared Add-on Credit balance that can be topped up and managed by team admins.
+* **Add-on Credits**: Once individual credits are used up, team members draw from a shared Add-on Credit balance that can be topped up and managed by team admins.
 
 This shared model gives teams the flexibility to handle variable AI usage – heavy users can consume more when needed, while the entire team benefits from shared value and volume-based discounts.


### PR DESCRIPTION
## Summary

Adds documentation for **Platform Credits**, the third credit bucket in Warp launching as part of the Oz Orchestration Launch (Codename Maestro). Platform Credits cover the Oz orchestration layer for the cases where Warp isn't paying for inference or compute — BYOLLM via Amazon Bedrock or Google Vertex, BYOK direct keys, or self-hosted cloud agents. AI credits and Cloud Agent Credits already cover the other two parts of the system; Platform Credits close the gap for customers who use Oz purely as an orchestration platform.

The new page is purely conceptual: it explains what Platform Credits are, when they apply, when they don't, and where they appear in usage views. Per scope, pricing specifics (per-minute rate, wall-time math, feature-flag rollout modes, telemetry, tier overrides, stale-fail short-circuit) are intentionally not documented and are deferred to warp.dev/pricing or kept internal.

## Pages

### New

- `src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx` — Conceptual page covering the three-bucket model, how Platform Credits are measured (at the conceptual "while an agent is actively working" level), when they apply / don't apply, and where they appear in user and admin usage surfaces.

### Edited

- `src/content/docs/support-and-community/plans-and-billing/credits.mdx` — Added a three-bucket model summary near the top (AI credits, Cloud Agent Credits, Platform Credits) and a "Platform Credits" subsection at the bottom mirroring the existing "Cloud Agent Credits" subsection. Both link to the new page.
- `src/content/docs/support-and-community/plans-and-billing/plans-pricing-refunds.mdx` — Added a Platform Credits entry to the credit-types list so the new page is discoverable from the plans landing surface.

## Out of scope (per launch coordination)

- No edits to `src/sidebar.ts` (reserved for the cross-cutting launch PR).
- No `vercel.json` redirects (reserved).
- No edits to top-level landing pages.
- No edits to the BYOLLM or Add-on Credits pages.

## Open questions / things to confirm before merge

1. **Rollout state at launch.** In `warp-server/config/prod.yaml`, `platform_credits_mode` is currently `report` — meaning telemetry is being emitted for calibration but no platform-credit charges are landing in the ledger yet. Staging and local are `charge`. I drafted the page to describe Platform Credits as an active billing concept ("are charged") rather than "will be charged," but if Platform Credits won't be in `charge` mode in prod on the launch date, we may want to soften the language (e.g., "Platform Credits are rolling out for [cohort]") or hold the page until the flag flips. Please confirm with Product/PM.
2. **Pricing page coverage.** The page defers the per-minute rate to `warp.dev/pricing`. Confirm the public pricing page will publish the rate by launch; otherwise the "The per-minute rate is published on warp.dev/pricing" sentence should be revised.
3. **Admin Panel visuals.** The page references "a `(Platform)` label in the tooltip" and "a stacked usage bar segment." Once the Admin Panel UI is finalized for launch, a screenshot would strengthen the "Where Platform Credits appear" section.

## Validation

- `python3 .agents/skills/style_lint/style_lint.py --changed` → 3 files scanned, 0 issues.
- Files touched are scoped exactly to the PR's listed paths.

## Context

- Source-of-truth tech spec: `warp-server/specs/REV-1551/TECH.md`
- Charge matrix: `warp-server/model/types/billing.go::ShouldChargePlatformCredits`
- Admin UI labels: `warp-server/client/src/components/admin/billing/memberUsageUtils.ts` (`BUCKET_LABELS`)

[Conversation](https://staging.warp.dev/conversation/8ef2ea5c-a983-463f-acc6-cd69eee7e185)

Co-Authored-By: Oz <oz-agent@warp.dev>
