### PR TITLE
docs(cloud-agents): add multi-harness pages (Warp Agent, Claude Code, Codex)

### DIFF
--- a/src/content/docs/agent-platform/cli-agents/claude-code.mdx
+++ b/src/content/docs/agent-platform/cli-agents/claude-code.mdx
@@ -14,7 +14,7 @@ Warp auto-detects Claude Code when you run it, giving you access to rich input c
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Claude Code](/guides/external-tools/how-to-set-up-claude-code/) guide.
 
 :::note
-**Running Claude Code in the cloud?** This page covers Claude Code as a local CLI agent in the Warp terminal. To run Claude Code as a cloud agent dispatched and orchestrated by Oz — with environments, scheduling, integrations, and shared credentials — see the [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/).
+**Running Claude Code in the cloud?** This page covers Claude Code as a local CLI agent in the Warp terminal. To run Claude Code as a cloud agent dispatched and orchestrated by Oz — with environments, scheduling, integrations, and shared credentials — see [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/).
 :::
 
 ## Setting up notifications
@@ -71,7 +71,7 @@ Claude Code supports the full set of Warp's agent integration features:
 
 ## Related pages
 
-* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as an Oz cloud harness
+* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness in Oz
 * [How to set up Claude Code](/guides/external-tools/how-to-set-up-claude-code/) — step-by-step setup guide
 * [Claude Code in Warp](https://warp.dev/agents/claude-code) — product overview
 * [Third-Party CLI Agents Overview](/agent-platform/cli-agents/overview/)

--- a/src/content/docs/agent-platform/cli-agents/claude-code.mdx
+++ b/src/content/docs/agent-platform/cli-agents/claude-code.mdx
@@ -14,7 +14,7 @@ Warp auto-detects Claude Code when you run it, giving you access to rich input c
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Claude Code](/guides/external-tools/how-to-set-up-claude-code/) guide.
 
 :::note
-Claude Code is also available as a harness in Oz for cloud orchestration. See [Claude Code in Oz](/agent-platform/cloud-agents/harnesses/claude-code/).
+Claude Code is also available as a harness in Oz for cloud orchestration. See [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/).
 :::
 
 ## Setting up notifications
@@ -74,6 +74,6 @@ Claude Code supports the full set of Warp's agent integration features:
 * [How to set up Claude Code](/guides/external-tools/how-to-set-up-claude-code/) — step-by-step setup guide
 * [Claude Code in Warp](https://warp.dev/agents/claude-code) — product overview
 * [Third-Party CLI Agents Overview](/agent-platform/cli-agents/overview/)
-* [Claude Code as a Cloud Agent](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness in Oz
+* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness
 * [OpenCode](/agent-platform/cli-agents/opencode/)
 * [Codex](/agent-platform/cli-agents/codex/)

--- a/src/content/docs/agent-platform/cli-agents/claude-code.mdx
+++ b/src/content/docs/agent-platform/cli-agents/claude-code.mdx
@@ -14,7 +14,7 @@ Warp auto-detects Claude Code when you run it, giving you access to rich input c
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Claude Code](/guides/external-tools/how-to-set-up-claude-code/) guide.
 
 :::note
-**Running Claude Code in the cloud?** This page covers Claude Code as a local CLI agent in the Warp terminal. To run Claude Code as a cloud agent dispatched and orchestrated by Oz — with environments, scheduling, integrations, and shared credentials — see [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/).
+Claude Code is also available as a harness in Oz for cloud orchestration. See [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/).
 :::
 
 ## Setting up notifications

--- a/src/content/docs/agent-platform/cli-agents/claude-code.mdx
+++ b/src/content/docs/agent-platform/cli-agents/claude-code.mdx
@@ -14,7 +14,7 @@ Warp auto-detects Claude Code when you run it, giving you access to rich input c
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Claude Code](/guides/external-tools/how-to-set-up-claude-code/) guide.
 
 :::note
-Claude Code is also available as a harness in Oz for cloud orchestration. See [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/).
+Claude Code is also available as a harness in Oz for cloud orchestration. See [Claude Code in Oz](/agent-platform/cloud-agents/harnesses/claude-code/).
 :::
 
 ## Setting up notifications
@@ -71,9 +71,9 @@ Claude Code supports the full set of Warp's agent integration features:
 
 ## Related pages
 
-* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness in Oz
 * [How to set up Claude Code](/guides/external-tools/how-to-set-up-claude-code/) — step-by-step setup guide
 * [Claude Code in Warp](https://warp.dev/agents/claude-code) — product overview
 * [Third-Party CLI Agents Overview](/agent-platform/cli-agents/overview/)
+* [Claude Code as a Cloud Agent](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness in Oz
 * [OpenCode](/agent-platform/cli-agents/opencode/)
 * [Codex](/agent-platform/cli-agents/codex/)

--- a/src/content/docs/agent-platform/cli-agents/claude-code.mdx
+++ b/src/content/docs/agent-platform/cli-agents/claude-code.mdx
@@ -13,6 +13,10 @@ Warp auto-detects Claude Code when you run it, giving you access to rich input c
 
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Claude Code](/guides/external-tools/how-to-set-up-claude-code/) guide.
 
+:::note
+**Running Claude Code in the cloud?** This page covers Claude Code as a local CLI agent in the Warp terminal. To run Claude Code as a cloud agent dispatched and orchestrated by Oz — with environments, scheduling, integrations, and shared credentials — see the [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/).
+:::
+
 ## Setting up notifications
 
 Warp supports agent notifications for Claude Code through a plugin. Once installed, Warp surfaces in-app and desktop alerts when Claude Code needs your input — such as command approval, code review, or error intervention.
@@ -67,6 +71,7 @@ Claude Code supports the full set of Warp's agent integration features:
 
 ## Related pages
 
+* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as an Oz cloud harness
 * [How to set up Claude Code](/guides/external-tools/how-to-set-up-claude-code/) — step-by-step setup guide
 * [Claude Code in Warp](https://warp.dev/agents/claude-code) — product overview
 * [Third-Party CLI Agents Overview](/agent-platform/cli-agents/overview/)

--- a/src/content/docs/agent-platform/cli-agents/codex.mdx
+++ b/src/content/docs/agent-platform/cli-agents/codex.mdx
@@ -14,7 +14,7 @@ Warp auto-detects Codex when you run it, giving you access to rich input control
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Codex CLI](/guides/external-tools/how-to-set-up-codex-cli/) guide.
 
 :::note
-**Running Codex in the cloud?** This page covers Codex as a local CLI agent in the Warp terminal. To run Codex as a cloud agent dispatched and orchestrated by Oz — with environments, scheduling, integrations, and shared credentials — see the [Codex harness](/agent-platform/cloud-agents/harnesses/codex/).
+**Running Codex in the cloud?** This page covers Codex as a local CLI agent in the Warp terminal. To run Codex as a cloud agent dispatched and orchestrated by Oz — with environments, scheduling, integrations, and shared credentials — see [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/).
 :::
 
 ## Setting up notifications
@@ -46,7 +46,7 @@ Codex supports the full set of Warp's agent integration features:
 
 ## Related pages
 
-* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as an Oz cloud harness
+* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness in Oz
 * [How to set up Codex CLI](/guides/external-tools/how-to-set-up-codex-cli/) — step-by-step setup guide
 * [Codex in Warp](https://warp.dev/agents/codex) — product overview
 * [Third-Party CLI Agents Overview](/agent-platform/cli-agents/overview/)

--- a/src/content/docs/agent-platform/cli-agents/codex.mdx
+++ b/src/content/docs/agent-platform/cli-agents/codex.mdx
@@ -13,6 +13,10 @@ Warp auto-detects Codex when you run it, giving you access to rich input control
 
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Codex CLI](/guides/external-tools/how-to-set-up-codex-cli/) guide.
 
+:::note
+**Running Codex in the cloud?** This page covers Codex as a local CLI agent in the Warp terminal. To run Codex as a cloud agent dispatched and orchestrated by Oz — with environments, scheduling, integrations, and shared credentials — see the [Codex harness](/agent-platform/cloud-agents/harnesses/codex/).
+:::
+
 ## Setting up notifications
 
 Codex supports native notifications that Warp surfaces as in-app and desktop alerts — such as when Codex completes a task, encounters an error, or needs your input.
@@ -42,6 +46,7 @@ Codex supports the full set of Warp's agent integration features:
 
 ## Related pages
 
+* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as an Oz cloud harness
 * [How to set up Codex CLI](/guides/external-tools/how-to-set-up-codex-cli/) — step-by-step setup guide
 * [Codex in Warp](https://warp.dev/agents/codex) — product overview
 * [Third-Party CLI Agents Overview](/agent-platform/cli-agents/overview/)

--- a/src/content/docs/agent-platform/cli-agents/codex.mdx
+++ b/src/content/docs/agent-platform/cli-agents/codex.mdx
@@ -14,7 +14,7 @@ Warp auto-detects Codex when you run it, giving you access to rich input control
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Codex CLI](/guides/external-tools/how-to-set-up-codex-cli/) guide.
 
 :::note
-**Running Codex in the cloud?** This page covers Codex as a local CLI agent in the Warp terminal. To run Codex as a cloud agent dispatched and orchestrated by Oz — with environments, scheduling, integrations, and shared credentials — see [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/).
+Codex is also available as a harness in Oz for cloud orchestration. See [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/).
 :::
 
 ## Setting up notifications

--- a/src/content/docs/agent-platform/cli-agents/codex.mdx
+++ b/src/content/docs/agent-platform/cli-agents/codex.mdx
@@ -14,7 +14,7 @@ Warp auto-detects Codex when you run it, giving you access to rich input control
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Codex CLI](/guides/external-tools/how-to-set-up-codex-cli/) guide.
 
 :::note
-Codex is also available as a harness in Oz for cloud orchestration. See [Codex in Oz](/agent-platform/cloud-agents/harnesses/codex/).
+Codex is also available as a harness in Oz for cloud orchestration. See [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/).
 :::
 
 ## Setting up notifications
@@ -49,6 +49,6 @@ Codex supports the full set of Warp's agent integration features:
 * [How to set up Codex CLI](/guides/external-tools/how-to-set-up-codex-cli/) — step-by-step setup guide
 * [Codex in Warp](https://warp.dev/agents/codex) — product overview
 * [Third-Party CLI Agents Overview](/agent-platform/cli-agents/overview/)
-* [Codex as a Cloud Agent](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness in Oz
+* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness
 * [Claude Code](/agent-platform/cli-agents/claude-code/)
 * [OpenCode](/agent-platform/cli-agents/opencode/)

--- a/src/content/docs/agent-platform/cli-agents/codex.mdx
+++ b/src/content/docs/agent-platform/cli-agents/codex.mdx
@@ -14,7 +14,7 @@ Warp auto-detects Codex when you run it, giving you access to rich input control
 For installation, authentication, project configuration, and productivity tips, see the [How to set up Codex CLI](/guides/external-tools/how-to-set-up-codex-cli/) guide.
 
 :::note
-Codex is also available as a harness in Oz for cloud orchestration. See [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/).
+Codex is also available as a harness in Oz for cloud orchestration. See [Codex in Oz](/agent-platform/cloud-agents/harnesses/codex/).
 :::
 
 ## Setting up notifications
@@ -46,9 +46,9 @@ Codex supports the full set of Warp's agent integration features:
 
 ## Related pages
 
-* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness in Oz
 * [How to set up Codex CLI](/guides/external-tools/how-to-set-up-codex-cli/) — step-by-step setup guide
 * [Codex in Warp](https://warp.dev/agents/codex) — product overview
 * [Third-Party CLI Agents Overview](/agent-platform/cli-agents/overview/)
+* [Codex as a Cloud Agent](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness in Oz
 * [Claude Code](/agent-platform/cli-agents/claude-code/)
 * [OpenCode](/agent-platform/cli-agents/opencode/)

--- a/src/content/docs/agent-platform/cli-agents/opencode.mdx
+++ b/src/content/docs/agent-platform/cli-agents/opencode.mdx
@@ -14,7 +14,7 @@ Warp auto-detects OpenCode when you run it, giving you access to rich input cont
 For installation, authentication, project configuration, and productivity tips, see the [How to set up OpenCode](/guides/external-tools/how-to-set-up-opencode/) guide.
 
 :::note
-**OpenCode as an Oz cloud harness is coming soon.** OpenCode currently runs only as a local CLI agent in the Warp terminal. Cloud orchestration through Oz (alongside the existing [Warp Agent](/agent-platform/cloud-agents/harnesses/warp-agent/), [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/), and [Codex](/agent-platform/cloud-agents/harnesses/codex/) harnesses) is on the [Harnesses](/agent-platform/cloud-agents/harnesses/) roadmap as a fast-follow.
+**OpenCode in Oz is coming soon.** OpenCode currently runs only as a local CLI agent in the Warp terminal. Cloud orchestration through Oz (alongside the existing [Warp Agent](/agent-platform/cloud-agents/harnesses/warp-agent/), [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/), and [Codex](/agent-platform/cloud-agents/harnesses/codex/) harnesses) is on the [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) roadmap as a fast-follow.
 :::
 
 ## Setting up notifications

--- a/src/content/docs/agent-platform/cli-agents/opencode.mdx
+++ b/src/content/docs/agent-platform/cli-agents/opencode.mdx
@@ -13,10 +13,6 @@ Warp auto-detects OpenCode when you run it, giving you access to rich input cont
 
 For installation, authentication, project configuration, and productivity tips, see the [How to set up OpenCode](/guides/external-tools/how-to-set-up-opencode/) guide.
 
-:::note
-**OpenCode in Oz is coming soon.** OpenCode currently runs only as a local CLI agent in the Warp terminal. Cloud orchestration through Oz (alongside the existing [Warp Agent](/agent-platform/cloud-agents/harnesses/warp-agent/), [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/), and [Codex](/agent-platform/cloud-agents/harnesses/codex/) harnesses) is on the [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) roadmap as a fast-follow.
-:::
-
 ## Setting up notifications
 
 Warp supports agent notifications for OpenCode through a plugin. Once installed, Warp surfaces in-app and desktop alerts when OpenCode needs your input.

--- a/src/content/docs/agent-platform/cli-agents/opencode.mdx
+++ b/src/content/docs/agent-platform/cli-agents/opencode.mdx
@@ -13,6 +13,10 @@ Warp auto-detects OpenCode when you run it, giving you access to rich input cont
 
 For installation, authentication, project configuration, and productivity tips, see the [How to set up OpenCode](/guides/external-tools/how-to-set-up-opencode/) guide.
 
+:::note
+**OpenCode as an Oz cloud harness is coming soon.** OpenCode currently runs only as a local CLI agent in the Warp terminal. Cloud orchestration through Oz (alongside the existing [Warp Agent](/agent-platform/cloud-agents/harnesses/warp-agent/), [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/), and [Codex](/agent-platform/cloud-agents/harnesses/codex/) harnesses) is on the [Harnesses](/agent-platform/cloud-agents/harnesses/) roadmap as a fast-follow.
+:::
+
 ## Setting up notifications
 
 Warp supports agent notifications for OpenCode through a plugin. Once installed, Warp surfaces in-app and desktop alerts when OpenCode needs your input.

--- a/src/content/docs/agent-platform/cli-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cli-agents/overview.mdx
@@ -12,7 +12,7 @@ Warp auto-detects supported CLI agents and enhances them with IDE-level features
 This feature set is also known as **universal agent support**.
 
 :::note
-**Two contexts for these agents.** This page covers third-party CLI agents in the **Warp terminal** — interactive sessions you run on your own machine with the Warp toolbelt around them. Claude Code, Codex, and other supported agents can also run as **harnesses in Oz**, dispatched and orchestrated by Oz on Warp-hosted or self-hosted infrastructure. The two experiences share branding but are different surfaces. For the cloud experience, see [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/).
+Claude Code and Codex are also supported as harnesses in Oz for cloud orchestration. See [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/).
 :::
 
 ## Supported agents

--- a/src/content/docs/agent-platform/cli-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cli-agents/overview.mdx
@@ -12,7 +12,7 @@ Warp auto-detects supported CLI agents and enhances them with IDE-level features
 This feature set is also known as **universal agent support**.
 
 :::note
-**Two contexts for these agents.** This page covers third-party CLI agents in the **Warp terminal** — interactive sessions you run on your own machine with the Warp toolbelt around them. Claude Code, Codex, and other supported agents can also run as **Oz cloud harnesses**, dispatched and orchestrated by Oz on Warp-hosted or self-hosted infrastructure. The two experiences share branding but are different surfaces. For the cloud experience, see the [Harnesses overview](/agent-platform/cloud-agents/harnesses/).
+**Two contexts for these agents.** This page covers third-party CLI agents in the **Warp terminal** — interactive sessions you run on your own machine with the Warp toolbelt around them. Claude Code, Codex, and other supported agents can also run as **harnesses in Oz**, dispatched and orchestrated by Oz on Warp-hosted or self-hosted infrastructure. The two experiences share branding but are different surfaces. For the cloud experience, see [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/).
 :::
 
 ## Supported agents

--- a/src/content/docs/agent-platform/cli-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cli-agents/overview.mdx
@@ -11,6 +11,10 @@ Warp auto-detects supported CLI agents and enhances them with IDE-level features
 
 This feature set is also known as **universal agent support**.
 
+:::note
+**Two contexts for these agents.** This page covers third-party CLI agents in the **Warp terminal** — interactive sessions you run on your own machine with the Warp toolbelt around them. Claude Code, Codex, and other supported agents can also run as **Oz cloud harnesses**, dispatched and orchestrated by Oz on Warp-hosted or self-hosted infrastructure. The two experiences share branding but are different surfaces. For the cloud experience, see the [Harnesses overview](/agent-platform/cloud-agents/harnesses/).
+:::
+
 ## Supported agents
 
 Warp currently supports the following CLI coding agents:

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
@@ -1,0 +1,138 @@
+---
+title: Connecting Claude and Codex credentials
+description: >-
+  Store Anthropic or OpenAI credentials as Warp-managed secrets so Oz can inject
+  them into Claude Code and Codex cloud agent runs at execution time.
+sidebar:
+  label: "Authentication"
+---
+
+This page walks through the one-time setup that connects your team's Anthropic or OpenAI credentials to Oz so cloud runs of the [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/) and [Codex](/agent-platform/cloud-agents/harnesses/codex/) harnesses can authenticate.
+
+Oz stores credentials as **Warp-managed secrets** (see [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) for the full secrets model). At run time, Oz looks up the secret you select for the run and injects it into the harness container. Secret values are write-once: you can rotate them or delete them, but you can't read them back after creation.
+
+:::note
+[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud runs of Claude Code and Codex always use Warp-managed secrets so credentials are accessible from the cloud container.
+:::
+
+## Prerequisites
+
+* **A Warp team** - Harness auth secrets are typically scoped to a team so everyone on the team can launch authenticated runs. Personal secrets work for individual users. See [Teams](/knowledge-and-collaboration/teams/) for setting up a team.
+* **An Anthropic credential** - For Claude Code: an Anthropic API key from the [Anthropic Console](https://console.anthropic.com/), or Bedrock credentials (API key, or AWS access key) for Bedrock-routed inference.
+* **An OpenAI credential** - For Codex: an OpenAI API key from the [OpenAI dashboard](https://platform.openai.com/api-keys).
+* **The Oz CLI installed** - Required for CLI-based secret creation. See [Oz CLI](/reference/cli/) for installation.
+
+## Connecting Claude Code credentials
+
+Claude Code supports three Anthropic credential types: a direct API key, a Bedrock API key, or Bedrock AWS access keys. Pick the one that matches how your team consumes Anthropic models.
+
+### Create the secret in the Oz web app
+
+Use the Oz web app when you want a guided form that handles every Anthropic credential variant.
+
+1. **Open managed secrets in the Oz web app.** Sign in to the Oz web app at [oz.warp.dev](https://oz.warp.dev) and navigate to managed secrets in the sidebar. You'll see all secrets your team has stored.
+2. **Create a new secret.** Click **New secret**, then choose the credential type that matches your provider — **Anthropic API key**, **Anthropic Bedrock API key**, or **Anthropic Bedrock access key**.
+3. **Fill in the value fields.** Enter a name (for example, `ANTHROPIC_API_KEY`), an optional description, and the credential value(s) the form asks for. For Bedrock variants, include the AWS region.
+4. **Choose the scope.** Select **Team** so the secret is available to all teammates' Claude Code runs. Use **Personal** if the credential is tied to an individual account.
+5. **Save the secret.** Click **Save**. Warp stores the value encrypted and shows the secret in the list with its name, scope, and last-updated timestamp.
+
+**Expected outcome.** The new secret appears in the Oz web app's managed secrets list. It will be selectable on the new run and new schedule panes when **Claude Code** is the chosen harness.
+
+### Create the secret with the Oz CLI
+
+Use the Oz CLI when you're already in the terminal or want to script setup.
+
+The Oz CLI ships dedicated subcommands for each Anthropic credential type. Each subcommand reads the secret value securely from standard input or `--value-file`.
+
+```bash
+# Direct Anthropic API key (team scope)
+oz secret create anthropic api-key --team ANTHROPIC_API_KEY
+
+# Bedrock API key (team scope) — prompts for the bearer token and AWS region
+oz secret create anthropic bedrock-api-key --team ANTHROPIC_BEDROCK_KEY
+
+# Bedrock access keys (team scope) — prompts for access key id, secret access key, optional session token, and region
+oz secret create anthropic bedrock-access-key --team ANTHROPIC_BEDROCK_ACCESS
+```
+
+Add `--description "..."` to record rotation notes or owner info. Replace `--team` with `--personal` to make the secret available only to your own runs.
+
+**Expected outcome.** `oz secret list` shows the new secret with type `anthropic_api_key`, `anthropic_bedrock_api_key`, or `anthropic_bedrock_access_key`. The value is never displayed.
+
+### Use the secret on a Claude Code run
+
+Once the secret is stored, point a Claude Code run at it:
+
+* **Warp app** - In Cloud Mode, choose **Claude Code** in the harness dropdown. Warp prompts for a Claude Code auth secret if your team has more than one available.
+* **Oz web app** - On the new run or new schedule pane, choose **Claude Code** in the **Harness** field. A **Claude Code auth secret** dropdown appears below it; choose the secret you just created.
+* **Oz CLI** - Pass `--claude-auth-secret <NAME>` to `oz agent run-cloud --harness claude`.
+* **API / SDK** - Set `harness_auth_secrets.claude_auth_secret_name` on the agent config to the secret's name.
+
+If no auth secret is selected, Oz falls through without injection — useful for self-hosted workers that already have credentials baked into the image, but Anthropic API calls will fail otherwise.
+
+## Connecting Codex credentials
+
+Codex needs an OpenAI API key. Storing the key follows the same pattern as Claude Code, but uses a different secret type.
+
+### Create the secret in the Oz web app
+
+1. **Open managed secrets in the Oz web app** at [oz.warp.dev](https://oz.warp.dev).
+2. **Create a new secret.** Click **New secret**, then choose **OpenAI API key**.
+3. **Fill in the value fields.** Enter a name (for example, `OPENAI_API_KEY`), an optional description, and the API key value. If your team uses a regional or proxy endpoint, set the optional base URL field.
+4. **Choose the scope.** Select **Team** so all teammates' Codex runs can pick it up. Use **Personal** for individual-only use.
+5. **Save the secret.** Warp stores the value encrypted; the new secret appears in the list.
+
+**Expected outcome.** The new secret shows up with type `openai_api_key` and is selectable on the new run and new schedule panes when **Codex** is the chosen harness.
+
+:::note
+Codex secret creation from the Oz CLI is a fast-follow. For now, use the Oz web app to store OpenAI credentials.
+:::
+
+### Use the secret on a Codex run
+
+Once the secret is stored, point a Codex run at it:
+
+* **Warp app** - In Cloud Mode, choose **Codex** in the harness dropdown. Warp prompts for a Codex auth secret if your team has more than one available.
+* **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. A **Codex auth secret** dropdown appears below it; choose the secret you just created.
+* **API / SDK** - Set `harness_auth_secrets.codex_auth_secret_name` on the agent config to the secret's name.
+
+## Managing harness auth secrets
+
+Auth secrets follow the same management commands as any other Warp-managed secret. See [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) for the full reference. Common tasks:
+
+```bash
+# List secrets you can see
+oz secret list
+
+# Rotate a secret value (prompts for the new value)
+oz secret update --team --value ANTHROPIC_API_KEY
+
+# Update the description
+oz secret update --team --description "Rotated 2026-05-12; owned by platform team" ANTHROPIC_API_KEY
+
+# Delete a secret (irreversible)
+oz secret delete --team ANTHROPIC_API_KEY
+```
+
+:::caution
+Deleting an auth secret breaks any scheduled or integration-triggered run that references it by name. Update the schedules and integrations to point at a new secret first.
+:::
+
+## Troubleshooting
+
+**Claude Code or Codex run fails with an authentication error**\
+Confirm the run was started with a harness auth secret selected. From the Oz web app's run detail pane, the **Harness auth secret** field shows which secret (if any) was used. Re-launch the run with the correct secret selected, or create one if your team doesn't have one yet.
+
+**The harness auth secret dropdown is empty**\
+The dropdown only lists secrets whose type matches the selected harness — Anthropic types for Claude Code, OpenAI types for Codex. If you stored the credential as a raw value, recreate it using the typed flow above.
+
+**The selected harness is disabled**\
+Your team admin has disabled the harness for your workspace. Contact your admin or pick a different harness for the run.
+
+## Related pages
+
+* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
+* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
+* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — full secrets reference, including scoping and rotation.
+* [Harnesses overview](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) — local-only credentials for the Warp desktop app.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
@@ -1,15 +1,15 @@
 ---
 title: Connecting Claude and Codex credentials
 description: >-
-  Store Anthropic or OpenAI credentials as Warp-managed secrets so Oz can inject
-  them into Claude Code and Codex cloud agent runs at execution time.
+  Store Anthropic or OpenAI credentials as Warp-managed secrets so Oz can
+  inject them into Claude Code and Codex cloud agent runs.
 sidebar:
   label: "Authentication"
 ---
 
-This page walks through the one-time setup that connects your team's Anthropic or OpenAI credentials to Oz so cloud runs of the [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/) and [Codex](/agent-platform/cloud-agents/harnesses/codex/) harnesses can authenticate.
+This page walks through the one-time setup that connects your team's Anthropic or OpenAI credentials to Oz so cloud runs of [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/) and [Codex](/agent-platform/cloud-agents/harnesses/codex/) can authenticate.
 
-Oz stores credentials as **Warp-managed secrets** (see [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) for the full secrets model). At run time, Oz looks up the secret you select for the run and injects it into the harness container. Secret values are write-once: you can rotate them or delete them, but you can't read them back after creation.
+Oz stores credentials as **Warp-managed secrets** (see [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) for the full secrets model). At run time, Oz looks up the secret you select for the run and injects it into the harness container. Secret values are write-once: you can rotate or delete them, but you can't read the value back after creation.
 
 :::note
 [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud runs of Claude Code and Codex always use Warp-managed secrets so credentials are accessible from the cloud container.
@@ -19,7 +19,7 @@ Oz stores credentials as **Warp-managed secrets** (see [Cloud agent secrets](/ag
 
 * **A Warp team** - Harness auth secrets are typically scoped to a team so everyone on the team can launch authenticated runs. Personal secrets work for individual users. See [Teams](/knowledge-and-collaboration/teams/) for setting up a team.
 * **An Anthropic credential** - For Claude Code: an Anthropic API key from the [Anthropic Console](https://console.anthropic.com/), or Bedrock credentials (API key, or AWS access key) for Bedrock-routed inference.
-* **An OpenAI credential** - For Codex: an OpenAI API key from the [OpenAI dashboard](https://platform.openai.com/api-keys).
+* **An OpenAI API key** - For Codex: an API key from the [OpenAI dashboard](https://platform.openai.com/api-keys).
 * **The Oz CLI installed** - Required for CLI-based secret creation. See [Oz CLI](/reference/cli/) for installation.
 
 ## Connecting Claude Code credentials
@@ -51,13 +51,14 @@ oz secret create anthropic api-key --team ANTHROPIC_API_KEY
 # Bedrock API key (team scope) — prompts for the bearer token and AWS region
 oz secret create anthropic bedrock-api-key --team ANTHROPIC_BEDROCK_KEY
 
-# Bedrock access keys (team scope) — prompts for access key id, secret access key, optional session token, and region
+# Bedrock access keys (team scope) — prompts for access key id, secret access key,
+# optional session token, and region
 oz secret create anthropic bedrock-access-key --team ANTHROPIC_BEDROCK_ACCESS
 ```
 
 Add `--description "..."` to record rotation notes or owner info. Replace `--team` with `--personal` to make the secret available only to your own runs.
 
-**Expected outcome.** `oz secret list` shows the new secret with type `anthropic_api_key`, `anthropic_bedrock_api_key`, or `anthropic_bedrock_access_key`. The value is never displayed.
+**Expected outcome.** `oz secret list` shows the new secret with the matching Anthropic credential type. The value is never displayed.
 
 ### Use the secret on a Claude Code run
 
@@ -65,10 +66,8 @@ Once the secret is stored, point a Claude Code run at it:
 
 * **Warp app** - In Cloud Mode, choose **Claude Code** in the harness dropdown. Warp prompts for a Claude Code auth secret if your team has more than one available.
 * **Oz web app** - On the new run or new schedule pane, choose **Claude Code** in the **Harness** field. A **Claude Code auth secret** dropdown appears below it; choose the secret you just created.
-* **Oz CLI** - Pass `--claude-auth-secret <NAME>` to `oz agent run-cloud --harness claude`.
-* **API / SDK** - Set `harness_auth_secrets.claude_auth_secret_name` on the agent config to the secret's name.
-
-If no auth secret is selected, Oz falls through without injection — useful for self-hosted workers that already have credentials baked into the image, but Anthropic API calls will fail otherwise.
+* **Oz CLI** - Pass `--claude-auth-secret NAME` to `oz agent run-cloud --harness claude`.
+* **API and SDK** - Set the Claude Code auth-secret field on the agent config to the secret's name. See the [API reference](/reference/api-and-sdk/) for the exact field name.
 
 ## Connecting Codex credentials
 
@@ -82,7 +81,7 @@ Codex needs an OpenAI API key. Storing the key follows the same pattern as Claud
 4. **Choose the scope.** Select **Team** so all teammates' Codex runs can pick it up. Use **Personal** for individual-only use.
 5. **Save the secret.** Warp stores the value encrypted; the new secret appears in the list.
 
-**Expected outcome.** The new secret shows up with type `openai_api_key` and is selectable on the new run and new schedule panes when **Codex** is the chosen harness.
+**Expected outcome.** The new OpenAI API key secret appears in the managed secrets list. It will be selectable on the new run and new schedule panes when **Codex** is the chosen harness.
 
 :::note
 Codex secret creation from the Oz CLI is a fast-follow. For now, use the Oz web app to store OpenAI credentials.
@@ -92,9 +91,10 @@ Codex secret creation from the Oz CLI is a fast-follow. For now, use the Oz web 
 
 Once the secret is stored, point a Codex run at it:
 
-* **Warp app** - In Cloud Mode, choose **Codex** in the harness dropdown. Warp prompts for a Codex auth secret if your team has more than one available.
 * **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. A **Codex auth secret** dropdown appears below it; choose the secret you just created.
-* **API / SDK** - Set `harness_auth_secrets.codex_auth_secret_name` on the agent config to the secret's name.
+* **API and SDK** - Set the Codex auth-secret field on the agent config to the secret's name. See the [API reference](/reference/api-and-sdk/) for the exact field name.
+
+The Warp app's Codex harness selector and the `oz agent run-cloud --harness codex` flag are fast-follows. Until they ship, launch Codex runs from the Oz web app, the API, or a trigger that references a Codex-configured agent.
 
 ## Managing harness auth secrets
 
@@ -120,19 +120,19 @@ Deleting an auth secret breaks any scheduled or integration-triggered run that r
 
 ## Troubleshooting
 
-**Claude Code or Codex run fails with an authentication error**\
+**Claude Code or Codex run fails with an authentication error.**\
 Confirm the run was started with a harness auth secret selected. From the Oz web app's run detail pane, the **Harness auth secret** field shows which secret (if any) was used. Re-launch the run with the correct secret selected, or create one if your team doesn't have one yet.
 
-**The harness auth secret dropdown is empty**\
-The dropdown only lists secrets whose type matches the selected harness — Anthropic types for Claude Code, OpenAI types for Codex. If you stored the credential as a raw value, recreate it using the typed flow above.
+**The harness auth secret dropdown is empty.**\
+The dropdown only lists secrets whose type matches the selected harness — Anthropic types for Claude Code, OpenAI for Codex. If you stored the credential as a raw value, recreate it using the typed flow above.
 
-**The selected harness is disabled**\
+**The selected harness is disabled.**\
 Your team admin has disabled the harness for your workspace. Contact your admin or pick a different harness for the run.
 
 ## Related pages
 
-* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
-* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
+* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
+* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
 * [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — full secrets reference, including scoping and rotation.
-* [Harnesses overview](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
 * [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) — local-only credentials for the Warp desktop app.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
@@ -21,7 +21,7 @@ Claude Code is Anthropic's agentic coding tool. For more on Claude Code authenti
 
 ### Create an Anthropic API key
 
-1. Go to the [Anthropic Console](https://console.anthropic.com/) and sign in (or create an account).
+1. Go to the [Anthropic Console](https://platform.claude.com/login?returnTo=/?) and sign in (or create an account).
 2. Navigate to **API keys** and create a new key.
 3. Make sure your account has API credits — Claude Code runs are billed against your Anthropic API balance.
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 Third-party cloud agents — [Claude Code](#connecting-claude-code-credentials) and [Codex](#connecting-codex-credentials) — call their provider directly, so you need to store credentials as Warp-managed secrets before launching a run. This page walks through the one-time setup for each.
 
-Auth secrets can be scoped to a **team** (available to all teammates' runs) or **personal** (only your own runs), just like normal Warp-managed secrets. 
+Auth secrets can be scoped to a **team** (available to all teammates' runs) or **personal** (only your own runs), just like any other Warp-managed secret.
 
 :::note
 [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud runs of Claude Code and Codex always use Warp-managed secrets.
@@ -21,7 +21,7 @@ Claude Code is Anthropic's coding agent. For more on Claude Code authentication,
 
 ### Create an Anthropic API key
 
-1. Go to the [Anthropic Console](https://platform.claude.com/login?returnTo=/?) and sign in (or create an account).
+1. Go to the [Anthropic Console](https://console.anthropic.com/) and sign in (or create an account).
 2. Navigate to **API keys** and create a new key.
 3. Make sure your account has API credits — Claude Code runs are billed against your Anthropic API balance.
 
@@ -40,7 +40,7 @@ Start a new run, choose **Claude Code** as the harness, and add a new key in the
 #### Oz CLI
 
 ```bash
-oz secret create claude api-key <KEY_NAME>
+oz secret create claude api-key --team <KEY_NAME>
 ```
 
 Add `--description "..."` to record rotation notes or owner info. Replace `--team` with `--personal` to make the secret available only to your own runs.
@@ -57,7 +57,7 @@ A ChatGPT subscription (Plus, Pro, Team) does not include API access. You need a
 
 ### Create an OpenAI API key
 
-1. Go to the [OpenAI platform](https://platform.openai.com/home) and sign in (or create an account).
+1. Go to the [OpenAI Platform](https://platform.openai.com/) and sign in (or create an account).
 2. Navigate to **API keys** and click **Create new secret key**.
 3. Make sure your account has API credits — Codex runs are billed against your OpenAI API balance, not a ChatGPT subscription.
 
@@ -74,13 +74,12 @@ Start a new run, choose **Codex** as the harness, and add a new key in the harne
 #### Oz CLI
 
 ```bash
-oz secret create codex api-key <KEY_NAME>
+oz secret create codex api-key --team <KEY_NAME>
 ```
-
 
 Add `--description "..."` to record rotation notes or owner info. Replace `--team` with `--personal` to make the secret available only to your own runs.
 
-**Expected outcome.** `oz secret list` shows the new secret with the matching OpenA credential type. The value is never displayed.
+**Expected outcome.** `oz secret list` shows the new secret with the matching OpenAI credential type. The value is never displayed.
 
 ## Managing harness auth secrets
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
@@ -17,7 +17,7 @@ Auth secrets can be scoped to a **team** (available to all teammates' runs) or *
 
 ## Connecting Claude Code credentials
 
-Claude Code is Anthropic's coding agent. For more on Claude Code authentication, see [Anthropic's Claude Code auth docs](https://code.claude.com/docs/en/authentication).
+Claude Code is Anthropic's agentic coding tool. For more on Claude Code authentication, see [Anthropic's Claude Code auth docs](https://code.claude.com/docs/en/authentication).
 
 ### Create an Anthropic API key
 
@@ -31,7 +31,7 @@ Oz also supports Bedrock-routed credentials (**Anthropic Bedrock API key** and *
 
 #### Warp desktop app
 
-In Cloud Mode, click the Key icon above the input box and add your Anthropic credential.
+In Cloud Mode, click the key icon above the input and add your Anthropic credential.
 
 #### Oz web app
 
@@ -49,7 +49,7 @@ Add `--description "..."` to record rotation notes or owner info. Replace `--tea
 
 ## Connecting Codex credentials
 
-Codex is OpenAI's CLI coding agent. For more on Codex authentication, see [OpenAI's Codex auth docs](https://developers.openai.com/codex/auth).
+Codex is OpenAI's coding agent. For more on Codex authentication, see [OpenAI's Codex auth docs](https://developers.openai.com/codex/auth).
 
 :::caution
 A ChatGPT subscription (Plus, Pro, Team) does not include API access. You need a separate OpenAI API key with API credits.
@@ -65,7 +65,7 @@ A ChatGPT subscription (Plus, Pro, Team) does not include API access. You need a
 
 #### Warp desktop app
 
-In Cloud Mode, click the Key icon above the input box and add your OpenAI credential.
+In Cloud Mode, click the key icon above the input and add your OpenAI credential.
 
 #### Oz web app
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
@@ -91,10 +91,10 @@ Codex secret creation from the Oz CLI is a fast-follow. For now, use the Oz web 
 
 Once the secret is stored, point a Codex run at it:
 
+* **Warp app** - In Cloud Mode, choose **Codex** in the harness dropdown. Warp prompts for a Codex auth secret if your team has more than one available.
 * **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. A **Codex auth secret** dropdown appears below it; choose the secret you just created.
+* **Oz CLI** - Pass `--harness codex` to `oz agent run-cloud` along with the matching auth-secret flag for your OpenAI secret.
 * **API and SDK** - Set the Codex auth-secret field on the agent config to the secret's name. See the [API reference](/reference/api-and-sdk/) for the exact field name.
-
-The Warp app's Codex harness selector and the `oz agent run-cloud --harness codex` flag are fast-follows. Until they ship, launch Codex runs from the Oz web app, the API, or a trigger that references a Codex-configured agent.
 
 ## Managing harness auth secrets
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
@@ -1,100 +1,86 @@
 ---
-title: Connecting Claude and Codex credentials
+title: Third-party cloud agent authentication
 description: >-
-  Store Anthropic or OpenAI credentials as Warp-managed secrets so Oz can
-  authenticate Claude Code and Codex cloud runs against the provider.
+  Connect your Anthropic or OpenAI credentials to Oz, then launch Claude Code
+  or Codex as cloud agents from the desktop app, Oz web app, or API.
 sidebar:
   label: "Authentication"
 ---
 
-This page walks through the one-time setup that connects your team's Anthropic or OpenAI credentials to Oz so cloud runs of [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/) and [Codex](/agent-platform/cloud-agents/harnesses/codex/) can authenticate.
+Third-party cloud agents — [Claude Code](#connecting-claude-code-credentials) and [Codex](#connecting-codex-credentials) — call their provider directly, so you need to store credentials as Warp-managed secrets before launching a run. This page walks through the one-time setup for each.
 
-Oz stores credentials as **Warp-managed secrets** (see [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) for the full secrets model) and uses the one you pick on a run to authenticate the harness with the provider. Secret values are write-once: you can rotate or delete them, but you can't read the value back after creation.
+Auth secrets can be scoped to a **team** (available to all teammates' runs) or **personal** (only your own runs), just like normal Warp-managed secrets. 
 
 :::note
 [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud runs of Claude Code and Codex always use Warp-managed secrets.
 :::
 
-## Prerequisites
-
-* **A Warp team** - Harness auth secrets are typically scoped to a team so everyone on the team can launch authenticated runs. Personal secrets work for individual users. See [Teams](/knowledge-and-collaboration/teams/) for setting up a team.
-* **An Anthropic credential** - For Claude Code: an Anthropic API key from the [Anthropic Console](https://console.anthropic.com/), or Bedrock credentials (API key, or AWS access key) for Bedrock-routed inference.
-* **An OpenAI API key** - For Codex: an API key from the [OpenAI dashboard](https://platform.openai.com/api-keys).
-* **The Oz CLI installed** - Required for CLI-based secret creation. See [Oz CLI](/reference/cli/) for installation.
-
 ## Connecting Claude Code credentials
 
-Claude Code supports three Anthropic credential types: a direct API key, a Bedrock API key, or Bedrock AWS access keys. Pick the one that matches how your team consumes Anthropic models.
+Claude Code is Anthropic's coding agent. For more on Claude Code authentication, see [Anthropic's Claude Code auth docs](https://code.claude.com/docs/en/authentication).
 
-### Create the secret in the Oz web app
+### Create an Anthropic API key
 
-Use the Oz web app when you want a guided form that handles every Anthropic credential variant.
+1. Go to the [Anthropic Console](https://platform.claude.com/login?returnTo=/?) and sign in (or create an account).
+2. Navigate to **API keys** and create a new key.
+3. Make sure your account has API credits — Claude Code runs are billed against your Anthropic API balance.
 
-1. **Open managed secrets in the Oz web app.** Sign in to the Oz web app at [oz.warp.dev](https://oz.warp.dev) and navigate to managed secrets in the sidebar. You'll see all secrets your team has stored.
-2. **Create a new secret.** Click **New secret**, then choose the credential type that matches your provider — **Anthropic API key**, **Anthropic Bedrock API key**, or **Anthropic Bedrock access key**.
-3. **Fill in the value fields.** Enter a name (for example, `ANTHROPIC_API_KEY`), an optional description, and the credential value(s) the form asks for. For Bedrock variants, include the AWS region.
-4. **Choose the scope.** Select **Team** so the secret is available to all teammates' Claude Code runs. Use **Personal** if the credential is tied to an individual account.
-5. **Save the secret.** Click **Save**. Warp stores the value encrypted and shows the secret in the list with its name, scope, and last-updated timestamp.
+Oz also supports Bedrock-routed credentials (**Anthropic Bedrock API key** and **Anthropic Bedrock access key**) if your team consumes Anthropic models through AWS.
 
-**Expected outcome.** The new secret appears in the Oz web app's managed secrets list. It will be selectable on the new run and new schedule panes when **Claude Code** is the chosen harness.
+### Store the key in Oz
 
-### Create the secret with the Oz CLI
+#### Warp desktop app
 
-Use the Oz CLI when you're already in the terminal or want to script setup.
+In Cloud Mode, click the Key icon above the input box and add your Anthropic credential.
 
-The Oz CLI ships dedicated subcommands for each Anthropic credential type. Each subcommand reads the secret value securely from standard input or `--value-file`.
+#### Oz web app
+
+Start a new run, choose **Claude Code** as the harness, and add a new key in the harness auth secrets dropdown.
+
+#### Oz CLI
 
 ```bash
-# Direct Anthropic API key (team scope)
-oz secret create anthropic api-key --team ANTHROPIC_API_KEY
-
-# Bedrock API key (team scope) — prompts for the bearer token and AWS region
-oz secret create anthropic bedrock-api-key --team ANTHROPIC_BEDROCK_KEY
-
-# Bedrock access keys (team scope) — prompts for access key id, secret access key,
-# optional session token, and region
-oz secret create anthropic bedrock-access-key --team ANTHROPIC_BEDROCK_ACCESS
+oz secret create claude api-key <KEY_NAME>
 ```
 
 Add `--description "..."` to record rotation notes or owner info. Replace `--team` with `--personal` to make the secret available only to your own runs.
 
 **Expected outcome.** `oz secret list` shows the new secret with the matching Anthropic credential type. The value is never displayed.
 
-### Use the secret on a Claude Code run
-
-Once the secret is stored, point a Claude Code run at it:
-
-* **Warp app** - In Cloud Mode, choose **Claude Code** in the harness dropdown. Warp prompts for a Claude Code auth secret if your team has more than one available.
-* **Oz web app** - On the new run or new schedule pane, choose **Claude Code** in the **Harness** field. A **Claude Code auth secret** dropdown appears below it; choose the secret you just created.
-* **Oz CLI** - Pass `--claude-auth-secret NAME` to `oz agent run-cloud --harness claude`.
-* **API and SDK** - Set the Claude Code auth-secret field on the agent config to the secret's name. See the [API reference](/reference/api-and-sdk/) for the exact field name.
-
 ## Connecting Codex credentials
 
-Codex needs an OpenAI API key. Storing the key follows the same pattern as Claude Code, but uses a different secret type.
+Codex is OpenAI's CLI coding agent. For more on Codex authentication, see [OpenAI's Codex auth docs](https://developers.openai.com/codex/auth).
 
-### Create the secret in the Oz web app
-
-1. **Open managed secrets in the Oz web app** at [oz.warp.dev](https://oz.warp.dev).
-2. **Create a new secret.** Click **New secret**, then choose **OpenAI API key**.
-3. **Fill in the value fields.** Enter a name (for example, `OPENAI_API_KEY`), an optional description, and the API key value. If your team uses a regional or proxy endpoint, set the optional base URL field.
-4. **Choose the scope.** Select **Team** so all teammates' Codex runs can pick it up. Use **Personal** for individual-only use.
-5. **Save the secret.** Warp stores the value encrypted; the new secret appears in the list.
-
-**Expected outcome.** The new OpenAI API key secret appears in the managed secrets list. It will be selectable on the new run and new schedule panes when **Codex** is the chosen harness.
-
-:::note
-Codex secret creation from the Oz CLI is a fast-follow. For now, use the Oz web app to store OpenAI credentials.
+:::caution
+A ChatGPT subscription (Plus, Pro, Team) does not include API access. You need a separate OpenAI API key with API credits.
 :::
 
-### Use the secret on a Codex run
+### Create an OpenAI API key
 
-Once the secret is stored, point a Codex run at it:
+1. Go to the [OpenAI platform](https://platform.openai.com/home) and sign in (or create an account).
+2. Navigate to **API keys** and click **Create new secret key**.
+3. Make sure your account has API credits — Codex runs are billed against your OpenAI API balance, not a ChatGPT subscription.
 
-* **Warp app** - In Cloud Mode, choose **Codex** in the harness dropdown. Warp prompts for a Codex auth secret if your team has more than one available.
-* **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. A **Codex auth secret** dropdown appears below it; choose the secret you just created.
-* **Oz CLI** - Pass `--harness codex` to `oz agent run-cloud` along with the matching auth-secret flag for your OpenAI secret.
-* **API and SDK** - Set the Codex auth-secret field on the agent config to the secret's name. See the [API reference](/reference/api-and-sdk/) for the exact field name.
+### Store the key in Oz
+
+#### Warp desktop app
+
+In Cloud Mode, click the Key icon above the input box and add your OpenAI credential.
+
+#### Oz web app
+
+Start a new run, choose **Codex** as the harness, and add a new key in the harness auth secrets dropdown.
+
+#### Oz CLI
+
+```bash
+oz secret create codex api-key <KEY_NAME>
+```
+
+
+Add `--description "..."` to record rotation notes or owner info. Replace `--team` with `--personal` to make the secret available only to your own runs.
+
+**Expected outcome.** `oz secret list` shows the new secret with the matching OpenA credential type. The value is never displayed.
 
 ## Managing harness auth secrets
 
@@ -131,8 +117,7 @@ Your team admin has disabled the harness for your workspace. Contact your admin 
 
 ## Related pages
 
-* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
-* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
-* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — full secrets reference, including scoping, rotation, and deletion.
-* [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
-* [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) — local-only credentials for the Warp desktop app.
+* [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — overview of third-party harnesses in Oz.
+* [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) — run Claude Code locally in the Warp terminal.
+* [Codex CLI in Warp](/agent-platform/cli-agents/codex/) — run Codex locally in the Warp terminal.
+* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — the full Warp-managed secrets reference.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
@@ -2,17 +2,17 @@
 title: Connecting Claude and Codex credentials
 description: >-
   Store Anthropic or OpenAI credentials as Warp-managed secrets so Oz can
-  inject them into Claude Code and Codex cloud agent runs.
+  authenticate Claude Code and Codex cloud runs against the provider.
 sidebar:
   label: "Authentication"
 ---
 
 This page walks through the one-time setup that connects your team's Anthropic or OpenAI credentials to Oz so cloud runs of [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/) and [Codex](/agent-platform/cloud-agents/harnesses/codex/) can authenticate.
 
-Oz stores credentials as **Warp-managed secrets** (see [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) for the full secrets model). At run time, Oz looks up the secret you select for the run and injects it into the harness container. Secret values are write-once: you can rotate or delete them, but you can't read the value back after creation.
+Oz stores credentials as **Warp-managed secrets** (see [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) for the full secrets model) and uses the one you pick on a run to authenticate the harness with the provider. Secret values are write-once: you can rotate or delete them, but you can't read the value back after creation.
 
 :::note
-[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud runs of Claude Code and Codex always use Warp-managed secrets so credentials are accessible from the cloud container.
+[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud runs of Claude Code and Codex always use Warp-managed secrets.
 :::
 
 ## Prerequisites
@@ -133,6 +133,6 @@ Your team admin has disabled the harness for your workspace. Contact your admin 
 
 * [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
 * [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
-* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — full secrets reference, including scoping and rotation.
+* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — full secrets reference, including scoping, rotation, and deletion.
 * [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
 * [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) — local-only credentials for the Warp desktop app.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
@@ -10,82 +10,46 @@ sidebar:
 Claude Code is Anthropic's agentic coding tool. Running it with Oz puts Claude Code inside a Warp-managed environment and connects it to the rest of the Oz platform — triggers, environments, secrets, observability, and governance — while still behaving like the Claude Code your team already uses.
 
 :::note
-This page covers Claude Code as a **cloud** harness, dispatched and orchestrated by Oz. To run Claude Code locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) instead.
+This page covers Claude Code as a **cloud** harness, dispatched and orchestrated by Oz. To run Claude Code locally in your Warp terminal, see [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) instead.
 :::
 
 ## Key features
 
 * **Cloud orchestration** - Launch Claude Code from any Oz trigger: the Warp app, the Oz web app, the Oz CLI, the REST API, schedules, Slack mentions, Linear issues, or GitHub Actions.
 * **Claude model picker** - Choose the Claude model the harness uses, including the latest pinned Opus, Sonnet, and Haiku releases, the `best`/`opus`/`sonnet`/`haiku` aliases, and 1M-context variants.
-* **Shared platform context** - Reads the same [environments](/agent-platform/cloud-agents/environments/), [agent secrets](/agent-platform/cloud-agents/secrets/), [MCP servers](/agent-platform/cloud-agents/mcp/), and [Skills](/agent-platform/capabilities/skills/) used by every other harness.
 * **First-class subagent** - A Warp Agent parent can dispatch Claude Code subagents to handle code-review-heavy or judgment-heavy steps within a larger orchestration.
 
-## How it works
-
-When a trigger fires for a Claude Code run, Oz hands the prompt and your stored Anthropic credentials to Claude Code inside the run's [environment](/agent-platform/cloud-agents/environments/). Claude Code drives the task end-to-end — plans, reads code, edits files, runs commands, and (by Oz convention) opens a draft PR with the result.
-
-Oz captures the transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/), so the run is reviewable after the fact and shareable with teammates.
-
-### Available models
+## Available models
 
 The Claude Code harness exposes Anthropic's coding-tuned model lineup. Common picks:
 
 * `best` - Resolves to the current top-of-line Claude model.
 * `opus`, `sonnet`, `haiku` - Aliases that resolve to the current default for that family.
-* `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` - Latest pinned full model names.
 
 For the full list — including 1M-context variants for very large codebases and planning-tuned models — open the model picker in the Warp app's Cloud Mode or the **Model** field on the Oz web app's new-run pane.
 
-### Credentials and billing
+## Credentials and billing
 
-Claude Code calls Anthropic directly using credentials your team provides. Oz supports three Anthropic credential types, stored as Warp-managed secrets:
+Claude Code calls Anthropic directly using credentials your team provides. Oz supports three Anthropic credential types, stored as [Warp-managed secrets](/agent-platform/cloud-agents/secrets/):
 
 * **Anthropic API key** - For direct Anthropic API access.
 * **Anthropic Bedrock API key** - For Bedrock-routed inference using an API key.
 * **Anthropic Bedrock access key** - For Bedrock-routed inference using AWS access credentials.
 
-Anthropic bills your account directly for the inference your runs make. Warp credits cover the rest of the platform — environment compute, triggers, observability — but not the third-party inference calls.
+Anthropic bills your account directly for inference. Warp credits cover the rest of the platform — environment compute, triggers, observability.
 
-For setup steps, see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
-
-:::note
-[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud Claude Code runs always use credentials stored as Warp-managed secrets.
-:::
-
-## Choosing Claude Code
-
-Pick Claude Code as the harness when:
-
-* The task is **code-review heavy** — reading a large diff, leaving inline comments, suggesting refactors.
-* The task is **investigation heavy** — finding a root cause, tracing a bug, reasoning about unfamiliar code paths.
-* The task is **large feature planning** — breaking a vague product ask into a buildable plan with tradeoffs called out.
-* The task involves **frontend or UI work** — component design, accessibility checks, visual polish where Claude tends to produce clean code.
-
-For tasks that need cross-harness orchestration, model auto-routing, or multi-repo work as a parent run, use the [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) instead — Warp Agent can still dispatch Claude Code subagents for individual steps.
+For setup steps, see [Connecting Claude Code credentials](/agent-platform/cloud-agents/harnesses/authentication/#connecting-claude-code-credentials).
 
 ## Starting a Claude Code run
 
-Before launching, make sure your team has stored an Anthropic credential as a Warp-managed secret. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
-
 * **Warp app** - In Cloud Mode, click the harness dropdown above the input and choose **Claude Code**.
-* **Oz web app** - On the new run or new schedule pane, choose **Claude Code** in the **Harness** field. When you do, a **Claude Code auth secret** field appears below it; pick one of your team's stored Anthropic secrets.
-* **Oz CLI** - Pass `--harness claude` to `oz agent run-cloud`. Use `--claude-auth-secret NAME` to point at a specific managed secret.
-
-```bash
-oz agent run-cloud \
-  --harness claude \
-  --claude-auth-secret ANTHROPIC_API_KEY \
-  --environment ENV_ID \
-  --prompt "review PR #482 and leave inline comments"
-```
-
-* **API and SDK** - Set the agent config `harness` to `claude` and the Anthropic secret name on the matching auth-secret field. See the [API reference](/reference/api-and-sdk/) for the exact field name.
+* **Oz web app** - On the new run or new schedule pane, choose **Claude Code** in the **Harness** field. A **Claude Code auth secret** field appears below it; pick one of your stored Anthropic secrets.
+* **API and SDK** - Set the agent config `harness` to `claude` and the Anthropic secret name on the matching auth-secret field. See the [API reference](/reference/api-and-sdk/).
 
 ## Related pages
 
-* [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
-* [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — store Anthropic credentials as Warp-managed secrets.
+* [H](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Authentication](/agent-platform/cloud-agents/harnesses/authentication/) — store Anthropic credentials as Warp-managed secrets.
 * [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — Oz's default harness, the only one that can orchestrate Claude Code subagents.
 * [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
 * [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) — Claude Code in your local Warp terminal.
-* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — the full Warp-managed secrets reference.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
@@ -36,13 +36,13 @@ Claude Code calls Anthropic directly using credentials your team provides. Oz su
 * **Anthropic Bedrock API key** - For Bedrock-routed inference using an API key.
 * **Anthropic Bedrock access key** - For Bedrock-routed inference using AWS access credentials.
 
-Anthropic bills your account directly for inference. Warp credits cover the rest of the platform — environment compute, triggers, observability.
+Anthropic bills your account directly for inference. Warp credits cover the rest of the platform — environment compute, triggers, and observability.
 
 For setup steps, see [Connecting Claude Code credentials](/agent-platform/cloud-agents/harnesses/authentication/#connecting-claude-code-credentials).
 
 ## Starting a Claude Code run
 
-* **Warp app** - In Cloud Mode, click the harness dropdown above the input and choose **Claude Code**.
+* **Warp app** - In Cloud Mode, click the **Agent harness** dropdown above the input and choose **Claude Code**.
 * **Oz web app** - On the new run or new schedule pane, choose **Claude Code** in the **Harness** field. A **Claude Code auth secret** field appears below it; pick one of your stored Anthropic secrets.
 * **API and SDK** - Set the agent config `harness` to `claude` and the Anthropic secret name on the matching auth-secret field. See the [API reference](/reference/api-and-sdk/).
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
@@ -1,0 +1,91 @@
+---
+title: Claude Code harness
+description: >-
+  Run Claude Code as a first-class Oz cloud harness. Strong at code review,
+  deep bug investigation, large feature planning, and frontend or UI work.
+sidebar:
+  label: "Claude Code"
+---
+
+Claude Code is Anthropic's agentic coding tool. As an Oz cloud harness, Claude Code runs inside an Oz-managed environment and inherits every Oz primitive — triggers, environments, secrets, observability, governance, and billing — while still behaving like the Claude Code your team already uses.
+
+:::note
+This page covers Claude Code as a **cloud** harness, dispatched and orchestrated by Oz. If you want to run Claude Code locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) instead.
+:::
+
+## Key features
+
+* **Cloud orchestration** - Launch Claude Code from any Oz trigger: the Warp app, the Oz web app, the Oz CLI, the REST API, schedules, Slack mentions, Linear issues, or GitHub Actions.
+* **Claude model picker** - Choose the Claude model the harness uses, including the latest pinned Opus, Sonnet, and Haiku releases, the `best`/`opus`/`sonnet`/`haiku` aliases, and 1M-context variants.
+* **Shared platform context** - Reads the same [environments](/agent-platform/cloud-agents/environments/), [agent secrets](/agent-platform/cloud-agents/secrets/), [MCP servers](/agent-platform/cloud-agents/mcp/), and [Skills](/agent-platform/capabilities/skills/) used by every other harness.
+* **One credit pool** - Claude Code runs bill against your Warp credits like any other cloud agent run. There's no separate Anthropic contract or seat count.
+* **First-class subagent** - A Warp Agent parent can dispatch Claude Code subagents to handle code-review-heavy or judgment-heavy steps within a larger orchestration.
+
+## How it works
+
+When a trigger fires for a Claude Code run, Oz prepares the environment (Docker image, repos, setup commands), injects the run's Anthropic credentials, and launches the `claude` CLI inside the container with the user prompt. From that point Claude Code runs the task end-to-end: it plans, reads code, edits files, runs commands, and (per Oz convention) opens a draft PR with the result.
+
+Oz captures Claude Code's transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/). The transcript shows every step Claude Code took, which makes the run reviewable after the fact and shareable with teammates.
+
+### Available models
+
+The Claude Code harness exposes Anthropic's coding-tuned model lineup. Common picks:
+
+* `opus`, `sonnet`, `haiku` - Aliases that resolve to the current default for that family.
+* `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` - Latest pinned full model names.
+* `opus[1m]`, `sonnet[1m]` - 1M-context variants for very large codebases.
+* `opusplan` - Opus tuned for `/plan`-style planning workflows.
+
+Older pinned models stay available for runs that need them. For the canonical list, open the model picker in the Warp app's Cloud Mode or the **Model** field on the Oz web app's new-run pane.
+
+### Credentials
+
+Claude Code needs your team's Anthropic credentials to make inference requests. Oz supports three credential types, stored as Warp-managed secrets:
+
+* **Anthropic API key** - For direct Anthropic API access.
+* **Anthropic Bedrock API key** - For Bedrock-routed inference using an API key.
+* **Anthropic Bedrock access key** - For Bedrock-routed inference using AWS access credentials.
+
+For setup steps, see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
+
+:::note
+[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app is not used for cloud Claude Code runs. Cloud runs always use credentials stored as Warp-managed secrets so they're available to the cloud container.
+:::
+
+## Choosing Claude Code
+
+Pick Claude Code as the harness when:
+
+* The task is **code review heavy** — reading a large diff, leaving inline comments, suggesting refactors.
+* The task is **investigation heavy** — finding a root cause, tracing a bug, reasoning about unfamiliar code paths.
+* The task is **large feature planning** — breaking a vague product ask into a buildable plan with tradeoffs called out.
+* The task involves **frontend or UI work** — component design, accessibility checks, visual polish where Claude tends to produce clean code.
+
+For tasks that need cross-harness orchestration, model auto-routing, or multi-repo work as a parent run, use the [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) instead — Warp Agent can still dispatch Claude Code subagents for individual steps.
+
+## Starting a Claude Code run
+
+Before launching, make sure your team has stored Anthropic credentials as Warp-managed secrets. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
+
+* **Warp app** - In Cloud Mode, click the harness dropdown above the input and choose **Claude Code**.
+* **Oz web app** - On the new run or new schedule pane, choose **Claude Code** in the **Harness** field. When you do, a **Claude Code auth secret** field appears below it; pick one of your team's stored Anthropic secrets.
+* **Oz CLI** - Pass `--harness claude` to `oz agent run-cloud`. Use `--claude-auth-secret <NAME>` to point at a specific managed secret.
+
+```bash
+oz agent run-cloud \
+  --harness claude \
+  --claude-auth-secret ANTHROPIC_API_KEY \
+  --environment <ENV_ID> \
+  --prompt "review PR #482 and leave inline comments"
+```
+
+* **API / SDK** - Set the agent config `harness` to `claude` and the auth-secret name in `harness_auth_secrets.claude_auth_secret_name`.
+
+## Related pages
+
+* [Harnesses overview](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — store Anthropic credentials as Warp-managed secrets.
+* [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Claude Code subagents.
+* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
+* [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) — Claude Code in your local Warp terminal.
+* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — how Warp-managed secrets are scoped and injected at runtime.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
@@ -22,9 +22,9 @@ This page covers Claude Code as a **cloud** harness, dispatched and orchestrated
 
 ## How it works
 
-When a trigger fires for a Claude Code run, Oz prepares the environment (Docker image, repos, setup commands), injects the run's Anthropic credentials, and launches the `claude` CLI inside the container with the user prompt. From that point Claude Code runs the task end-to-end: it plans, reads code, edits files, runs commands, and (by Oz convention) opens a draft PR with the result.
+When a trigger fires for a Claude Code run, Oz hands the prompt and your stored Anthropic credentials to Claude Code inside the run's [environment](/agent-platform/cloud-agents/environments/). Claude Code drives the task end-to-end — plans, reads code, edits files, runs commands, and (by Oz convention) opens a draft PR with the result.
 
-Oz captures the Claude Code transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/). The transcript shows every step Claude Code took, which makes the run reviewable after the fact and shareable with teammates.
+Oz captures the transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/), so the run is reviewable after the fact and shareable with teammates.
 
 ### Available models
 
@@ -32,10 +32,8 @@ The Claude Code harness exposes Anthropic's coding-tuned model lineup. Common pi
 
 * `opus`, `sonnet`, `haiku` - Aliases that resolve to the current default for that family.
 * `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` - Latest pinned full model names.
-* `opus[1m]`, `sonnet[1m]` - 1M-context variants for very large codebases.
-* `opusplan` - Opus tuned for `/plan`-style planning workflows.
 
-Older pinned models stay available for runs that need them. For the canonical list, open the model picker in the Warp app's Cloud Mode or the **Model** field on the Oz web app's new-run pane.
+For the full list — including 1M-context variants for very large codebases and planning-tuned models — open the model picker in the Warp app's Cloud Mode or the **Model** field on the Oz web app's new-run pane.
 
 ### Credentials and billing
 
@@ -50,7 +48,7 @@ Anthropic bills your account directly for the inference your runs make. Warp cre
 For setup steps, see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
 
 :::note
-[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app is not used for cloud Claude Code runs. Cloud runs always use credentials stored as Warp-managed secrets so they're available to the cloud container.
+[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud Claude Code runs always use credentials stored as Warp-managed secrets.
 :::
 
 ## Choosing Claude Code
@@ -89,4 +87,4 @@ oz agent run-cloud \
 * [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Claude Code subagents.
 * [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
 * [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) — Claude Code in your local Warp terminal.
-* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — how Warp-managed secrets are scoped and injected at runtime.
+* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — the full Warp-managed secrets reference.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
@@ -1,16 +1,16 @@
 ---
-title: Claude Code harness
+title: Claude Code with Oz
 description: >-
-  Run Claude Code as a first-class Oz cloud harness. Strong at code review,
-  deep bug investigation, large feature planning, and frontend or UI work.
+  Run Claude Code on Oz. Strong at code review, deep bug investigation, large
+  feature planning, and frontend or UI work.
 sidebar:
   label: "Claude Code"
 ---
 
-Claude Code is Anthropic's agentic coding tool. As an Oz cloud harness, Claude Code runs inside an Oz-managed environment and inherits every Oz primitive — triggers, environments, secrets, observability, governance, and billing — while still behaving like the Claude Code your team already uses.
+Claude Code is Anthropic's agentic coding tool. Running it on Oz puts Claude Code inside a Warp-managed environment and connects it to the rest of the Oz platform — triggers, environments, secrets, observability, and governance — while still behaving like the Claude Code your team already uses.
 
 :::note
-This page covers Claude Code as a **cloud** harness, dispatched and orchestrated by Oz. If you want to run Claude Code locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) instead.
+This page covers Claude Code as a **cloud** harness, dispatched and orchestrated by Oz. To run Claude Code locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) instead.
 :::
 
 ## Key features
@@ -18,14 +18,13 @@ This page covers Claude Code as a **cloud** harness, dispatched and orchestrated
 * **Cloud orchestration** - Launch Claude Code from any Oz trigger: the Warp app, the Oz web app, the Oz CLI, the REST API, schedules, Slack mentions, Linear issues, or GitHub Actions.
 * **Claude model picker** - Choose the Claude model the harness uses, including the latest pinned Opus, Sonnet, and Haiku releases, the `best`/`opus`/`sonnet`/`haiku` aliases, and 1M-context variants.
 * **Shared platform context** - Reads the same [environments](/agent-platform/cloud-agents/environments/), [agent secrets](/agent-platform/cloud-agents/secrets/), [MCP servers](/agent-platform/cloud-agents/mcp/), and [Skills](/agent-platform/capabilities/skills/) used by every other harness.
-* **One credit pool** - Claude Code runs bill against your Warp credits like any other cloud agent run. There's no separate Anthropic contract or seat count.
 * **First-class subagent** - A Warp Agent parent can dispatch Claude Code subagents to handle code-review-heavy or judgment-heavy steps within a larger orchestration.
 
 ## How it works
 
-When a trigger fires for a Claude Code run, Oz prepares the environment (Docker image, repos, setup commands), injects the run's Anthropic credentials, and launches the `claude` CLI inside the container with the user prompt. From that point Claude Code runs the task end-to-end: it plans, reads code, edits files, runs commands, and (per Oz convention) opens a draft PR with the result.
+When a trigger fires for a Claude Code run, Oz prepares the environment (Docker image, repos, setup commands), injects the run's Anthropic credentials, and launches the `claude` CLI inside the container with the user prompt. From that point Claude Code runs the task end-to-end: it plans, reads code, edits files, runs commands, and (by Oz convention) opens a draft PR with the result.
 
-Oz captures Claude Code's transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/). The transcript shows every step Claude Code took, which makes the run reviewable after the fact and shareable with teammates.
+Oz captures the Claude Code transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/). The transcript shows every step Claude Code took, which makes the run reviewable after the fact and shareable with teammates.
 
 ### Available models
 
@@ -38,13 +37,15 @@ The Claude Code harness exposes Anthropic's coding-tuned model lineup. Common pi
 
 Older pinned models stay available for runs that need them. For the canonical list, open the model picker in the Warp app's Cloud Mode or the **Model** field on the Oz web app's new-run pane.
 
-### Credentials
+### Credentials and billing
 
-Claude Code needs your team's Anthropic credentials to make inference requests. Oz supports three credential types, stored as Warp-managed secrets:
+Claude Code calls Anthropic directly using credentials your team provides. Oz supports three Anthropic credential types, stored as Warp-managed secrets:
 
 * **Anthropic API key** - For direct Anthropic API access.
 * **Anthropic Bedrock API key** - For Bedrock-routed inference using an API key.
 * **Anthropic Bedrock access key** - For Bedrock-routed inference using AWS access credentials.
+
+Anthropic bills your account directly for the inference your runs make. Warp credits cover the rest of the platform — environment compute, triggers, observability — but not the third-party inference calls.
 
 For setup steps, see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
 
@@ -56,7 +57,7 @@ For setup steps, see [Connecting Claude and Codex credentials](/agent-platform/c
 
 Pick Claude Code as the harness when:
 
-* The task is **code review heavy** — reading a large diff, leaving inline comments, suggesting refactors.
+* The task is **code-review heavy** — reading a large diff, leaving inline comments, suggesting refactors.
 * The task is **investigation heavy** — finding a root cause, tracing a bug, reasoning about unfamiliar code paths.
 * The task is **large feature planning** — breaking a vague product ask into a buildable plan with tradeoffs called out.
 * The task involves **frontend or UI work** — component design, accessibility checks, visual polish where Claude tends to produce clean code.
@@ -65,27 +66,27 @@ For tasks that need cross-harness orchestration, model auto-routing, or multi-re
 
 ## Starting a Claude Code run
 
-Before launching, make sure your team has stored Anthropic credentials as Warp-managed secrets. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
+Before launching, make sure your team has stored an Anthropic credential as a Warp-managed secret. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
 
 * **Warp app** - In Cloud Mode, click the harness dropdown above the input and choose **Claude Code**.
 * **Oz web app** - On the new run or new schedule pane, choose **Claude Code** in the **Harness** field. When you do, a **Claude Code auth secret** field appears below it; pick one of your team's stored Anthropic secrets.
-* **Oz CLI** - Pass `--harness claude` to `oz agent run-cloud`. Use `--claude-auth-secret <NAME>` to point at a specific managed secret.
+* **Oz CLI** - Pass `--harness claude` to `oz agent run-cloud`. Use `--claude-auth-secret NAME` to point at a specific managed secret.
 
 ```bash
 oz agent run-cloud \
   --harness claude \
   --claude-auth-secret ANTHROPIC_API_KEY \
-  --environment <ENV_ID> \
+  --environment ENV_ID \
   --prompt "review PR #482 and leave inline comments"
 ```
 
-* **API / SDK** - Set the agent config `harness` to `claude` and the auth-secret name in `harness_auth_secrets.claude_auth_secret_name`.
+* **API and SDK** - Set the agent config `harness` to `claude` and the Anthropic secret name on the matching auth-secret field. See the [API reference](/reference/api-and-sdk/) for the exact field name.
 
 ## Related pages
 
-* [Harnesses overview](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
 * [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — store Anthropic credentials as Warp-managed secrets.
-* [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Claude Code subagents.
-* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
+* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Claude Code subagents.
+* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
 * [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) — Claude Code in your local Warp terminal.
 * [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — how Warp-managed secrets are scoped and injected at runtime.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
@@ -1,13 +1,13 @@
 ---
 title: Claude Code with Oz
 description: >-
-  Run Claude Code on Oz. Strong at code review, deep bug investigation, large
+  Run Claude Code with Oz. Strong at code review, deep bug investigation, large
   feature planning, and frontend or UI work.
 sidebar:
   label: "Claude Code"
 ---
 
-Claude Code is Anthropic's agentic coding tool. Running it on Oz puts Claude Code inside a Warp-managed environment and connects it to the rest of the Oz platform — triggers, environments, secrets, observability, and governance — while still behaving like the Claude Code your team already uses.
+Claude Code is Anthropic's agentic coding tool. Running it with Oz puts Claude Code inside a Warp-managed environment and connects it to the rest of the Oz platform — triggers, environments, secrets, observability, and governance — while still behaving like the Claude Code your team already uses.
 
 :::note
 This page covers Claude Code as a **cloud** harness, dispatched and orchestrated by Oz. To run Claude Code locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) instead.
@@ -30,6 +30,7 @@ Oz captures the transcript and exposes it through the [Oz dashboard](/agent-plat
 
 The Claude Code harness exposes Anthropic's coding-tuned model lineup. Common picks:
 
+* `best` - Resolves to the current top-of-line Claude model.
 * `opus`, `sonnet`, `haiku` - Aliases that resolve to the current default for that family.
 * `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` - Latest pinned full model names.
 
@@ -84,7 +85,7 @@ oz agent run-cloud \
 
 * [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
 * [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — store Anthropic credentials as Warp-managed secrets.
-* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Claude Code subagents.
+* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — Oz's default harness, the only one that can orchestrate Claude Code subagents.
 * [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
 * [Claude Code in Warp](/agent-platform/cli-agents/claude-code/) — Claude Code in your local Warp terminal.
 * [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — the full Warp-managed secrets reference.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
@@ -48,7 +48,7 @@ For setup steps, see [Connecting Claude Code credentials](/agent-platform/cloud-
 
 ## Related pages
 
-* [H](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
 * [Authentication](/agent-platform/cloud-agents/harnesses/authentication/) — store Anthropic credentials as Warp-managed secrets.
 * [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — Oz's default harness, the only one that can orchestrate Claude Code subagents.
 * [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
@@ -24,7 +24,7 @@ This page covers Codex as a **cloud** harness, dispatched and orchestrated by Oz
 The Codex harness exposes OpenAI's Codex-tuned and general coding models. Common picks:
 
 * `default` - Lets Codex pick its own recommended model based on your OpenAI account access.
-* `gpt-5.5`, `gpt-5.4` - Recent strong coding models from OpenAI, which you can configure the reasoning level for.
+* `gpt-5.5`, `gpt-5.4` - Recent strong coding models from OpenAI with a configurable reasoning level.
 * `gpt-5.4-mini` - A faster, lower-cost option for lighter coding tasks or subagents.
 
 For the full list — including older Codex-tuned and general models — open the model picker on the Oz web app's new-run pane. For details on each model, see [OpenAI's Codex model docs](https://developers.openai.com/codex/models).

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
@@ -1,48 +1,48 @@
 ---
-title: Codex harness
+title: Codex with Oz
 description: >-
-  Run Codex as a first-class Oz cloud harness. Strong at codebase migrations,
-  release coordination, batch test generation, and backend or DevOps automation.
+  Run Codex on Oz. Strong at codebase migrations, release coordination, batch
+  test generation, and backend or DevOps automation.
 sidebar:
   label: "Codex"
 ---
 
-Codex is OpenAI's coding agent. As an Oz cloud harness, Codex runs inside an Oz-managed environment and inherits every Oz primitive — triggers, environments, secrets, observability, governance, and billing — while still behaving like the Codex CLI your team already uses.
+Codex is OpenAI's coding agent. Running it on Oz puts Codex inside a Warp-managed environment and connects it to the rest of the Oz platform — triggers, environments, secrets, observability, and governance — while still behaving like the Codex CLI your team already uses.
 
 :::note
-This page covers Codex as a **cloud** harness, dispatched and orchestrated by Oz. If you want to run Codex locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Codex CLI in Warp](/agent-platform/cli-agents/codex/) instead.
+This page covers Codex as a **cloud** harness, dispatched and orchestrated by Oz. To run Codex locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Codex CLI in Warp](/agent-platform/cli-agents/codex/) instead.
 :::
 
 ## Key features
 
-* **Cloud orchestration** - Launch Codex from any Oz trigger: the Warp app, the Oz web app, the Oz CLI, the REST API, schedules, Slack mentions, Linear issues, or GitHub Actions.
+* **Cloud orchestration** - Launch Codex from the Oz web app and from any non-CLI trigger today: schedules, Slack mentions, Linear issues, GitHub Actions, and the REST API. (Launching Codex from the Warp app's harness dropdown and from `oz agent run-cloud` are fast-follows.)
 * **Codex model picker** - Choose the OpenAI model Codex uses, including the GPT-5.5 family, Codex-tuned variants, and a `default` option that lets Codex pick its own recommended model.
 * **Shared platform context** - Reads the same [environments](/agent-platform/cloud-agents/environments/), [agent secrets](/agent-platform/cloud-agents/secrets/), [MCP servers](/agent-platform/cloud-agents/mcp/), and [Skills](/agent-platform/capabilities/skills/) used by every other harness.
-* **One credit pool** - Codex runs bill against your Warp credits like any other cloud agent run. There's no separate OpenAI contract or seat count.
 * **First-class subagent** - A Warp Agent parent can dispatch Codex subagents to handle high-volume or well-defined coding steps inside a larger orchestration.
 
 ## How it works
 
-When a trigger fires for a Codex run, Oz prepares the environment (Docker image, repos, setup commands), injects the run's OpenAI credentials, and launches the `codex` CLI inside the container with the user prompt. From that point Codex runs the task end-to-end: it plans, edits files, runs commands, and (per Oz convention) opens a draft PR with the result.
+When a trigger fires for a Codex run, Oz prepares the environment (Docker image, repos, setup commands), injects the run's OpenAI credentials, and launches the `codex` CLI inside the container with the user prompt. From that point Codex runs the task end-to-end: it plans, edits files, runs commands, and (by Oz convention) opens a draft PR with the result.
 
-Oz captures Codex's transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/). The transcript shows every step Codex took, which makes the run reviewable after the fact and shareable with teammates.
+Oz captures the Codex transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/). The transcript shows every step Codex took, which makes the run reviewable after the fact and shareable with teammates.
 
 ### Available models
 
 The Codex harness exposes OpenAI's Codex-tuned and general coding models. Common picks:
 
-* `default` - Lets Codex pick its own recommended model (GPT-5.5 for ChatGPT-authenticated users, GPT-5.4 otherwise).
-* `gpt-5.5` - The current recommended primary, ChatGPT auth only.
-* `gpt-5.4`, `gpt-5.4-mini` - Fallback for API-key auth or lower-cost runs.
+* `default` - Lets Codex pick its own recommended model based on the API key's account access. Selecting `default` means Oz doesn't pin a model and Codex applies the model its own runtime would.
+* `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` - GPT-5 family options. `gpt-5.5` is the current recommended primary; `gpt-5.4-mini` is faster and lower-cost.
 * `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` - Older Codex-tuned and general models still available as alternatives.
 
-For the canonical list, open the model picker in the Warp app's Cloud Mode or the **Model** field on the Oz web app's new-run pane. For details on each model, see [OpenAI's Codex model docs](https://developers.openai.com/codex/models).
+For the canonical list, open the model picker on the Oz web app's new-run pane. For details on each model, see [OpenAI's Codex model docs](https://developers.openai.com/codex/models). Access to individual models depends on what your OpenAI account supports — pick `default` if you're unsure which models your key is entitled to.
 
-### Credentials
+### Credentials and billing
 
-Codex needs your team's OpenAI credentials to make inference requests. Oz supports one credential type today, stored as a Warp-managed secret:
+Codex calls OpenAI directly using credentials your team provides. Oz supports one credential type today, stored as a Warp-managed secret:
 
-* **OpenAI API key** - Used for OpenAI-authenticated Codex runs.
+* **OpenAI API key** - The Codex harness authenticates to OpenAI using this key for every run.
+
+OpenAI bills your account directly for the inference your runs make. Warp credits cover the rest of the platform — environment compute, triggers, observability — but not the third-party inference calls.
 
 For setup steps, see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
 
@@ -66,18 +66,18 @@ For tasks that need cross-harness orchestration, model auto-routing, or multi-re
 
 Before launching, make sure your team has stored an OpenAI API key as a Warp-managed secret. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
 
-* **Warp app** - In Cloud Mode, click the harness dropdown above the input and choose **Codex**.
 * **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. When you do, a **Codex auth secret** field appears below it; pick the OpenAI secret your team has stored.
+* **API and SDK** - Set the agent config `harness` to `codex` and the OpenAI secret name on the matching auth-secret field. See the [API reference](/reference/api-and-sdk/) for the exact field name.
 
 :::caution
-Codex selection from the Oz CLI is a fast-follow. To launch a Codex cloud run today, use the Warp app or the Oz web app. Existing schedules and Slack/Linear/GitHub Actions triggers can dispatch Codex runs without CLI changes.
+The Warp app's harness dropdown and the `oz agent run-cloud --harness codex` flag are fast-follows. To launch a Codex cloud run today, use the Oz web app or the API. Existing schedules and Slack, Linear, or GitHub Actions triggers can dispatch Codex runs as long as the agent they reference is configured for the Codex harness.
 :::
 
 ## Related pages
 
-* [Harnesses overview](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
 * [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — store OpenAI credentials as Warp-managed secrets.
-* [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Codex subagents.
-* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
+* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Codex subagents.
+* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
 * [Codex CLI in Warp](/agent-platform/cli-agents/codex/) — Codex in your local Warp terminal.
 * [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — how Warp-managed secrets are scoped and injected at runtime.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
@@ -10,74 +10,45 @@ sidebar:
 Codex is OpenAI's coding agent. Running it with Oz puts Codex inside a Warp-managed environment and connects it to the rest of the Oz platform — triggers, environments, secrets, observability, and governance — while still behaving like the Codex CLI your team already uses.
 
 :::note
-This page covers Codex as a **cloud** harness, dispatched and orchestrated by Oz. To run Codex locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Codex CLI in Warp](/agent-platform/cli-agents/codex/) instead.
+This page covers Codex as a **cloud** harness, dispatched and orchestrated by Oz. To run Codex locally in your Warp terminal, see [Codex CLI in Warp](/agent-platform/cli-agents/codex/) instead.
 :::
 
 ## Key features
 
 * **Cloud orchestration** - Launch Codex from any Oz trigger: the Warp app, the Oz web app, the Oz CLI, the REST API, schedules, Slack mentions, Linear issues, or GitHub Actions.
 * **Codex model picker** - Choose the OpenAI model Codex uses, including the GPT-5 lineup, Codex-tuned variants, and a `default` option that lets Codex pick its own recommended model.
-* **Shared platform context** - Reads the same [environments](/agent-platform/cloud-agents/environments/), [agent secrets](/agent-platform/cloud-agents/secrets/), [MCP servers](/agent-platform/cloud-agents/mcp/), and [Skills](/agent-platform/capabilities/skills/) used by every other harness.
 * **First-class subagent** - A Warp Agent parent can dispatch Codex subagents to handle high-volume or well-defined coding steps inside a larger orchestration.
 
-## How it works
-
-When a trigger fires for a Codex run, Oz hands the prompt and your stored OpenAI credentials to Codex inside the run's [environment](/agent-platform/cloud-agents/environments/). Codex drives the task end-to-end — plans, edits files, runs commands, and (by Oz convention) opens a draft PR with the result.
-
-Oz captures the transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/), so the run is reviewable after the fact and shareable with teammates.
-
-### Available models
+## Available models
 
 The Codex harness exposes OpenAI's Codex-tuned and general coding models. Common picks:
 
-* `default` - Lets Codex pick its own recommended model based on your OpenAI account access. Use this if you're unsure which models your key is entitled to.
-* `gpt-5.4` - The recommended primary for cloud Codex runs, which authenticate with an OpenAI API key.
+* `default` - Lets Codex pick its own recommended model based on your OpenAI account access.
+* `gpt-5.5`, `gpt-5.4` - Recent strong coding models from OpenAI, which you can configure the reasoning level for.
 * `gpt-5.4-mini` - A faster, lower-cost option for lighter coding tasks or subagents.
 
 For the full list — including older Codex-tuned and general models — open the model picker on the Oz web app's new-run pane. For details on each model, see [OpenAI's Codex model docs](https://developers.openai.com/codex/models).
 
-### Credentials and billing
+## Credentials and billing
 
-Codex calls OpenAI directly using credentials your team provides. Oz supports one credential type today, stored as a Warp-managed secret:
+Codex calls OpenAI directly using credentials your team provides. Oz supports one credential type today, stored as a [Warp-managed secret](/agent-platform/cloud-agents/secrets/):
 
 * **OpenAI API key** - The Codex harness authenticates to OpenAI using this key for every run.
 
-OpenAI bills your account directly for the inference your runs make. Warp credits cover the rest of the platform — environment compute, triggers, observability — but not the third-party inference calls.
+OpenAI bills your account directly for inference. Warp credits cover the rest of the platform — environment compute, triggers, observability.
 
-For setup steps, see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
-
-:::note
-[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud Codex runs always use credentials stored as Warp-managed secrets.
-:::
-
-## Choosing Codex
-
-Pick Codex as the harness when:
-
-* The task is a **codebase migration** — moving a large project to a new framework, language version, or library.
-* The task is **release coordination** — generating release notes, sweeping CHANGELOGs, or tagging breaking changes across services.
-* The task is **batch test generation** — adding unit tests across many files or backfilling coverage on a legacy module.
-* The task is **backend service work** — API changes, schema migrations, server-side refactors where consistency matters more than design judgment.
-* The task is **DevOps or CI/CD** — pipeline edits, infrastructure-as-code changes, Dockerfile updates, build-system maintenance.
-
-For tasks that need cross-harness orchestration, model auto-routing, or multi-repo work as a parent run, use the [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) instead — Warp Agent can still dispatch Codex subagents for individual steps.
+For setup steps, see [Connecting Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/#connecting-codex-credentials).
 
 ## Starting a Codex run
 
-Before launching, make sure your team has stored an OpenAI API key as a Warp-managed secret. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
-
 * **Warp app** - In Cloud Mode, click the harness dropdown above the input and choose **Codex**.
-* **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. When you do, a **Codex auth secret** field appears below it; pick the OpenAI secret your team has stored.
-* **Oz CLI** - Pass `--harness codex` to `oz agent run-cloud` and reference the OpenAI secret on the matching auth-secret field.
-* **API and SDK** - Set the agent config `harness` to `codex` and the OpenAI secret name on the matching auth-secret field. See the [API reference](/reference/api-and-sdk/) for the exact field name.
-
-Schedules and Slack, Linear, or GitHub Actions triggers can dispatch Codex runs as long as the agent they reference is configured for the Codex harness.
+* **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. A **Codex auth secret** field appears below it; pick the OpenAI secret your team has stored.
+* **API and SDK** - Set the agent config `harness` to `codex` and the OpenAI secret name on the matching auth-secret field. See the [API reference](/reference/api-and-sdk/).
 
 ## Related pages
 
 * [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
-* [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — store OpenAI credentials as Warp-managed secrets.
+* [Authentication](/agent-platform/cloud-agents/harnesses/authentication/) — store OpenAI credentials as Warp-managed secrets.
 * [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — Oz's default harness, the only one that can orchestrate Codex subagents.
 * [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
 * [Codex CLI in Warp](/agent-platform/cli-agents/codex/) — Codex in your local Warp terminal.
-* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — the full Warp-managed secrets reference.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
@@ -1,0 +1,83 @@
+---
+title: Codex harness
+description: >-
+  Run Codex as a first-class Oz cloud harness. Strong at codebase migrations,
+  release coordination, batch test generation, and backend or DevOps automation.
+sidebar:
+  label: "Codex"
+---
+
+Codex is OpenAI's coding agent. As an Oz cloud harness, Codex runs inside an Oz-managed environment and inherits every Oz primitive — triggers, environments, secrets, observability, governance, and billing — while still behaving like the Codex CLI your team already uses.
+
+:::note
+This page covers Codex as a **cloud** harness, dispatched and orchestrated by Oz. If you want to run Codex locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Codex CLI in Warp](/agent-platform/cli-agents/codex/) instead.
+:::
+
+## Key features
+
+* **Cloud orchestration** - Launch Codex from any Oz trigger: the Warp app, the Oz web app, the Oz CLI, the REST API, schedules, Slack mentions, Linear issues, or GitHub Actions.
+* **Codex model picker** - Choose the OpenAI model Codex uses, including the GPT-5.5 family, Codex-tuned variants, and a `default` option that lets Codex pick its own recommended model.
+* **Shared platform context** - Reads the same [environments](/agent-platform/cloud-agents/environments/), [agent secrets](/agent-platform/cloud-agents/secrets/), [MCP servers](/agent-platform/cloud-agents/mcp/), and [Skills](/agent-platform/capabilities/skills/) used by every other harness.
+* **One credit pool** - Codex runs bill against your Warp credits like any other cloud agent run. There's no separate OpenAI contract or seat count.
+* **First-class subagent** - A Warp Agent parent can dispatch Codex subagents to handle high-volume or well-defined coding steps inside a larger orchestration.
+
+## How it works
+
+When a trigger fires for a Codex run, Oz prepares the environment (Docker image, repos, setup commands), injects the run's OpenAI credentials, and launches the `codex` CLI inside the container with the user prompt. From that point Codex runs the task end-to-end: it plans, edits files, runs commands, and (per Oz convention) opens a draft PR with the result.
+
+Oz captures Codex's transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/). The transcript shows every step Codex took, which makes the run reviewable after the fact and shareable with teammates.
+
+### Available models
+
+The Codex harness exposes OpenAI's Codex-tuned and general coding models. Common picks:
+
+* `default` - Lets Codex pick its own recommended model (GPT-5.5 for ChatGPT-authenticated users, GPT-5.4 otherwise).
+* `gpt-5.5` - The current recommended primary, ChatGPT auth only.
+* `gpt-5.4`, `gpt-5.4-mini` - Fallback for API-key auth or lower-cost runs.
+* `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` - Older Codex-tuned and general models still available as alternatives.
+
+For the canonical list, open the model picker in the Warp app's Cloud Mode or the **Model** field on the Oz web app's new-run pane. For details on each model, see [OpenAI's Codex model docs](https://developers.openai.com/codex/models).
+
+### Credentials
+
+Codex needs your team's OpenAI credentials to make inference requests. Oz supports one credential type today, stored as a Warp-managed secret:
+
+* **OpenAI API key** - Used for OpenAI-authenticated Codex runs.
+
+For setup steps, see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
+
+:::note
+[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app is not used for cloud Codex runs. Cloud runs always use credentials stored as Warp-managed secrets so they're available to the cloud container.
+:::
+
+## Choosing Codex
+
+Pick Codex as the harness when:
+
+* The task is a **codebase migration** — moving a large project to a new framework, language version, or library.
+* The task is **release coordination** — generating release notes, sweeping CHANGELOGs, or tagging breaking changes across services.
+* The task is **batch test generation** — adding unit tests across many files or backfilling coverage on a legacy module.
+* The task is **backend service work** — API changes, schema migrations, server-side refactors where consistency matters more than design judgment.
+* The task is **DevOps or CI/CD** — pipeline edits, infrastructure-as-code changes, Dockerfile updates, build-system maintenance.
+
+For tasks that need cross-harness orchestration, model auto-routing, or multi-repo work as a parent run, use the [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) instead — Warp Agent can still dispatch Codex subagents for individual steps.
+
+## Starting a Codex run
+
+Before launching, make sure your team has stored an OpenAI API key as a Warp-managed secret. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
+
+* **Warp app** - In Cloud Mode, click the harness dropdown above the input and choose **Codex**.
+* **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. When you do, a **Codex auth secret** field appears below it; pick the OpenAI secret your team has stored.
+
+:::caution
+Codex selection from the Oz CLI is a fast-follow. To launch a Codex cloud run today, use the Warp app or the Oz web app. Existing schedules and Slack/Linear/GitHub Actions triggers can dispatch Codex runs without CLI changes.
+:::
+
+## Related pages
+
+* [Harnesses overview](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — store OpenAI credentials as Warp-managed secrets.
+* [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Codex subagents.
+* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
+* [Codex CLI in Warp](/agent-platform/cli-agents/codex/) — Codex in your local Warp terminal.
+* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — how Warp-managed secrets are scoped and injected at runtime.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
@@ -1,13 +1,13 @@
 ---
 title: Codex with Oz
 description: >-
-  Run Codex on Oz. Strong at codebase migrations, release coordination, batch
+  Run Codex with Oz. Strong at codebase migrations, release coordination, batch
   test generation, and backend or DevOps automation.
 sidebar:
   label: "Codex"
 ---
 
-Codex is OpenAI's coding agent. Running it on Oz puts Codex inside a Warp-managed environment and connects it to the rest of the Oz platform — triggers, environments, secrets, observability, and governance — while still behaving like the Codex CLI your team already uses.
+Codex is OpenAI's coding agent. Running it with Oz puts Codex inside a Warp-managed environment and connects it to the rest of the Oz platform — triggers, environments, secrets, observability, and governance — while still behaving like the Codex CLI your team already uses.
 
 :::note
 This page covers Codex as a **cloud** harness, dispatched and orchestrated by Oz. To run Codex locally in your Warp terminal — with the rich input editor, code review, agent notifications, and other in-terminal features — see [Codex CLI in Warp](/agent-platform/cli-agents/codex/) instead.
@@ -15,8 +15,8 @@ This page covers Codex as a **cloud** harness, dispatched and orchestrated by Oz
 
 ## Key features
 
-* **Cloud orchestration** - Launch Codex from the Oz web app and from any non-CLI trigger today: schedules, Slack mentions, Linear issues, GitHub Actions, and the REST API. (Launching Codex from the Warp app's harness dropdown and from `oz agent run-cloud` are fast-follows.)
-* **Codex model picker** - Choose the OpenAI model Codex uses, including the GPT-5.5 family, Codex-tuned variants, and a `default` option that lets Codex pick its own recommended model.
+* **Cloud orchestration** - Launch Codex from any Oz trigger: the Warp app, the Oz web app, the Oz CLI, the REST API, schedules, Slack mentions, Linear issues, or GitHub Actions.
+* **Codex model picker** - Choose the OpenAI model Codex uses, including the GPT-5 lineup, Codex-tuned variants, and a `default` option that lets Codex pick its own recommended model.
 * **Shared platform context** - Reads the same [environments](/agent-platform/cloud-agents/environments/), [agent secrets](/agent-platform/cloud-agents/secrets/), [MCP servers](/agent-platform/cloud-agents/mcp/), and [Skills](/agent-platform/capabilities/skills/) used by every other harness.
 * **First-class subagent** - A Warp Agent parent can dispatch Codex subagents to handle high-volume or well-defined coding steps inside a larger orchestration.
 
@@ -31,7 +31,8 @@ Oz captures the transcript and exposes it through the [Oz dashboard](/agent-plat
 The Codex harness exposes OpenAI's Codex-tuned and general coding models. Common picks:
 
 * `default` - Lets Codex pick its own recommended model based on your OpenAI account access. Use this if you're unsure which models your key is entitled to.
-* `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` - GPT-5 family options. `gpt-5.5` is the current recommended primary; `gpt-5.4-mini` is faster and lower-cost.
+* `gpt-5.4` - The recommended primary for cloud Codex runs, which authenticate with an OpenAI API key.
+* `gpt-5.4-mini` - A faster, lower-cost option for lighter coding tasks or subagents.
 
 For the full list — including older Codex-tuned and general models — open the model picker on the Oz web app's new-run pane. For details on each model, see [OpenAI's Codex model docs](https://developers.openai.com/codex/models).
 
@@ -65,18 +66,18 @@ For tasks that need cross-harness orchestration, model auto-routing, or multi-re
 
 Before launching, make sure your team has stored an OpenAI API key as a Warp-managed secret. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
 
+* **Warp app** - In Cloud Mode, click the harness dropdown above the input and choose **Codex**.
 * **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. When you do, a **Codex auth secret** field appears below it; pick the OpenAI secret your team has stored.
+* **Oz CLI** - Pass `--harness codex` to `oz agent run-cloud` and reference the OpenAI secret on the matching auth-secret field.
 * **API and SDK** - Set the agent config `harness` to `codex` and the OpenAI secret name on the matching auth-secret field. See the [API reference](/reference/api-and-sdk/) for the exact field name.
 
-:::caution
-The Warp app's harness dropdown and the `oz agent run-cloud --harness codex` flag are fast-follows. To launch a Codex cloud run today, use the Oz web app or the API. Existing schedules and Slack, Linear, or GitHub Actions triggers can dispatch Codex runs as long as the agent they reference is configured for the Codex harness.
-:::
+Schedules and Slack, Linear, or GitHub Actions triggers can dispatch Codex runs as long as the agent they reference is configured for the Codex harness.
 
 ## Related pages
 
 * [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
 * [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — store OpenAI credentials as Warp-managed secrets.
-* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Codex subagents.
+* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — Oz's default harness, the only one that can orchestrate Codex subagents.
 * [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
 * [Codex CLI in Warp](/agent-platform/cli-agents/codex/) — Codex in your local Warp terminal.
 * [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — the full Warp-managed secrets reference.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
@@ -22,19 +22,18 @@ This page covers Codex as a **cloud** harness, dispatched and orchestrated by Oz
 
 ## How it works
 
-When a trigger fires for a Codex run, Oz prepares the environment (Docker image, repos, setup commands), injects the run's OpenAI credentials, and launches the `codex` CLI inside the container with the user prompt. From that point Codex runs the task end-to-end: it plans, edits files, runs commands, and (by Oz convention) opens a draft PR with the result.
+When a trigger fires for a Codex run, Oz hands the prompt and your stored OpenAI credentials to Codex inside the run's [environment](/agent-platform/cloud-agents/environments/). Codex drives the task end-to-end — plans, edits files, runs commands, and (by Oz convention) opens a draft PR with the result.
 
-Oz captures the Codex transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/). The transcript shows every step Codex took, which makes the run reviewable after the fact and shareable with teammates.
+Oz captures the transcript and exposes it through the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app's conversations panel, and the [Oz API](/reference/api-and-sdk/), so the run is reviewable after the fact and shareable with teammates.
 
 ### Available models
 
 The Codex harness exposes OpenAI's Codex-tuned and general coding models. Common picks:
 
-* `default` - Lets Codex pick its own recommended model based on the API key's account access. Selecting `default` means Oz doesn't pin a model and Codex applies the model its own runtime would.
+* `default` - Lets Codex pick its own recommended model based on your OpenAI account access. Use this if you're unsure which models your key is entitled to.
 * `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` - GPT-5 family options. `gpt-5.5` is the current recommended primary; `gpt-5.4-mini` is faster and lower-cost.
-* `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` - Older Codex-tuned and general models still available as alternatives.
 
-For the canonical list, open the model picker on the Oz web app's new-run pane. For details on each model, see [OpenAI's Codex model docs](https://developers.openai.com/codex/models). Access to individual models depends on what your OpenAI account supports — pick `default` if you're unsure which models your key is entitled to.
+For the full list — including older Codex-tuned and general models — open the model picker on the Oz web app's new-run pane. For details on each model, see [OpenAI's Codex model docs](https://developers.openai.com/codex/models).
 
 ### Credentials and billing
 
@@ -47,7 +46,7 @@ OpenAI bills your account directly for the inference your runs make. Warp credit
 For setup steps, see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/).
 
 :::note
-[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app is not used for cloud Codex runs. Cloud runs always use credentials stored as Warp-managed secrets so they're available to the cloud container.
+[Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud Codex runs always use credentials stored as Warp-managed secrets.
 :::
 
 ## Choosing Codex
@@ -80,4 +79,4 @@ The Warp app's harness dropdown and the `oz agent run-cloud --harness codex` fla
 * [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness, the only one that can orchestrate Codex subagents.
 * [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
 * [Codex CLI in Warp](/agent-platform/cli-agents/codex/) — Codex in your local Warp terminal.
-* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — how Warp-managed secrets are scoped and injected at runtime.
+* [Cloud agent secrets](/agent-platform/cloud-agents/secrets/) — the full Warp-managed secrets reference.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
@@ -35,13 +35,13 @@ Codex calls OpenAI directly using credentials your team provides. Oz supports on
 
 * **OpenAI API key** - The Codex harness authenticates to OpenAI using this key for every run.
 
-OpenAI bills your account directly for inference. Warp credits cover the rest of the platform — environment compute, triggers, observability.
+OpenAI bills your account directly for inference. Warp credits cover the rest of the platform — environment compute, triggers, and observability.
 
 For setup steps, see [Connecting Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/#connecting-codex-credentials).
 
 ## Starting a Codex run
 
-* **Warp app** - In Cloud Mode, click the harness dropdown above the input and choose **Codex**.
+* **Warp app** - In Cloud Mode, click the **Agent harness** dropdown above the input and choose **Codex**.
 * **Oz web app** - On the new run or new schedule pane, choose **Codex** in the **Harness** field. A **Codex auth secret** field appears below it; pick the OpenAI secret your team has stored.
 * **API and SDK** - Set the agent config `harness` to `codex` and the OpenAI secret name on the matching auth-secret field. See the [API reference](/reference/api-and-sdk/).
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -1,24 +1,24 @@
 ---
-title: Harnesses
+title: Harnesses in Oz
 description: >-
-  Run Warp Agent, Claude Code, or Codex as first-class harnesses inside Oz with
-  one access-control, memory, and billing model across every harness.
+  Run Warp Agent, Claude Code, or Codex on Oz. Each harness inherits the same
+  triggers, environments, secrets, observability, and governance.
 sidebar:
   label: "Overview"
 ---
 
 A harness is the agent runtime that executes a cloud agent run. Oz lets you pick the harness that fits the task — [Warp Agent](/agent-platform/cloud-agents/harnesses/warp-agent/), [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/), or [Codex](/agent-platform/cloud-agents/harnesses/codex/) — without changing how you launch, observe, or govern the run.
 
-Every harness is a first-class citizen on the [Oz Platform](/agent-platform/cloud-agents/platform/). You can launch and steer any harness from the Warp terminal, the [Oz web app](/agent-platform/cloud-agents/oz-web-app/), the [Oz CLI](/reference/cli/), the [REST API or SDK](/reference/api-and-sdk/), and direct it to do work across multiple repos, integrations, and machines. The harness changes; the platform around it does not.
+Whichever harness you pick runs on the [Oz platform](/agent-platform/cloud-agents/platform/). You launch it the same way, with the same triggers, environments, secrets, and observability around it. The harness changes; the platform around it does not.
 
 ## Available harnesses
 
-* **Warp Agent** - Oz's default harness, built by Warp. Routes across leading models (Anthropic, OpenAI, Google, Fireworks), has full terminal and tool access, and is the only harness that can act as a parent in a cross-harness orchestration.
-* **Claude Code** - Anthropic's coding agent, running as an Oz cloud harness. Strong at code review, deep bug investigation, large feature planning, and frontend or UI work.
-* **Codex** - OpenAI's coding agent, running as an Oz cloud harness. Strong at codebase migrations, release coordination, batch test generation, and backend or DevOps automation.
+* **Warp Agent** - Oz's default harness, built by Warp. Routes across leading models (Anthropic, OpenAI, Google, Fireworks), has full terminal and tool access, and is the only harness that can act as a parent in a multi-harness orchestration.
+* **Claude Code** - Anthropic's coding agent, running on Oz. Strong at code review, deep bug investigation, large feature planning, and frontend or UI work.
+* **Codex** - OpenAI's coding agent, running on Oz. Strong at codebase migrations, release coordination, batch test generation, and backend or DevOps automation.
 
 :::note
-Gemini CLI and OpenCode are fast-follow harnesses. They are not yet available as Oz harnesses but are tracked for a near-term release.
+Gemini and OpenCode are on the roadmap. Gemini is wired through the Oz CLI and the terminal harness selector today but is not yet broadly available; OpenCode is a fast-follow. Coverage on this page may expand as those harnesses ship.
 :::
 
 ## Harness vs. model
@@ -26,9 +26,9 @@ Gemini CLI and OpenCode are fast-follow harnesses. They are not yet available as
 A harness and a model are not the same thing.
 
 * **Harness** - The agent runtime. It decides how the agent plans, calls tools, manages context, and reports results. Warp Agent, Claude Code, and Codex are different harnesses.
-* **Model** - The LLM the harness calls for inference. A single harness can use many models, and Warp Agent in particular can route between providers (see [Model choice](/agent-platform/capabilities/model-choice/)). Claude Code uses Anthropic models; Codex uses OpenAI models.
+* **Model** - The LLM the harness calls for inference. A single harness can use many models. Warp Agent in particular can route between providers (see [Model choice](/agent-platform/capabilities/model-choice/)). Claude Code uses Anthropic models; Codex uses OpenAI models.
 
-When you start an Oz cloud agent run, you choose both: a harness (which runtime to run inside) and a model (which LLM the harness should use). Each harness exposes its own model picker — see the harness-specific pages for the supported models.
+When you start a cloud agent run, you choose both: a harness (which runtime executes the run) and a model (which LLM the harness should call). Each harness exposes its own model picker — see the harness-specific pages for the supported models.
 
 ## What stays the same across harnesses
 
@@ -37,13 +37,19 @@ Switching harnesses doesn't change the surrounding platform. Every harness inher
 * **Access control and governance** - The same [team permissions and identity model](/agent-platform/cloud-agents/team-access-billing-and-identity/) applies. Admins can disable harnesses for a team in workspace settings.
 * **Orchestration and triggers** - Any [trigger](/agent-platform/cloud-agents/integrations/) (Slack, Linear, schedules, CI, API) can launch any harness. Skills, prompts, and conversations move between harnesses cleanly.
 * **Environments and secrets** - [Environments](/agent-platform/cloud-agents/environments/) and [agent secrets](/agent-platform/cloud-agents/secrets/) are harness-agnostic. The same Docker image, repos, and setup commands work regardless of which harness runs.
-* **Memory, Skills, and Rules** - Saved [Skills](/agent-platform/capabilities/skills/), [Rules](/agent-platform/capabilities/rules/), and saved prompts apply across harnesses. Warp Agent has the deepest native support; Claude Code and Codex also receive skill content via prompt injection at run start.
+* **Memory, Skills, and Rules** - Saved [Skills](/agent-platform/capabilities/skills/), [Rules](/agent-platform/capabilities/rules/), and saved prompts apply across harnesses. Warp Agent has the deepest native support; Claude Code and Codex receive skill content as part of the run prompt.
 * **Observability** - Every run produces a transcript, status record, and shareable session, surfaced in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app, and the [Oz API](/reference/api-and-sdk/).
-* **Billing** - All harnesses bill against the same Warp credit pool. There's no separate metering or contract for third-party harnesses.
+
+## Billing across harnesses
+
+The billing model differs depending on which harness runs the inference:
+
+* **Warp Agent** - Inference is billed against your Warp credits, the same as Agent Mode in the terminal. No separate provider contract is required.
+* **Claude Code and Codex** - These harnesses call Anthropic or OpenAI directly using credentials you supply (see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/)). The provider bills your account directly for inference. Warp credits still cover the orchestration platform — environment compute, triggers, observability — but not the third-party inference calls.
 
 ## When to choose which harness
 
-Use the harness that fits the task. Strengths are heuristic — every harness can run any task — but using the right one tends to be faster and produce cleaner output.
+Use the harness that fits the task. Strengths are heuristic — every harness can run any task — but matching the harness to the work tends to be faster and produce cleaner output.
 
 * **Warp Agent** - Multi-step work that spans repos, tools, or harnesses; tasks that benefit from auto-routing between models; long-running ambient agents that orchestrate Claude Code or Codex subagents.
 * **Claude Code** - Tasks where deep code reading and judgment matter more than execution speed: code review, root-cause investigation, large feature scoping, frontend and UI iteration.
@@ -53,19 +59,21 @@ If you're unsure, start with Warp Agent — it can delegate to Claude Code or Co
 
 ## How to switch harnesses
 
-You can choose a harness when starting a cloud agent run from any surface:
+Where you can choose each harness depends on the surface. Today's coverage:
 
-* **Warp app** - In Cloud Mode, the harness dropdown appears above the input.
-* **Oz web app** - On the new run or new schedule pane, the **Harness** field lists every harness available to you.
-* **Oz CLI** - Pass `--harness` to `oz agent run` or `oz agent run-cloud`. Valid values today: `oz`, `claude`, `gemini`. (Codex CLI support is fast-follow; use the Warp app or Oz web app to launch a Codex run today.)
-* **API / SDK** - Set the `harness` field on the agent config when creating a run.
+* **Warp app** - In Cloud Mode, click the **Agent harness** dropdown above the input. Lists Warp Agent, Claude Code, and Gemini.
+* **Oz web app** - On the new run or new schedule pane, the **Harness** field lists every harness available to your team — Warp Agent, Claude Code, Gemini, and Codex.
+* **Oz CLI** - Pass `--harness` to `oz agent run` or `oz agent run-cloud`. Valid values today: `oz`, `claude`, `gemini`. Codex selection from the CLI is a fast-follow.
+* **API and SDK** - Set the `harness` field on the agent config to `oz`, `claude`, `gemini`, or `codex` when creating a run.
+
+Schedules, Slack mentions, Linear issues, and GitHub Actions triggers can launch any harness by referencing the agent or run config that picks it.
 
 Claude Code and Codex runs need credentials. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) for the one-time setup.
 
 ## Related pages
 
-* [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness.
-* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
-* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
+* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness.
+* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
+* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
 * [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — connect Anthropic or OpenAI credentials to Oz.
 * [Third-party CLI agents in the Warp terminal](/agent-platform/cli-agents/overview/) — the other context where Claude Code, Codex, and other CLI agents run.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -13,14 +13,14 @@ Oz can run third-party agents — [Claude Code](/agent-platform/cloud-agents/har
 
 Third-party harnesses inherit the same Oz platform features as Warp Agent:
 
-* **Triggers** — Slack, Linear, schedules, CI, and API [triggers](/agent-platform/cloud-agents/integrations/) launch any harness.
+* **Triggers** — Slack, Linear, schedules, CI, and API [triggers](/agent-platform/cloud-agents/triggers/) launch any harness.
 * **Environments and secrets** — Reuse the same [environments](/agent-platform/cloud-agents/environments/) and [agent secrets](/agent-platform/cloud-agents/secrets/).
 * **Skills and Rules** — Saved [Skills](/agent-platform/capabilities/skills/) and [Rules](/agent-platform/capabilities/rules/) apply across harnesses.
 * **Observability** — Every run produces a transcript and shareable session in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/).
 
 ## Billing
 
-Claude Code and Codex call Anthropic or OpenAI directly using credentials you supply. The provider bills your account for inference. Warp credits cover the orchestration platform — environment compute, triggers, observability — but not third-party inference.
+Claude Code and Codex each call their provider directly using credentials you supply, and the provider bills your account for inference. Warp credits cover the orchestration platform — environment compute, triggers, and observability — but not third-party inference.
 
 ## How to switch harnesses
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -26,15 +26,15 @@ Claude Code and Codex call Anthropic or OpenAI directly using credentials you su
 
 ### Warp desktop app
 
-In Cloud Mode, choose a harness from the harness dropdown above the input.
+In Cloud Mode, choose a harness from the **Agent harness** dropdown above the input.
 
 :::note
-You can enter Cloud Mode by creating a new `Cloud Agent` tab or by using the `/cloud-agent` slash command.
+You can enter Cloud Mode by creating a new **Cloud Agent** tab or by using the `/cloud-agent` slash command.
 :::
 
 ### Oz web app
 
-On the new run or new schedule pane, choose the harness in the **Harness** field. 
+On the new run or new schedule pane, choose the harness in the **Harness** field.
 
 ### API and SDK
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Harnesses in Oz
 description: >-
-  Run Warp Agent, Claude Code, or Codex on Oz. Each harness inherits the same
+  Run Warp Agent, Claude Code, or Codex with Oz. Each harness inherits the same
   triggers, environments, secrets, observability, and governance.
 sidebar:
   label: "Overview"
@@ -14,8 +14,8 @@ Whichever harness you pick runs on the [Oz platform](/agent-platform/cloud-agent
 ## Available harnesses
 
 * **Warp Agent** - Oz's default harness, built by Warp. Routes across leading models (Anthropic, OpenAI, Google, Fireworks), has full terminal and tool access, and is the only harness that can act as a parent in a multi-harness orchestration.
-* **Claude Code** - Anthropic's coding agent, running on Oz. Strong at code review, deep bug investigation, large feature planning, and frontend or UI work.
-* **Codex** - OpenAI's coding agent, running on Oz. Strong at codebase migrations, release coordination, batch test generation, and backend or DevOps automation.
+* **Claude Code** - Anthropic's coding agent, running with Oz. Strong at code review, deep bug investigation, large feature planning, and frontend or UI work.
+* **Codex** - OpenAI's coding agent, running with Oz. Strong at codebase migrations, release coordination, batch test generation, and backend or DevOps automation.
 
 :::note
 Gemini is on the roadmap. It's wired through the Oz CLI and the terminal harness selector today but is not yet broadly available. Coverage on this page expands as Gemini ships.
@@ -63,7 +63,7 @@ Where you can choose each harness depends on the surface. Today's coverage:
 
 * **Warp app** - In Cloud Mode, click the **Agent harness** dropdown above the input. Lists Warp Agent, Claude Code, and Gemini.
 * **Oz web app** - On the new run or new schedule pane, the **Harness** field lists every harness available to your team — Warp Agent, Claude Code, Gemini, and Codex.
-* **Oz CLI** - Pass `--harness` to `oz agent run` or `oz agent run-cloud`. Valid values today: `oz`, `claude`, `gemini`. Codex selection from the CLI is a fast-follow.
+* **Oz CLI** - Pass `--harness` to `oz agent run` or `oz agent run-cloud`. Valid values: `oz`, `claude`, `gemini`, or `codex`.
 * **API and SDK** - Set the `harness` field on the agent config to `oz`, `claude`, `gemini`, or `codex` when creating a run.
 
 Schedules, Slack mentions, Linear issues, and GitHub Actions triggers can launch any harness by referencing the agent or run config that picks it.
@@ -72,7 +72,7 @@ Claude Code and Codex runs need credentials. See [Connecting Claude and Codex cr
 
 ## Related pages
 
-* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness.
+* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — Oz's default harness.
 * [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
 * [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
 * [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — connect Anthropic or OpenAI credentials to Oz.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: "Overview"
 ---
 
-Oz can run third-party agents — [Claude Code](/agent-platform/cloud-agents/harnesses/authentication/#connecting-claude-code-credentials) and [Codex](/agent-platform/cloud-agents/harnesses/authentication/#connecting-codex-credentials) — as cloud agents alongside Warp Agent. You choose the harness (agent runtime) that fits the task; the platform around the run stays the same.
+Oz can run third-party agents — [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/) and [Codex](/agent-platform/cloud-agents/harnesses/codex/) — as cloud agents alongside Warp Agent. You choose the harness (agent runtime) that fits the task; the platform around the run stays the same.
 
 ## What stays the same
 
@@ -42,5 +42,8 @@ Set the `harness` field on the agent config. See the [API reference](/reference/
 
 ## Related pages
 
+* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — Oz's default first-party harness.
+* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
+* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
 * [Authentication](/agent-platform/cloud-agents/harnesses/authentication/) — connect credentials and launch Claude Code or Codex.
 * [Third-party CLI agents in the Warp terminal](/agent-platform/cli-agents/overview/) — run Claude Code, Codex, and other CLI agents locally.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -1,79 +1,46 @@
 ---
 title: Harnesses in Oz
 description: >-
-  Run Warp Agent, Claude Code, or Codex with Oz. Each harness inherits the same
-  triggers, environments, secrets, observability, and governance.
+  Run Claude Code or Codex as Oz cloud agents. Both inherit the same triggers,
+  environments, secrets, and observability as Warp Agent.
 sidebar:
   label: "Overview"
 ---
 
-A harness is the agent runtime that executes a cloud agent run. Oz lets you pick the harness that fits the task — [Warp Agent](/agent-platform/cloud-agents/harnesses/warp-agent/), [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/), or [Codex](/agent-platform/cloud-agents/harnesses/codex/) — without changing how you launch, observe, or govern the run.
+Oz can run third-party agents — [Claude Code](/agent-platform/cloud-agents/harnesses/authentication/#connecting-claude-code-credentials) and [Codex](/agent-platform/cloud-agents/harnesses/authentication/#connecting-codex-credentials) — as cloud agents alongside Warp Agent. You choose the harness (agent runtime) that fits the task; the platform around the run stays the same.
 
-Whichever harness you pick runs on the [Oz platform](/agent-platform/cloud-agents/platform/). You launch it the same way, with the same triggers, environments, secrets, and observability around it. The harness changes; the platform around it does not.
+## What stays the same
 
-## Available harnesses
+Third-party harnesses inherit the same Oz platform features as Warp Agent:
 
-* **Warp Agent** - Oz's default harness, built by Warp. Routes across leading models (Anthropic, OpenAI, Google, Fireworks), has full terminal and tool access, and is the only harness that can act as a parent in a multi-harness orchestration.
-* **Claude Code** - Anthropic's coding agent, running with Oz. Strong at code review, deep bug investigation, large feature planning, and frontend or UI work.
-* **Codex** - OpenAI's coding agent, running with Oz. Strong at codebase migrations, release coordination, batch test generation, and backend or DevOps automation.
+* **Triggers** — Slack, Linear, schedules, CI, and API [triggers](/agent-platform/cloud-agents/integrations/) launch any harness.
+* **Environments and secrets** — Reuse the same [environments](/agent-platform/cloud-agents/environments/) and [agent secrets](/agent-platform/cloud-agents/secrets/).
+* **Skills and Rules** — Saved [Skills](/agent-platform/capabilities/skills/) and [Rules](/agent-platform/capabilities/rules/) apply across harnesses.
+* **Observability** — Every run produces a transcript and shareable session in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/).
 
-:::note
-Gemini is on the roadmap. It's wired through the Oz CLI and the terminal harness selector today but is not yet broadly available. Coverage on this page expands as Gemini ships.
-:::
+## Billing
 
-## Harness vs. model
-
-A harness and a model are not the same thing.
-
-* **Harness** - The agent runtime. It decides how the agent plans, calls tools, manages context, and reports results. Warp Agent, Claude Code, and Codex are different harnesses.
-* **Model** - The LLM the harness calls for inference. A single harness can use many models. Warp Agent in particular can route between providers (see [Model choice](/agent-platform/capabilities/model-choice/)). Claude Code uses Anthropic models; Codex uses OpenAI models.
-
-When you start a cloud agent run, you choose both: a harness (which runtime executes the run) and a model (which LLM the harness should call). Each harness exposes its own model picker — see the harness-specific pages for the supported models.
-
-## What stays the same across harnesses
-
-Switching harnesses doesn't change the surrounding platform. Every harness inherits:
-
-* **Access control and governance** - Your existing [team permissions and identity model](/agent-platform/cloud-agents/team-access-billing-and-identity/) applies. Admins can disable harnesses for a team in workspace settings.
-* **Triggers** - Slack, Linear, schedules, CI, and API [triggers](/agent-platform/cloud-agents/integrations/) launch any harness. Skills, prompts, and conversations move between harnesses cleanly.
-* **Environments and secrets** - Reuse the same [environments](/agent-platform/cloud-agents/environments/) and [agent secrets](/agent-platform/cloud-agents/secrets/) regardless of which harness runs the work.
-* **Memory, Skills, and Rules** - Saved [Skills](/agent-platform/capabilities/skills/), [Rules](/agent-platform/capabilities/rules/), and saved prompts apply across harnesses. Warp Agent has the deepest native support; Claude Code and Codex also pick them up.
-* **Observability** - Every run produces a transcript, status record, and shareable session in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app, and the [Oz API](/reference/api-and-sdk/).
-
-## Billing across harnesses
-
-The billing model differs depending on which harness runs the inference:
-
-* **Warp Agent** - Inference is billed against your Warp credits, the same as Agent Mode in the terminal. No separate provider contract is required.
-* **Claude Code and Codex** - These harnesses call Anthropic or OpenAI directly using credentials you supply (see [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/)). The provider bills your account directly for inference. Warp credits still cover the orchestration platform — environment compute, triggers, observability — but not the third-party inference calls.
-
-## When to choose which harness
-
-Use the harness that fits the task. Strengths are heuristic — every harness can run any task — but matching the harness to the work tends to be faster and produce cleaner output.
-
-* **Warp Agent** - Multi-step work that spans repos, tools, or harnesses; tasks that benefit from auto-routing between models; long-running ambient agents that orchestrate Claude Code or Codex subagents.
-* **Claude Code** - Tasks where deep code reading and judgment matter more than execution speed: code review, root-cause investigation, large feature scoping, frontend and UI iteration.
-* **Codex** - High-volume, well-defined coding work where consistency matters: codebase migrations, release notes, batch test generation, backend service changes, and CI/CD automation.
-
-If you're unsure, start with Warp Agent — it can delegate to Claude Code or Codex via subagents when it decides that's the better fit for a step.
+Claude Code and Codex call Anthropic or OpenAI directly using credentials you supply. The provider bills your account for inference. Warp credits cover the orchestration platform — environment compute, triggers, observability — but not third-party inference.
 
 ## How to switch harnesses
 
-Where you can choose each harness depends on the surface. Today's coverage:
+### Warp desktop app
 
-* **Warp app** - In Cloud Mode, click the **Agent harness** dropdown above the input. Lists Warp Agent, Claude Code, and Gemini.
-* **Oz web app** - On the new run or new schedule pane, the **Harness** field lists every harness available to your team — Warp Agent, Claude Code, Gemini, and Codex.
-* **Oz CLI** - Pass `--harness` to `oz agent run` or `oz agent run-cloud`. Valid values: `oz`, `claude`, `gemini`, or `codex`.
-* **API and SDK** - Set the `harness` field on the agent config to `oz`, `claude`, `gemini`, or `codex` when creating a run.
+In Cloud Mode, choose a harness from the harness dropdown above the input.
 
-Schedules, Slack mentions, Linear issues, and GitHub Actions triggers can launch any harness by referencing the agent or run config that picks it.
+:::note
+You can enter Cloud Mode by creating a new `Cloud Agent` tab or by using the `/cloud-agent` slash command.
+:::
 
-Claude Code and Codex runs need credentials. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) for the one-time setup.
+### Oz web app
+
+On the new run or new schedule pane, choose the harness in the **Harness** field. 
+
+### API and SDK
+
+Set the `harness` field on the agent config. See the [API reference](/reference/api-and-sdk/) for the exact field names.
 
 ## Related pages
 
-* [Warp Agent with Oz](/agent-platform/cloud-agents/harnesses/warp-agent/) — Oz's default harness.
-* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
-* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
-* [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — connect Anthropic or OpenAI credentials to Oz.
-* [Third-party CLI agents in the Warp terminal](/agent-platform/cli-agents/overview/) — the other context where Claude Code, Codex, and other CLI agents run.
+* [Authentication](/agent-platform/cloud-agents/harnesses/authentication/) — connect credentials and launch Claude Code or Codex.
+* [Third-party CLI agents in the Warp terminal](/agent-platform/cli-agents/overview/) — run Claude Code, Codex, and other CLI agents locally.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -1,0 +1,71 @@
+---
+title: Harnesses
+description: >-
+  Run Warp Agent, Claude Code, or Codex as first-class harnesses inside Oz with
+  one access-control, memory, and billing model across every harness.
+sidebar:
+  label: "Overview"
+---
+
+A harness is the agent runtime that executes a cloud agent run. Oz lets you pick the harness that fits the task — [Warp Agent](/agent-platform/cloud-agents/harnesses/warp-agent/), [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/), or [Codex](/agent-platform/cloud-agents/harnesses/codex/) — without changing how you launch, observe, or govern the run.
+
+Every harness is a first-class citizen on the [Oz Platform](/agent-platform/cloud-agents/platform/). You can launch and steer any harness from the Warp terminal, the [Oz web app](/agent-platform/cloud-agents/oz-web-app/), the [Oz CLI](/reference/cli/), the [REST API or SDK](/reference/api-and-sdk/), and direct it to do work across multiple repos, integrations, and machines. The harness changes; the platform around it does not.
+
+## Available harnesses
+
+* **Warp Agent** - Oz's default harness, built by Warp. Routes across leading models (Anthropic, OpenAI, Google, Fireworks), has full terminal and tool access, and is the only harness that can act as a parent in a cross-harness orchestration.
+* **Claude Code** - Anthropic's coding agent, running as an Oz cloud harness. Strong at code review, deep bug investigation, large feature planning, and frontend or UI work.
+* **Codex** - OpenAI's coding agent, running as an Oz cloud harness. Strong at codebase migrations, release coordination, batch test generation, and backend or DevOps automation.
+
+:::note
+Gemini CLI and OpenCode are fast-follow harnesses. They are not yet available as Oz harnesses but are tracked for a near-term release.
+:::
+
+## Harness vs. model
+
+A harness and a model are not the same thing.
+
+* **Harness** - The agent runtime. It decides how the agent plans, calls tools, manages context, and reports results. Warp Agent, Claude Code, and Codex are different harnesses.
+* **Model** - The LLM the harness calls for inference. A single harness can use many models, and Warp Agent in particular can route between providers (see [Model choice](/agent-platform/capabilities/model-choice/)). Claude Code uses Anthropic models; Codex uses OpenAI models.
+
+When you start an Oz cloud agent run, you choose both: a harness (which runtime to run inside) and a model (which LLM the harness should use). Each harness exposes its own model picker — see the harness-specific pages for the supported models.
+
+## What stays the same across harnesses
+
+Switching harnesses doesn't change the surrounding platform. Every harness inherits:
+
+* **Access control and governance** - The same [team permissions and identity model](/agent-platform/cloud-agents/team-access-billing-and-identity/) applies. Admins can disable harnesses for a team in workspace settings.
+* **Orchestration and triggers** - Any [trigger](/agent-platform/cloud-agents/integrations/) (Slack, Linear, schedules, CI, API) can launch any harness. Skills, prompts, and conversations move between harnesses cleanly.
+* **Environments and secrets** - [Environments](/agent-platform/cloud-agents/environments/) and [agent secrets](/agent-platform/cloud-agents/secrets/) are harness-agnostic. The same Docker image, repos, and setup commands work regardless of which harness runs.
+* **Memory, Skills, and Rules** - Saved [Skills](/agent-platform/capabilities/skills/), [Rules](/agent-platform/capabilities/rules/), and saved prompts apply across harnesses. Warp Agent has the deepest native support; Claude Code and Codex also receive skill content via prompt injection at run start.
+* **Observability** - Every run produces a transcript, status record, and shareable session, surfaced in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app, and the [Oz API](/reference/api-and-sdk/).
+* **Billing** - All harnesses bill against the same Warp credit pool. There's no separate metering or contract for third-party harnesses.
+
+## When to choose which harness
+
+Use the harness that fits the task. Strengths are heuristic — every harness can run any task — but using the right one tends to be faster and produce cleaner output.
+
+* **Warp Agent** - Multi-step work that spans repos, tools, or harnesses; tasks that benefit from auto-routing between models; long-running ambient agents that orchestrate Claude Code or Codex subagents.
+* **Claude Code** - Tasks where deep code reading and judgment matter more than execution speed: code review, root-cause investigation, large feature scoping, frontend and UI iteration.
+* **Codex** - High-volume, well-defined coding work where consistency matters: codebase migrations, release notes, batch test generation, backend service changes, and CI/CD automation.
+
+If you're unsure, start with Warp Agent — it can delegate to Claude Code or Codex via subagents when it decides that's the better fit for a step.
+
+## How to switch harnesses
+
+You can choose a harness when starting a cloud agent run from any surface:
+
+* **Warp app** - In Cloud Mode, the harness dropdown appears above the input.
+* **Oz web app** - On the new run or new schedule pane, the **Harness** field lists every harness available to you.
+* **Oz CLI** - Pass `--harness` to `oz agent run` or `oz agent run-cloud`. Valid values today: `oz`, `claude`, `gemini`. (Codex CLI support is fast-follow; use the Warp app or Oz web app to launch a Codex run today.)
+* **API / SDK** - Set the `harness` field on the agent config when creating a run.
+
+Claude Code and Codex runs need credentials. See [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) for the one-time setup.
+
+## Related pages
+
+* [Warp Agent harness](/agent-platform/cloud-agents/harnesses/warp-agent/) — the default Oz harness.
+* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
+* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
+* [Connecting Claude and Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/) — connect Anthropic or OpenAI credentials to Oz.
+* [Third-party CLI agents in the Warp terminal](/agent-platform/cli-agents/overview/) — the other context where Claude Code, Codex, and other CLI agents run.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -18,7 +18,7 @@ Whichever harness you pick runs on the [Oz platform](/agent-platform/cloud-agent
 * **Codex** - OpenAI's coding agent, running on Oz. Strong at codebase migrations, release coordination, batch test generation, and backend or DevOps automation.
 
 :::note
-Gemini and OpenCode are on the roadmap. Gemini is wired through the Oz CLI and the terminal harness selector today but is not yet broadly available; OpenCode is a fast-follow. Coverage on this page may expand as those harnesses ship.
+Gemini is on the roadmap. It's wired through the Oz CLI and the terminal harness selector today but is not yet broadly available. Coverage on this page expands as Gemini ships.
 :::
 
 ## Harness vs. model
@@ -34,11 +34,11 @@ When you start a cloud agent run, you choose both: a harness (which runtime exec
 
 Switching harnesses doesn't change the surrounding platform. Every harness inherits:
 
-* **Access control and governance** - The same [team permissions and identity model](/agent-platform/cloud-agents/team-access-billing-and-identity/) applies. Admins can disable harnesses for a team in workspace settings.
-* **Orchestration and triggers** - Any [trigger](/agent-platform/cloud-agents/integrations/) (Slack, Linear, schedules, CI, API) can launch any harness. Skills, prompts, and conversations move between harnesses cleanly.
-* **Environments and secrets** - [Environments](/agent-platform/cloud-agents/environments/) and [agent secrets](/agent-platform/cloud-agents/secrets/) are harness-agnostic. The same Docker image, repos, and setup commands work regardless of which harness runs.
-* **Memory, Skills, and Rules** - Saved [Skills](/agent-platform/capabilities/skills/), [Rules](/agent-platform/capabilities/rules/), and saved prompts apply across harnesses. Warp Agent has the deepest native support; Claude Code and Codex receive skill content as part of the run prompt.
-* **Observability** - Every run produces a transcript, status record, and shareable session, surfaced in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app, and the [Oz API](/reference/api-and-sdk/).
+* **Access control and governance** - Your existing [team permissions and identity model](/agent-platform/cloud-agents/team-access-billing-and-identity/) applies. Admins can disable harnesses for a team in workspace settings.
+* **Triggers** - Slack, Linear, schedules, CI, and API [triggers](/agent-platform/cloud-agents/integrations/) launch any harness. Skills, prompts, and conversations move between harnesses cleanly.
+* **Environments and secrets** - Reuse the same [environments](/agent-platform/cloud-agents/environments/) and [agent secrets](/agent-platform/cloud-agents/secrets/) regardless of which harness runs the work.
+* **Memory, Skills, and Rules** - Saved [Skills](/agent-platform/capabilities/skills/), [Rules](/agent-platform/capabilities/rules/), and saved prompts apply across harnesses. Warp Agent has the deepest native support; Claude Code and Codex also pick them up.
+* **Observability** - Every run produces a transcript, status record, and shareable session in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), the Warp app, and the [Oz API](/reference/api-and-sdk/).
 
 ## Billing across harnesses
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
@@ -14,7 +14,7 @@ Warp Agent is the same agent runtime that powers Agent Mode in the Warp terminal
 ## Key features
 
 * **Multi-model auto-routing** - Routes between Anthropic, OpenAI, Google, and Fireworks-hosted models. Choose a specific model, or let Warp pick via `auto`, `auto-efficient`, `auto-genius`, or `auto-open`. See [Model choice](/agent-platform/capabilities/model-choice/) for the full catalog.
-* **Full terminal and tool access** - Runs commands, edits files, reads logs, executes tests, navigates repos, and calls MCP servers — the same toolbelt the Warp Agent uses locally.
+* **Full terminal and tool access** - Runs commands, edits files, reads logs, executes tests, navigates repos, and calls MCP servers — the same toolbelt Warp Agent uses locally.
 * **Platform-native context** - Reads [Codebase Context](/agent-platform/capabilities/codebase-context/), applies [Rules](/agent-platform/capabilities/rules/), reuses saved [Skills](/agent-platform/capabilities/skills/), and respects Memory and Warp Drive context with no extra setup.
 * **Multi-repo execution** - Clones every repo configured on the [environment](/agent-platform/cloud-agents/environments/) and works across them in a single run.
 * **Cross-harness orchestration parent** - A Warp Agent parent run can spawn Claude Code or Codex [subagents](/agent-platform/cloud-agents/overview/) and coordinate their outputs. Other harnesses cannot act as parents in a multi-harness orchestration.
@@ -22,7 +22,7 @@ Warp Agent is the same agent runtime that powers Agent Mode in the Warp terminal
 
 ## How it works
 
-Warp Agent with Oz is the same agent runtime as Agent Mode in the Warp terminal: it plans, calls tools, edits code, runs tests, and reports progress. The cloud platform adds the [environment](/agent-platform/cloud-agents/environments/), triggers, observability, and team governance around the run, and the transcript is inspectable in real time and replayable afterward from the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/).
+Warp Agent is the same agent runtime as Agent Mode in the Warp terminal: it plans, calls tools, edits code, runs tests, and reports progress. The cloud platform adds the [environment](/agent-platform/cloud-agents/environments/), triggers, observability, and team governance around the run, and the transcript is inspectable in real time and replayable afterward from the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/).
 
 Team admins can disable any harness for their workspace; whichever harnesses remain are the ones available to users on that team.
 
@@ -52,7 +52,7 @@ Subagents run in the same environment as the parent and share the same secrets, 
 
 Warp Agent is the default, so there's nothing extra to configure.
 
-* **Warp app** - Start a cloud agent run from the input. The harness dropdown defaults to **Warp Agent**.
+* **Warp app** - Start a cloud agent run from the input. The **Agent harness** dropdown defaults to **Warp Agent**.
 * **Oz web app** - On a new run or new schedule pane, leave the **Harness** field set to **Warp Agent**.
 * **Oz CLI** - Run `oz agent run-cloud --prompt "..."` with no `--harness` flag, or pass `--harness oz` explicitly.
 * **API and SDK** - Omit the `harness` field on the agent config, or set it to `oz`. See the [API reference](/reference/api-and-sdk/).

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
@@ -24,7 +24,7 @@ Warp Agent is the same agent runtime that powers Agent Mode in the Warp terminal
 
 Warp Agent is the same agent runtime as Agent Mode in the Warp terminal: it plans, calls tools, edits code, runs tests, and reports progress. The cloud platform adds the [environment](/agent-platform/cloud-agents/environments/), triggers, observability, and team governance around the run, and the transcript is inspectable in real time and replayable afterward from the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/).
 
-Team admins can disable any harness for their workspace; whichever harnesses remain are the ones available to users on that team.
+Team admins can disable any harness for their workspace. Users on that team can only start runs with the harnesses that remain enabled.
 
 ### Available models
 
@@ -48,7 +48,7 @@ Subagents run in the same environment as the parent and share the same secrets, 
 * You want the deepest integration with Warp's platform features (Skills, Rules, Memory, Codebase Context).
 * You're not sure which harness fits — Warp Agent is the safe default and can delegate to other harnesses when it decides that's the better fit.
 
-## Starting a run
+## Starting a Warp Agent run
 
 Warp Agent is the default, so there's nothing extra to configure.
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
@@ -22,11 +22,9 @@ Warp Agent is the same agent runtime that powers Agent Mode in the Warp terminal
 
 ## How it works
 
-When you start a cloud agent run without specifying a harness — or when you select **Warp Agent** explicitly — Oz launches the run inside a Warp-managed container. The container clones the repos on the environment, runs setup commands, then hands the prompt to the Warp Agent runtime.
+Warp Agent on Oz is the same agent runtime as Agent Mode in the Warp terminal: it plans, calls tools, edits code, runs tests, and reports progress. The cloud platform adds the [environment](/agent-platform/cloud-agents/environments/), triggers, observability, and team governance around the run, and the transcript is inspectable in real time and replayable afterward from the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/).
 
-From there the runtime behaves like Agent Mode in the Warp terminal: it plans, calls tools, edits code, runs tests, and reports progress. Every step is captured in the run transcript and surfaced in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), so the run is inspectable in real time and replayable afterward.
-
-Warp Agent obeys the same governance as any other harness. Team admins can disable any harness for their workspace; whichever harnesses remain are the ones available to users on that team.
+Team admins can disable any harness for their workspace; whichever harnesses remain are the ones available to users on that team.
 
 ### Available models
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
@@ -22,7 +22,7 @@ Warp Agent is the same agent runtime that powers Agent Mode in the Warp terminal
 
 ## How it works
 
-Warp Agent on Oz is the same agent runtime as Agent Mode in the Warp terminal: it plans, calls tools, edits code, runs tests, and reports progress. The cloud platform adds the [environment](/agent-platform/cloud-agents/environments/), triggers, observability, and team governance around the run, and the transcript is inspectable in real time and replayable afterward from the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/).
+Warp Agent with Oz is the same agent runtime as Agent Mode in the Warp terminal: it plans, calls tools, edits code, runs tests, and reports progress. The cloud platform adds the [environment](/agent-platform/cloud-agents/environments/), triggers, observability, and team governance around the run, and the transcript is inspectable in real time and replayable afterward from the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/).
 
 Team admins can disable any harness for their workspace; whichever harnesses remain are the ones available to users on that team.
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
@@ -1,0 +1,73 @@
+---
+title: Warp Agent harness
+description: >-
+  Warp Agent is Oz's default harness. It routes across leading models, has full
+  terminal access, and is the only harness that can orchestrate subagents.
+sidebar:
+  label: "Warp Agent"
+---
+
+Warp Agent is the harness Warp builds and ships with Oz. It's the default harness for every cloud agent run unless you pick another one, and it's the only harness that can spawn cross-harness subagents (for example, a Warp Agent parent dispatching a Claude Code or Codex child).
+
+Warp Agent is the same agent runtime that powers Agent Mode in the Warp terminal. Running it as a cloud harness gives you the same behavior — model routing, tool access, Skills, Rules, Memory — without tying execution to a single laptop.
+
+## Key features
+
+* **Multi-model auto-routing** - Routes between Anthropic, OpenAI, Google, and Fireworks-hosted models. Choose a specific model, or let Warp pick via `auto`, `auto-efficient`, `auto-genius`, or `auto-open`. See [Model choice](/agent-platform/capabilities/model-choice/) for the full catalog.
+* **Full terminal and tool access** - Runs commands, edits files, reads logs, executes tests, navigates repos, and calls MCP servers — the same toolbelt the Warp Agent uses locally.
+* **Platform-native context** - Reads [Codebase Context](/agent-platform/capabilities/codebase-context/), applies [Rules](/agent-platform/capabilities/rules/), reuses saved [Skills](/agent-platform/capabilities/skills/), and respects Memory and Warp Drive context with no extra setup.
+* **Multi-repo execution** - Clones every repo configured on the [environment](/agent-platform/cloud-agents/environments/) and works across them in a single run.
+* **Cross-harness orchestration parent** - A Warp Agent parent run can spawn Claude Code or Codex [subagents](/agent-platform/cloud-agents/overview/) and coordinate their outputs. Other harnesses cannot act as parents in a multi-harness orchestration.
+* **No extra credentials** - Warp Agent uses your existing Warp account and credits. There's no separate API key, no auth-secret to configure.
+
+## How it works
+
+When you start an Oz cloud agent run without specifying a harness — or when you select **Warp Agent** explicitly — Oz launches the run inside a Warp-managed agent container. The container clones the repos on the environment, runs setup commands, then hands the prompt to the Warp Agent runtime.
+
+From there the runtime behaves like Agent Mode in the Warp terminal: it plans, calls tools, edits code, runs tests, and reports progress. Every step is captured in the run transcript and surfaced in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), so the run is inspectable in real time and replayable afterward.
+
+Warp Agent obeys the same governance as any other harness. Team admins can disable any harness for their workspace; whichever harnesses remain are the ones available to users on that team.
+
+### Available models
+
+Warp Agent supports the full Warp model catalog. Configure the model per [Agent Profile](/agent-platform/capabilities/agent-profiles-permissions/), or pick one at run time. See [Model choice](/agent-platform/capabilities/model-choice/) for the supported `model_id` values, including the `auto`, `auto-efficient`, `auto-genius`, and `auto-open` routing options.
+
+### Cross-harness orchestration
+
+Warp Agent is the orchestration host for multi-harness runs. A typical pattern:
+
+1. A Warp Agent parent run analyzes a task and breaks it into subtasks.
+2. The parent dispatches Claude Code subagents for code-review-heavy steps and Codex subagents for high-volume edits.
+3. The parent collects results, resolves conflicts, and returns a single final output (a PR, a report, a Slack reply).
+
+Subagents run in the same environment as the parent and share the same secrets, MCP servers, and integrations. The transcript shows the full tree, so reviewers can see exactly which subagent did what.
+
+## Choosing Warp Agent
+
+Pick Warp Agent when:
+
+* The task spans multiple repos, languages, or domains.
+* You want model auto-routing instead of pinning one provider.
+* The run needs to orchestrate other harnesses as subagents.
+* You want the deepest integration with Warp's platform features (Skills, Rules, Memory, Codebase Context).
+* You're not sure which harness fits — Warp Agent is the safe default and can delegate to other harnesses when it decides that's the better fit.
+
+## Starting a Warp Agent run
+
+Warp Agent is the default, so there's nothing extra to configure to use it.
+
+* **Warp app** - Start a cloud agent run from the input. The harness dropdown defaults to **Warp Agent**.
+* **Oz web app** - On a new run or new schedule pane, leave the **Harness** field set to **Warp**.
+* **Oz CLI** - Run `oz agent run-cloud --prompt "..."` with no `--harness` flag, or pass `--harness oz` explicitly.
+* **API / SDK** - Omit the `harness` field on the agent config, or set it to `oz`.
+
+For a complete walkthrough, see the [Cloud agents quickstart](/agent-platform/cloud-agents/quickstart/).
+
+## Related pages
+
+* [Harnesses overview](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
+* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
+* [Model choice](/agent-platform/capabilities/model-choice/) — the model catalog Warp Agent routes across.
+* [Agent Profiles and permissions](/agent-platform/capabilities/agent-profiles-permissions/) — configure the default model, autonomy, and tool access for Warp Agent.
+* [Skills as agents](/agent-platform/cloud-agents/skills-as-agents/) — turn a saved skill into a reusable Warp Agent run.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
@@ -40,9 +40,7 @@ Warp Agent is the orchestration host for multi-harness runs. A typical pattern:
 
 Subagents run in the same environment as the parent and share the same secrets, MCP servers, and integrations. The transcript shows the full tree, so reviewers can see exactly which subagent did what.
 
-## Choosing Warp Agent
-
-Pick Warp Agent when:
+## When to choose Warp Agent
 
 * The task spans multiple repos, languages, or domains.
 * You want model auto-routing instead of pinning one provider.
@@ -50,14 +48,14 @@ Pick Warp Agent when:
 * You want the deepest integration with Warp's platform features (Skills, Rules, Memory, Codebase Context).
 * You're not sure which harness fits — Warp Agent is the safe default and can delegate to other harnesses when it decides that's the better fit.
 
-## Starting a Warp Agent run
+## Starting a run
 
-Warp Agent is the default, so there's nothing extra to configure to use it.
+Warp Agent is the default, so there's nothing extra to configure.
 
 * **Warp app** - Start a cloud agent run from the input. The harness dropdown defaults to **Warp Agent**.
 * **Oz web app** - On a new run or new schedule pane, leave the **Harness** field set to **Warp Agent**.
 * **Oz CLI** - Run `oz agent run-cloud --prompt "..."` with no `--harness` flag, or pass `--harness oz` explicitly.
-* **API and SDK** - Omit the `harness` field on the agent config, or set it to `oz`.
+* **API and SDK** - Omit the `harness` field on the agent config, or set it to `oz`. See the [API reference](/reference/api-and-sdk/).
 
 For a complete walkthrough, see the [Cloud agents quickstart](/agent-platform/cloud-agents/quickstart/).
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
@@ -1,5 +1,5 @@
 ---
-title: Warp Agent harness
+title: Warp Agent with Oz
 description: >-
   Warp Agent is Oz's default harness. It routes across leading models, has full
   terminal access, and is the only harness that can orchestrate subagents.
@@ -7,7 +7,7 @@ sidebar:
   label: "Warp Agent"
 ---
 
-Warp Agent is the harness Warp builds and ships with Oz. It's the default harness for every cloud agent run unless you pick another one, and it's the only harness that can spawn cross-harness subagents (for example, a Warp Agent parent dispatching a Claude Code or Codex child).
+Warp Agent is the harness Warp builds and ships with Oz. It's the default for every cloud agent run unless you pick another harness, and it's the only harness that can spawn cross-harness subagents (for example, a Warp Agent parent dispatching a Claude Code or Codex child).
 
 Warp Agent is the same agent runtime that powers Agent Mode in the Warp terminal. Running it as a cloud harness gives you the same behavior — model routing, tool access, Skills, Rules, Memory — without tying execution to a single laptop.
 
@@ -18,11 +18,11 @@ Warp Agent is the same agent runtime that powers Agent Mode in the Warp terminal
 * **Platform-native context** - Reads [Codebase Context](/agent-platform/capabilities/codebase-context/), applies [Rules](/agent-platform/capabilities/rules/), reuses saved [Skills](/agent-platform/capabilities/skills/), and respects Memory and Warp Drive context with no extra setup.
 * **Multi-repo execution** - Clones every repo configured on the [environment](/agent-platform/cloud-agents/environments/) and works across them in a single run.
 * **Cross-harness orchestration parent** - A Warp Agent parent run can spawn Claude Code or Codex [subagents](/agent-platform/cloud-agents/overview/) and coordinate their outputs. Other harnesses cannot act as parents in a multi-harness orchestration.
-* **No extra credentials** - Warp Agent uses your existing Warp account and credits. There's no separate API key, no auth-secret to configure.
+* **No extra credentials** - Warp Agent uses your existing Warp account and credits. There's no separate API key to configure.
 
 ## How it works
 
-When you start an Oz cloud agent run without specifying a harness — or when you select **Warp Agent** explicitly — Oz launches the run inside a Warp-managed agent container. The container clones the repos on the environment, runs setup commands, then hands the prompt to the Warp Agent runtime.
+When you start a cloud agent run without specifying a harness — or when you select **Warp Agent** explicitly — Oz launches the run inside a Warp-managed container. The container clones the repos on the environment, runs setup commands, then hands the prompt to the Warp Agent runtime.
 
 From there the runtime behaves like Agent Mode in the Warp terminal: it plans, calls tools, edits code, runs tests, and reports progress. Every step is captured in the run transcript and surfaced in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/), so the run is inspectable in real time and replayable afterward.
 
@@ -30,7 +30,7 @@ Warp Agent obeys the same governance as any other harness. Team admins can disab
 
 ### Available models
 
-Warp Agent supports the full Warp model catalog. Configure the model per [Agent Profile](/agent-platform/capabilities/agent-profiles-permissions/), or pick one at run time. See [Model choice](/agent-platform/capabilities/model-choice/) for the supported `model_id` values, including the `auto`, `auto-efficient`, `auto-genius`, and `auto-open` routing options.
+Warp Agent supports the full Warp model catalog. Configure the model per [Agent Profile](/agent-platform/capabilities/agent-profiles-permissions/), or pick one at run time. See [Model choice](/agent-platform/capabilities/model-choice/) for the supported model IDs, including the `auto`, `auto-efficient`, `auto-genius`, and `auto-open` routing options.
 
 ### Cross-harness orchestration
 
@@ -57,17 +57,17 @@ Pick Warp Agent when:
 Warp Agent is the default, so there's nothing extra to configure to use it.
 
 * **Warp app** - Start a cloud agent run from the input. The harness dropdown defaults to **Warp Agent**.
-* **Oz web app** - On a new run or new schedule pane, leave the **Harness** field set to **Warp**.
+* **Oz web app** - On a new run or new schedule pane, leave the **Harness** field set to **Warp Agent**.
 * **Oz CLI** - Run `oz agent run-cloud --prompt "..."` with no `--harness` flag, or pass `--harness oz` explicitly.
-* **API / SDK** - Omit the `harness` field on the agent config, or set it to `oz`.
+* **API and SDK** - Omit the `harness` field on the agent config, or set it to `oz`.
 
 For a complete walkthrough, see the [Cloud agents quickstart](/agent-platform/cloud-agents/quickstart/).
 
 ## Related pages
 
-* [Harnesses overview](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
-* [Claude Code harness](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
-* [Codex harness](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
+* [Harnesses in Oz](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex.
+* [Claude Code with Oz](/agent-platform/cloud-agents/harnesses/claude-code/) — Claude Code as a cloud harness.
+* [Codex with Oz](/agent-platform/cloud-agents/harnesses/codex/) — Codex as a cloud harness.
 * [Model choice](/agent-platform/capabilities/model-choice/) — the model catalog Warp Agent routes across.
 * [Agent Profiles and permissions](/agent-platform/capabilities/agent-profiles-permissions/) — configure the default model, autonomy, and tool access for Warp Agent.
 * [Skills as agents](/agent-platform/cloud-agents/skills-as-agents/) — turn a saved skill into a reusable Warp Agent run.


### PR DESCRIPTION
## Summary

Adds the documentation for the multi-harness story in the Oz Orchestration Launch (Codename Maestro): customers can now launch and steer **Warp Agent**, **Claude Code**, and **Codex** as first-class harnesses inside Oz from the Warp terminal, the Oz web app, the Oz CLI, the REST API, or the SDK. One access-control, environment, secret, observability, governance, and billing model spans every harness.

This PR ships five new pages under `agent-platform/cloud-agents/harnesses/` (conceptual overview, per-harness feature docs for Warp Agent / Claude Code / Codex, and a procedural authentication page for connecting Anthropic and OpenAI credentials), and adds short "two contexts" callouts to the existing CLI-agent pages so readers can tell the local Warp-terminal experience apart from the cloud harness experience. OpenCode and Gemini are flagged as fast-follow harnesses where it's natural to do so.

## New pages

- `src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx` — Harnesses overview. What a harness is, harness vs. model, what stays the same across harnesses, how to choose, how to switch.
- `src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx` — Warp Agent harness. Default; multi-model auto-routing; full terminal/tool access; Skills/Rules/Memory/Codebase Context native support; cross-harness orchestration parent.
- `src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx` — Claude Code harness. Cloud orchestration, Claude model picker (opus/sonnet/haiku, 1M-context variants), credential types, choosing-Claude heuristics, how to launch from every surface.
- `src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx` — Codex harness. Cloud orchestration, Codex model picker (GPT-5.5 / GPT-5.4 / Codex-tuned variants), credential type, choosing-Codex heuristics, how to launch.
- `src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx` — One-time auth setup for Claude Code and Codex via Warp-managed secrets (Oz web app and Oz CLI), with rotation/deletion guidance and troubleshooting.

## Edited pages

- `src/content/docs/agent-platform/cli-agents/overview.mdx` — Added a "Two contexts for these agents" callout up top distinguishing the Warp-terminal experience from the Oz cloud harness experience, with a link to the new harnesses overview.
- `src/content/docs/agent-platform/cli-agents/claude-code.mdx` — Added a top-of-page callout linking to the Claude Code harness page; added the harness page to "Related pages".
- `src/content/docs/agent-platform/cli-agents/codex.mdx` — Same treatment as Claude Code.
- `src/content/docs/agent-platform/cli-agents/opencode.mdx` — Noted that OpenCode as an Oz cloud harness is a fast-follow with a link to the harnesses overview.

## Research grounding

Confirmed against `warp-server` and `warp-internal`:

- `model/types/enums/agent_harness.go` defines `OZ`, `CLAUDE_CODE`, `GEMINI`, `CODEX`. Per-harness feature flags + admin-disable via workspace settings, plus the `OzMultiHarnessExperiment` arm gate in production (`logic/harness_availability.go`).
- `config/harness_models.go` confirms the Claude model picker (opus/sonnet/haiku aliases, pinned `claude-opus-4-7` etc., `opus[1m]`, `sonnet[1m]`, `opusplan`) and the Codex picker (`default`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, `gpt-5.3-codex`, `gpt-5.2`).
- `model/types/enums/managed_secret_type.go` confirms the auth-secret types per harness: `anthropic_api_key` / `anthropic_bedrock_api_key` / `anthropic_bedrock_access_key` for Claude Code, `openai_api_key` for Codex.
- Web app `HarnessSelector` and `HarnessAuthSecretSelector` (`client/packages/agents/src/components/`) confirm the new-run and new-schedule UI flows.
- `crates/warp_cli/src/agent.rs` confirms `oz agent run --harness` and `oz agent run-cloud --harness` with `--claude-auth-secret`. `crates/warp_cli/src/secret.rs` confirms `oz secret create anthropic api-key|bedrock-api-key|bedrock-access-key`.

## Caveats / open questions for product / PM

- **CLI is behind server on Codex.** The Oz CLI's `Harness` clap enum lists `oz`, `claude`, `gemini` only — no `codex` value yet. There's also no `--codex-auth-secret` flag and no `oz secret create openai` provider subcommand. The Codex harness page reflects this and steers CLI-first users toward the Warp app / Oz web app. Please confirm timing of CLI catch-up so the page can be amended.
- **Terminal harness dropdown is missing Codex.** `app/src/terminal/view/ambient_agent/harness_selector.rs` renders Oz / Claude / Gemini. If Codex is expected to be live in Cloud Mode's harness dropdown at launch, the menu needs updating; otherwise I should re-word the "Warp app" steps to say Codex starts from the Oz web app today.
- **Gemini vs. OpenCode messaging.** Per the launch tracker brief, Gemini and OpenCode are fast-follow harnesses. Gemini is already wired through more surfaces than OpenCode (server enum, CLI `--harness gemini`, terminal selector), so saying both are "coming soon" is slightly conservative. I've labeled both as fast-follow on the harnesses overview and as a "coming soon" note on the OpenCode page. Please confirm this matches marketing copy.
- **Sidebar wiring is deferred.** This PR intentionally does not edit `src/sidebar.ts` per the orchestration launch file-scope guidance — the cross-cutting sidebar PR will add the five new pages to the `Agents` topic. As a result, `npm run build` currently fails on this branch with `AstroUserError: Failed to find the topic for the agent-platform/cloud-agents/harnesses page` until the sidebar PR lands. If the cross-cutting PR is meant to land later, this PR can merge first; the build will resolve once both are on the gating branch. Flagging in case the sequencing needs adjusting.
- **`HarnessAuthSecrets.codex_auth_secret_name` field.** APP-4374 introduces this on the agent-config snapshot; the Codex page and authentication page reference it. Confirm it's shipping in the launch window so the doc isn't ahead of the SDK.

## Validation

- Five new pages and four edited pages render with sentence-case headers, bold-term + dash list format, second-person voice, and Oz/Warp/Warp Agent terminology per `AGENTS.md`.
- Internal links use the new `harnesses/...` paths consistently.
- All managed-secret type names match the `ManagedSecretType` enum (`anthropic_api_key`, `anthropic_bedrock_api_key`, `anthropic_bedrock_access_key`, `openai_api_key`).
- Per the [Oz harness display module](https://github.com/warpdotdev/warp/blob/main/app/src/ai/harness_display.rs), the user-visible name for the Oz harness is "Warp Agent" — this PR uses that consistently.

Co-Authored-By: Oz <oz-agent@warp.dev>
