### PR TITLE
docs(model-choice): remove GLM 5 from Fireworks AI hosted models

### DIFF
--- a/src/content/docs/agent-platform/capabilities/model-choice.mdx
+++ b/src/content/docs/agent-platform/capabilities/model-choice.mdx
@@ -82,7 +82,6 @@ Warp also supports leading open source models hosted via Fireworks AI, so you ca
 
 | Model | `model_id` |
 | --- | --- |
-| GLM 5 | `glm-5-fireworks` |
 | GLM 5.1 | `glm-5.1-fireworks` |
 | Kimi K2.5 | `kimi-k25-fireworks` |
 | Kimi K2.6 | `kimi-k26-fireworks` |


### PR DESCRIPTION
GLM 5 is no longer offered as a hosted model on Fireworks AI. Removes the row from the **Hosted models (via Fireworks AI)** table in `agent-platform/capabilities/model-choice.mdx`.

GLM 5.1 remains in the table, alongside the other hosted models.

### Diff scope
- One line removed.
- No other content changes.

### Validation
- `style_lint --changed`: clean.
- `check_links --internal-only`: 0 broken links across 317 files and 2,384 internal links.

Conversation: https://staging.warp.dev/conversation/3a6bb67d-22cd-4592-8c99-3f7ef795266a

Co-Authored-By: Oz <oz-agent@warp.dev>