### PR TITLE
Audit pass 2: factual corrections, terminology unification, style cleanup

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/agents.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/agents.mdx
@@ -49,13 +49,12 @@ When a team is over its plan limit (for example, after downgrading), the extra i
 
 ## Managing agent identities
 
-You can create, list, update, and delete agent identities through the public API. The full request and response shapes — including error codes — live on the [API Reference](/api) page; the operations to look for are `createAgent`, `listAgents`, `getAgent`, `updateAgent`, and `deleteAgent` under the **agent** tag.
+You can create, list, update, and delete agent identities through the public API. The full request and response shapes — including error codes — live on the [API Reference](/api) page; the operations to look for are `createAgent`, `listAgents`, `updateAgent`, and `deleteAgent` under the **agent** tag.
 
 The endpoints behave as follows:
 
 * **Create** - `POST /agent/identities` with a `name` and optional `description`, `secrets`, and `skills`. Returns `201` with the new identity's `uid`, `name`, and `available` flag.
 * **List** - `GET /agent/identities` returns every agent identity on the team, including the default. Each entry includes an `available` flag indicating whether it is within the plan limit.
-* **Retrieve** - `GET /agent/identities/{uid}` returns a single identity by its UID.
 * **Update** - `PUT /agent/identities/{uid}` replaces individual fields. Omitting a field preserves the current value; passing an empty string or empty array clears it.
 * **Delete** - `DELETE /agent/identities/{uid}` soft-deletes the identity and atomically deletes every API key bound to it. The default agent identity cannot be deleted.
 
@@ -71,7 +70,7 @@ A few constraints apply across every endpoint:
 
 A team API key can be bound to a specific agent identity at creation time. Calls authenticated with that key run as the chosen identity. The team is resolved automatically from the identity — you don't need to specify a team when generating the key.
 
-To create a key bound to an agent identity, pass the identity's UID to the `generateApiKey` mutation. See [API Keys](/reference/cli/api-keys/) for the full key creation flow and for the difference between user-scoped and team-scoped keys.
+To create a key bound to an agent identity, choose the identity when creating the team API key. See [API Keys](/reference/cli/api-keys/) for the full key creation flow and for the difference between user-scoped and team-scoped keys.
 
 Once the key exists, the CLI and SDK authenticate as that agent identity for every call. There is no extra flag to set; the binding is on the key itself.
 
@@ -82,7 +81,7 @@ There are two ways to run a cloud agent as a specific agent identity:
 * **Authenticate with a key bound to the identity** - Every run started with that key executes as the bound agent identity. This is the typical path for CI pipelines and scheduled work.
 * **Pass `agent_identity_uid` on `POST /agent/runs`** - For one-off runs, send the agent identity's `uid` in the request body. The field is only valid for team-owned runs.
 
-When neither path is used, runs execute under the default identity ("Quick run" in the web app).
+When neither path is used, runs execute under the default identity.
 
 ## Where agent identities appear in the product
 

--- a/src/content/docs/agent-platform/cloud-agents/deployment-patterns.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/deployment-patterns.mdx
@@ -22,7 +22,7 @@ Oz cloud agent setups usually have four moving parts:
 
 ### Pattern 1: CLI-only agents (bring your own orchestrator)
 
-Use this when you already have a system that schedules work (CI, dev boxes, internal orchestrators), and you just need a reliable, cloud-connected agent runner.
+Use this when you already have a system that schedules work (CI, dev boxes, internal orchestrators), and you need a reliable, cloud-connected agent runner.
 
 #### What it looks like
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/authentication.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 Third-party cloud agents — [Claude Code](#connecting-claude-code-credentials) and [Codex](#connecting-codex-credentials) — call their provider directly, so you need to store credentials as Warp-managed secrets before launching a run. This page walks through the one-time setup for each.
 
-Auth secrets can be scoped to a **team** (available to all teammates' runs) or **personal** (only your own runs), just like any other Warp-managed secret.
+Auth secrets can be scoped to a **team** (available to all teammates' runs) or **personal** (only your own runs), like any other Warp-managed secret.
 
 :::note
 [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) configured in the Warp desktop app applies to local agent runs only. Cloud runs of Claude Code and Codex always use Warp-managed secrets.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/claude-code.mdx
@@ -36,7 +36,7 @@ Claude Code calls Anthropic directly using credentials your team provides. Oz su
 * **Anthropic Bedrock API key** - For Bedrock-routed inference using an API key.
 * **Anthropic Bedrock access key** - For Bedrock-routed inference using AWS access credentials.
 
-Anthropic bills your account directly for inference. Warp credits cover the rest of the platform — environment compute, triggers, and observability.
+Anthropic bills your account directly for inference. Warp still meters [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits) for the run's sandbox and [platform credits](/support-and-community/plans-and-billing/platform-credits/) for the orchestration layer.
 
 For setup steps, see [Connecting Claude Code credentials](/agent-platform/cloud-agents/harnesses/authentication/#connecting-claude-code-credentials).
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/codex.mdx
@@ -35,7 +35,7 @@ Codex calls OpenAI directly using credentials your team provides. Oz supports on
 
 * **OpenAI API key** - The Codex harness authenticates to OpenAI using this key for every run.
 
-OpenAI bills your account directly for inference. Warp credits cover the rest of the platform — environment compute, triggers, and observability.
+OpenAI bills your account directly for inference. Warp still meters [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits) for the run's sandbox and [platform credits](/support-and-community/plans-and-billing/platform-credits/) for the orchestration layer.
 
 For setup steps, see [Connecting Codex credentials](/agent-platform/cloud-agents/harnesses/authentication/#connecting-codex-credentials).
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -20,7 +20,7 @@ Third-party harnesses inherit the same Oz platform features as Warp Agent:
 
 ## Billing
 
-Claude Code and Codex each call their provider directly using credentials you supply, and the provider bills your account for inference. Warp credits cover the orchestration platform — environment compute, triggers, and observability — but not third-party inference.
+Claude Code and Codex each call their provider directly using credentials you supply, and the provider bills your account for inference. Warp meters [compute credits](/support-and-community/plans-and-billing/credits/#compute-credits) for the run's sandbox and [platform credits](/support-and-community/plans-and-billing/platform-credits/) for the orchestration layer.
 
 ## How to switch harnesses
 

--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -113,7 +113,7 @@ Cloud agents and [integrations](/agent-platform/cloud-agents/integrations/) run 
 [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) is not supported for cloud agent runs. BYOK keys are stored locally on your device and are not accessible to cloud-hosted agents. All cloud agent runs consume Warp credits.
 :::
 
-#### For Cloud Agents via CLI/API
+#### For cloud agents via CLI/API
 
 Individual users can run cloud agents without being on a team. Requirements:
 
@@ -121,7 +121,7 @@ Individual users can run cloud agents without being on a team. Requirements:
 * Cloud agents run on Warp-hosted infrastructure
 * Self-hosted agents require a team subscription
 
-#### For Integrations (Slack/Linear)
+#### For integrations (Slack/Linear)
 
 Integrations require you to be part of a [Warp team](/knowledge-and-collaboration/teams/) and additional requirements:
 

--- a/src/content/docs/agent-platform/cloud-agents/oz-web-app.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/oz-web-app.mdx
@@ -1,5 +1,5 @@
 ---
-title: Oz Web App for cloud agents
+title: Oz web app for cloud agents
 description: >-
   Use the Oz web app to manage cloud agents, view runs, create schedules, and
   configure environments and integrations from any browser or mobile device.
@@ -22,7 +22,7 @@ Watch this short demo to create an environment and run an agent using the Oz web
 <table><thead><tr><th width="150">Page</th><th width="120">Path</th><th>What you can do</th></tr></thead><tbody><tr><td><strong>Dashboard</strong></td><td><code>/dashboard</code></td><td>Quick actions, suggested agents, recent agents, and featured reads</td></tr><tr><td><strong>Runs</strong></td><td><code>/runs</code></td><td>View all runs, filter by status/source/creator, start new runs, inspect transcripts</td></tr><tr><td><strong>Agents</strong></td><td><code>/agents</code></td><td>Browse skills from your environments, manage agent identities, dispatch skills as agents</td></tr><tr><td><strong>Schedules</strong></td><td><code>/schedules</code></td><td>Create scheduled agents, pause/enable schedules, view run history</td></tr><tr><td><strong>Environments</strong></td><td><code>/environments</code></td><td>Create and manage environments with repos, Docker images, and setup commands</td></tr><tr><td><strong>Secrets</strong></td><td><code>/secrets</code></td><td>Create and manage Warp-managed secrets for cloud agent runs</td></tr><tr><td><strong>Integrations</strong></td><td><code>/integrations</code></td><td>Connect Slack and Linear to trigger agents from external tools</td></tr></tbody></table>
 
 <figure>
-![The Oz Web App's management view.](../../../../assets/agent-platform/oz-web-app-runs-view.png)
+![The Oz web app's management view.](../../../../assets/agent-platform/oz-web-app-runs-view.png)
 <figcaption>The Oz web app management view.</figcaption>
 </figure>
 
@@ -133,7 +133,7 @@ Each skill displays:
 <table><thead><tr><th width="150">Field</th><th>Description</th></tr></thead><tbody><tr><td><strong>Name</strong></td><td>The skill's identifier</td></tr><tr><td><strong>Description</strong></td><td>What the skill does</td></tr><tr><td><strong>Environments</strong></td><td>Which environments have access to this skill</td></tr></tbody></table>
 
 <figure>
-![The Agents page in the Oz Web App.](../../../../assets/agent-platform/oz-web-app-agents.png)
+![The Agents page in the Oz web app.](../../../../assets/agent-platform/oz-web-app-agents.png)
 <figcaption>The Agents page in the Oz web app.</figcaption>
 </figure>
 
@@ -152,7 +152,7 @@ For more details on how skills work with cloud agents, see [Skills as Agents](/a
 Click **New skill** to create a new skill. The guided flow helps you define the skill's instructions, which are then available for future runs.
 
 <figure>
-![Creating a new agent skill in the Oz Web App.](../../../../assets/agent-platform/oz-web-app-new-agent.png)
+![Creating a new agent skill in the Oz web app.](../../../../assets/agent-platform/oz-web-app-new-agent.png)
 <figcaption>Creating a new skill in the Oz web app.</figcaption>
 </figure>
 
@@ -197,7 +197,7 @@ Each schedule displays:
 <table><thead><tr><th width="150">Field</th><th>Description</th></tr></thead><tbody><tr><td><strong>Name</strong></td><td>A descriptive name for the scheduled task</td></tr><tr><td><strong>Frequency</strong></td><td>Human-readable description of the cron schedule (e.g., "Every Monday at 10am")</td></tr><tr><td><strong>Next run</strong></td><td>When the schedule will next execute</td></tr><tr><td><strong>Environment</strong></td><td>Which environment the scheduled agent runs in</td></tr><tr><td><strong>Agent</strong></td><td>Which skill the schedule uses (if any)</td></tr><tr><td><strong>Status</strong></td><td>Whether the schedule is active or paused</td></tr></tbody></table>
 
 <figure>
-![The Schedules page in the Oz Web App.](../../../../assets/agent-platform/oz-web-app-schedules.png)
+![The Schedules page in the Oz web app.](../../../../assets/agent-platform/oz-web-app-schedules.png)
 <figcaption>The Schedules page in the Oz web app.</figcaption>
 </figure>
 
@@ -243,7 +243,7 @@ Each environment displays:
 <table><thead><tr><th width="170">Field</th><th>Description</th></tr></thead><tbody><tr><td><strong>Name</strong></td><td>The environment's identifier</td></tr><tr><td><strong>Docker image</strong></td><td>The container image used for execution</td></tr><tr><td><strong>Repositories</strong></td><td>Which repos the agent can access</td></tr><tr><td><strong>Setup commands</strong></td><td>Commands run before the agent starts</td></tr></tbody></table>
 
 <figure>
-![The Environments page in the Oz Web App.](../../../../assets/agent-platform/oz-web-app-environments.png)
+![The Environments page in the Oz web app.](../../../../assets/agent-platform/oz-web-app-environments.png)
 <figcaption>The Environments page in the Oz web app.</figcaption>
 </figure>
 
@@ -275,7 +275,7 @@ The **Integrations** page (`/integrations`) lets you configure first-party integ
 <table><thead><tr><th width="120">Integration</th><th>Description</th></tr></thead><tbody><tr><td><strong>Slack</strong></td><td>Tag @Oz in messages or threads to trigger agents directly from Slack conversations</td></tr><tr><td><strong>Linear</strong></td><td>Tag @Oz on issues to trigger agents from your issue tracker</td></tr></tbody></table>
 
 <figure>
-![The Integrations page in the Oz Web App.](../../../../assets/agent-platform/oz-web-app-integrations.png)
+![The Integrations page in the Oz web app.](../../../../assets/agent-platform/oz-web-app-integrations.png)
 <figcaption>The Integrations page in the Oz web app.</figcaption>
 </figure>
 

--- a/src/content/docs/agent-platform/cloud-agents/secrets.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/secrets.mdx
@@ -30,7 +30,7 @@ Warp-managed secrets are designed to work across [cloud agent](/agent-platform/c
 
 Warp provides a set of CLI commands for creating, updating, and listing secrets. Secret values are stored securely and cannot be retrieved once created.
 
-At runtime, **Warp sets the relevant secrets as environment variables** for each cloud agent run, based on who triggered the agent and how it was triggered.&#x20;
+At runtime, **Warp sets the relevant secrets as environment variables** for each cloud agent run, based on who triggered the agent and how it was triggered.
 
 :::note
 Secret values are available only to the agent process (and any subprocesses it spawns) during execution, and **can’t be viewed or retrieved afterward.**
@@ -69,7 +69,7 @@ Because team secrets are broadly available and may be used by fully automated or
 This ensures credentials remain valid as team membership changes, permissions are tightly scoped, and ownership and rotation align with internal security policies.
 
 :::note
-Team secrets can also be attached directly to an [agent identity](/agent-platform/cloud-agents/agents/), so only runs executing as that identity receive them. The secret itself still lives in the team's secret scope; the agent identity just references it by name.
+Team secrets can also be attached directly to an [agent identity](/agent-platform/cloud-agents/agents/), so only runs executing as that identity receive them. The secret itself still lives in the team's secret scope; the agent identity only references it by name.
 :::
 
 #### Personal secrets
@@ -102,7 +102,7 @@ The new secret appears in the Secrets list immediately. Its value is never reada
 
 ## Managing agent secrets with the Oz CLI
 
-Secrets are managed using the oz secret command family.
+Secrets are managed using the `oz secret` command family.
 
 You can create secrets interactively or from a file.
 

--- a/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
@@ -76,12 +76,12 @@ Integrations and [cloud agents](/agent-platform/cloud-agents/overview/) run insi
 
 Your team must meet the following requirements to run integrations:
 
-* You must be on a plan that supports **[Reload Credits (Add-on Credits)](/support-and-community/plans-and-billing/add-on-credits/)**.
+* You must be on a plan that supports **[Add-on Credits](/support-and-community/plans-and-billing/add-on-credits/)**.
   * Supported: **Build, Max, Business**
   * Not supported: Pro, Turbo, Lightspeed, legacy Business.
 * Your team needs at least **20 credits** available to run cloud agents and integrations
 
-When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
+When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [cloud agent credits](/support-and-community/plans-and-billing/credits/#compute-credits) the user has, then moves to the user's base credits, followed by the team's Add-on Credits, and finally the user's own Add-on Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
 
 :::note
 If you're on an Enterprise plan, please reach out to [warp.dev/contact-sales](https://warp.dev/contact-sales) with any billing questions related to integrations.
@@ -212,12 +212,12 @@ How credits are consumed depends on how the agent run is triggered and authentic
 **User-triggered runs** (CLI with personal API key, Slack, Linear, or the Warp app):
 
 * Runs are tied to the triggering user's identity
-* Credits are consumed starting with any credit grants specifically allocated for cloud agent usage, then the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits
+* Credits are consumed starting with any credit grants specifically allocated for cloud agent usage, then the user's base credits, followed by the team's Add-on Credits, and finally the user's own Add-on Credits
 
 **Team API key runs** (fully automated or headless workflows):
 
 * Runs are not tied to any individual user
-* Only the team's Reload Credit pool is used—no individual base credits are available
+* Only the team's Add-on Credit pool is used—no individual base credits are available
 * Ideal for CI/CD pipelines, scheduled tasks, and other automated workflows
 * For workflows that require code changes (opening pull requests, pushing branches, or writing to a repository), configure [team GitHub authorization](#team-github-authorization) so the agent can authenticate with the Oz by Warp GitHub App. Alternatively, use a [personal API key](/reference/cli/api-keys/) to authenticate as an individual user.
 
@@ -236,7 +236,7 @@ All triggers and instructions used by cloud agents are defined and controlled by
 
 #### Staying aware of usage
 
-Because triggers and instructions are configured by your team, any credits used when an agent runs are billed to your team's Reload Credit balance.
+Because triggers and instructions are configured by your team, any credits used when an agent runs are billed to your team's Add-on Credit balance.
 
 * It’s the team’s responsibility to manage triggers, confirm they behave as intended, and monitor usage.
 * Reviewing triggers, prompts, and agent behavior periodically helps ensure that credit usage aligns with expectations.


### PR DESCRIPTION
Comprehensive content audit of the `hyc/orchestration-launch` branch to catch issues that the wiring-focused audit in #97 left behind. 10 files changed, +25 / \u221226.

## Factual corrections

- **`agents.mdx`**:
  - Drop `getAgent` from the operationId list and remove the **Retrieve** \u2014 `GET /agent/identities/{uid}` bullet. The OpenAPI spec only ships `createAgent` / `listAgents` / `updateAgent` / `deleteAgent` under `/agent/identities`; there is no single-resource GET.
  - Replace "pass the identity's UID to the `generateApiKey` mutation" with "choose the identity when creating the team API key". No `generateApiKey` mutation exists in the spec; `api-keys.mdx` documents a UI-driven creation flow.
  - Drop the "(\"Quick run\" in the web app)" parenthetical from the default-identity fallback note. `oz-web-app.mdx` defines Quick run as user-attributed ("runs as your own user"), so equating it with the default agent identity contradicts the rest of the docs.

## Terminology unification (post three-bucket / agents-launch model)

- **`harnesses/index.mdx`, `claude-code.mdx`, `codex.mdx`** \u2014 replace the vague "Warp credits cover the orchestration platform" wording with the explicit three-bucket framing: "Warp meters compute credits for the run's sandbox and platform credits for the orchestration layer."
- **`team-access-billing-and-identity.mdx`** \u2014 rename every `Reload Credits` / `Reload Credit pool` / `Reload Credit balance` reference to the canonical `Add-on Credits` (5 spots, including the legacy parenthetical `[Reload Credits (Add-on Credits)](...)`).
- **`oz-web-app.mdx`** \u2014 rename the page title and 6 image alt texts from "Oz Web App" (Title Case) to "Oz web app" to match the canonical glossary entry and the sidebar label.

## Style guide cleanup

- **`secrets.mdx`** \u2014 drop a trailing `&#x20;` GitBook artifact, replace "just references it by name" with "only references it by name", and backtick the bare `oz secret` in "oz secret command family".
- **`harnesses/authentication.mdx`** \u2014 replace "just like any other Warp-managed secret" with "like any other Warp-managed secret".
- **`deployment-patterns.mdx`** \u2014 drop "just" from "and you just need a reliable, cloud-connected agent runner".
- **`cloud-agents/overview.mdx`** \u2014 lowercase two H4 headings (`For Cloud Agents via CLI/API` \u2192 `For cloud agents via CLI/API`; `For Integrations (Slack/Linear)` \u2192 `For integrations (Slack/Linear)`) per the sentence-case style guide.

## Validation

- `check_links --internal-only`: **0 broken** across **2,501 internal links** (up 6 from the 2,495 baseline; the additions are the new `#compute-credits` and `/platform-credits/` anchors in the three harnesses billing sections).
- `style_lint --changed`: only pre-existing proper-name false positives in `pricing-faqs.mdx` (Build / Business / Pro / Turbo / Lightspeed / Add-on Credits headings).
- `npm run build`: **326 pages built**; sidebar compiles; new anchor and slug references resolve.

## Out of scope

- The audit kept its diff to files already on `hyc/orchestration-launch` and the new pages it adds. Pre-existing `&#x20;` artifacts in `environments.mdx` and "Oz Web App" alt text in `skills-as-agents.mdx` / `environments.mdx` are unrelated; leaving for a separate cleanup.
- The three open feature branches into `hyc/orchestration-launch` (#84 multi-agent, #85 handoff, #86 Memory) are untouched.

Co-Authored-By: Oz <oz-agent@warp.dev>