### PR TITLE
Audit pass 3: Memory + Handoff polish, cross-references, glossary entries

### DIFF
--- a/.agents/references/terminology.md
+++ b/.agents/references/terminology.md
@@ -93,6 +93,15 @@ For the summary of the most critical terms (core features, Oz terms, terms to av
 
 - **Slash Commands** — Built-in commands you run by typing `/` to trigger actions (or run saved prompts).
 
+- **Agent Memory** — Oz's persistent, cross-harness memory layer that lets agents read and write durable knowledge across conversations, harnesses, and devices. Currently in research preview.
+  *Usage note:* Capitalize as a feature name. Lowercase "memory" only when describing the generic concept (e.g., "the memory layer").
+
+- **memory store** — A named collection of memories owned by a user (personal) or team. Multiple agents can share a store, and per-agent attachments control read/write access.
+  *Usage note:* Lowercase common noun. Capitalize the first letter only at the start of a sentence or bullet.
+
+- **Handoff** — The feature for moving an agent's work between a local Warp session and the cloud, or continuing a finished cloud run. Supports local-to-cloud, cloud-to-cloud, and cloud-to-local directions.
+  *Usage note:* Capitalize as a feature name. Use lowercase "hand off" / "handed off" only as a verb.
+
 ## Coding terms (Warp features)
 
 - **Code** — Warp's coding experience for agent-assisted changes (editing, diffs, code review).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -558,6 +558,8 @@ Product feature names retain their standard capitalization. Match the exact casi
 - **Codebase Context** - Warp indexes your Git-tracked codebase to help Agents understand your code.
 - **Admin Panel** - Team management surface for controlling members, roles, and billing.
 - **Agent Management Panel** - Interface for viewing and managing running agents (not "agent dashboard" or "agent manager").
+- **Agent Memory** - Persistent, cross-harness memory layer for Oz agents that captures durable facts, decisions, and outcomes across conversations (currently in research preview). Capitalize as a feature name; use lowercase "memory store" for individual stores.
+- **Handoff** - Feature for moving agent work between a local Warp session and the cloud, or continuing a finished cloud run; supports local-to-cloud, cloud-to-cloud, and cloud-to-local. Capitalize as a feature name; lowercase "hand off" only as a verb.
 
 ### Oz terminology
 

--- a/src/content/docs/agent-platform/agent-memory/index.mdx
+++ b/src/content/docs/agent-platform/agent-memory/index.mdx
@@ -4,7 +4,7 @@ description: >-
   Agent Memory is a persistent, cross-harness memory layer for agents in
   Oz, including the Warp Agent, Claude Code, and Codex.
 sidebar:
-  label: "Agent Memory"
+  label: "Agent Memory (Research Preview)"
 ---
 :::caution
 Agent Memory is in **research preview** and is enabled per team for design partners. [Join the waitlist](https://warp.dev/oz/agent-memory#waitlist) to request access for your team.

--- a/src/content/docs/agent-platform/agent-memory/index.mdx
+++ b/src/content/docs/agent-platform/agent-memory/index.mdx
@@ -4,7 +4,7 @@ description: >-
   Agent Memory is a persistent, cross-harness memory layer for agents in
   Oz, including the Warp Agent, Claude Code, and Codex.
 sidebar:
-  label: "Agent Memory (Research Preview)"
+  label: "Agent Memory"
 ---
 :::caution
 Agent Memory is in **research preview** and is enabled per team for design partners. [Join the waitlist](https://warp.dev/oz/agent-memory#waitlist) to request access for your team.

--- a/src/content/docs/agent-platform/capabilities/skills.mdx
+++ b/src/content/docs/agent-platform/capabilities/skills.mdx
@@ -411,7 +411,7 @@ Warp maintains a public collection of ready-to-use skills in the [warpdotdev/oz-
 
 These same skills also appear as suggested agents in the [Oz web app](/agent-platform/cloud-agents/oz-web-app/), where you can run them directly in the cloud.
 
-## Suggested Skills from Agent Memory
+## Suggested skills from Agent Memory
 
 Promoting recurring patterns from [Agent Memory](/agent-platform/agent-memory/) into reviewable skill drafts is in design as part of the research preview. See the Agent Memory page for current status.
 

--- a/src/content/docs/agent-platform/cloud-agents/handoff/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/handoff/index.mdx
@@ -27,7 +27,7 @@ Handoff coverage depends on which agent is running the conversation:
 
 ## What carries over
 
-Handoff preserves enough state that the receiving agent can resume the work, not just read about it.
+Handoff preserves enough state that the receiving agent can resume the work, not only read about it.
 
 * **Conversation history** - The receiving agent sees the full transcript of the prior session. Local-to-cloud forks the conversation so the source isn't modified; cloud-to-cloud continues in the same conversation.
 * **Workspace state** - Local-to-cloud and cloud-to-cloud capture the prior session's repository changes (tracked and untracked) and apply them in the receiving run before the agent answers the next prompt. The cloud-to-local direction doesn't currently apply workspace patches to your local checkout; review the cloud agent's branch or pull request artifact to inspect those changes.

--- a/src/content/docs/agent-platform/cloud-agents/managing-cloud-agents.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/managing-cloud-agents.mdx
@@ -99,3 +99,10 @@ In both _Personal_ and _All_ views, you can open the filter menu and filter by:
 * Status
 
 This is the fastest way to isolate "everything that failed today," "runs from Slack," or "what a specific teammate triggered via integrations."
+
+## Related pages
+
+* [Cloud agents overview](/agent-platform/cloud-agents/overview/) — What cloud agents are and when to use them.
+* [Viewing cloud agent runs](/agent-platform/cloud-agents/viewing-cloud-agent-runs/) — Open and inspect a remote cloud agent run.
+* [Handoff between local and cloud agents](/agent-platform/cloud-agents/handoff/) — Move agent work between local and cloud, or continue a finished cloud run.
+* [Oz web app](/agent-platform/cloud-agents/oz-web-app/) — Manage runs and schedules from any browser.

--- a/src/content/docs/agent-platform/cloud-agents/viewing-cloud-agent-runs.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/viewing-cloud-agent-runs.mdx
@@ -71,6 +71,8 @@ If you still want to continue the conversation or work on the code, you can clic
 
 #### 5. Fork the session to your local Warp
 
+Forking is the cloud-to-local direction of [Handoff between local and cloud agents](/agent-platform/cloud-agents/handoff/) — see that page for the other directions (local-to-cloud and cloud-to-cloud).
+
 Forking brings the cloud agent conversation into your local machine, so you can pick up where the agent left off.
 
 Once forked:

--- a/src/content/docs/agent-platform/local-agents/cloud-conversations.mdx
+++ b/src/content/docs/agent-platform/local-agents/cloud-conversations.mdx
@@ -136,3 +136,4 @@ When you delete a conversation, it is removed permanently and immediately. Make 
 * [Conversation Forking](/agent-platform/local-agents/interacting-with-agents/conversation-forking/) - Branch conversations to explore different directions.
 * [Session Sharing](/agent-platform/local-agents/session-sharing/) - Collaborate in real time on a live Agent session.
 * [Cloud Agents Overview](/agent-platform/cloud-agents/overview/) - Run agents in the cloud from triggers, schedules, or integrations.
+* [Handoff between local and cloud agents](/agent-platform/cloud-agents/handoff/) - Promote a local conversation to a cloud agent run, or continue a finished cloud run.


### PR DESCRIPTION
Final audit pass over `hyc/orchestration-launch` before the rollout PR. Covers the deltas from #86 (Agent Memory research preview) and #85 (local\u2194cloud handoff) that landed after audit pass 2. 8 files changed, +24 / \u22123.

## Changes

**Sentence-case fix (clears the one new style-lint warning):**
- `capabilities/skills.mdx:414` \u2014 `## Suggested Skills from Agent Memory` \u2192 `## Suggested skills from Agent Memory`. The section body refers to "reviewable **skill** drafts" (lowercase common noun), so the heading now matches.

**Dead frontmatter:**
- `agent-platform/agent-memory/index.mdx` \u2014 drop the `(Research Preview)` suffix from the frontmatter `sidebar.label`. `sidebar.ts` already overrides it to `Agent Memory` under a group named `Memory (Research Preview)`; the duplicate annotation was dead config.

**Cross-link gaps from neighboring pages \u2014 new pages linked out, but the existing pages didn't link back:**
- `cloud-agents/viewing-cloud-agent-runs.mdx` (the \u201C5. Fork the session to your local Warp\u201D section): add a one-line reference to the Handoff overview so the cloud-to-local direction is discoverable from the broader doc.
- `cloud-agents/managing-cloud-agents.mdx`: add a \u201CRelated pages\u201D section linking to the Handoff overview alongside cloud-agents overview, viewing-cloud-agent-runs, and oz-web-app.
- `local-agents/cloud-conversations.mdx` (Related features): add a link to the Handoff overview, since handoff relies on cloud-synced conversations.

**Style (consistency with audit pass 2):**
- `cloud-agents/handoff/index.mdx:30` \u2014 \u201Cthe receiving agent can resume the work, not just read about it\u201D \u2192 \u201C\u2026not only read about it.\u201D

**Glossary additions:**
- `.agents/references/terminology.md` (Agent concepts) and `AGENTS.md` (Core features) \u2014 canonical entries for the launch terms:
  - **Agent Memory** (Title Case as feature; lowercase "memory" only for the generic concept)
  - **memory store** (lowercase common noun)
  - **Handoff** (Title Case as feature; lowercase "hand off" / "handed off" as the verb)

## Validation
- `check_links --internal-only`: 0 broken across **2,543** internal links (up 6 from the 2,537 baseline, matching the 6 new cross-refs).
- `style_lint --changed`: **14 warnings (one fewer than baseline)** \u2014 the new `Suggested Skills\u2026` heading is no longer flagged. The remaining 14 are all pre-existing proper-name false positives in pricing-faqs / add-on-credits / BYOK / Slack-Linear integration headers.
- `npm run build`: **330 pages built**; sidebar resolves all slugs; the `#5-fork-the-session-to-your-local-warp` anchor reference resolves.

## Out of scope
- The `&` hotkey in `handoff/local-to-cloud.mdx:39` is potentially ambiguous (literal `&` vs `Shift+7`); needs product verification.
- Dash style varies between memory (em-dash) and handoff (hyphen) bullet definitions. Both are permitted by the style guide; each page is internally consistent.
- Adding Agent Memory cross-links to the three harness pages was intentionally skipped \u2014 the Memory page itself documents the cross-harness behavior, and pushing it into each harness page risks duplicate maintenance.
- 14 pre-existing proper-name lint warnings unrelated to this drop.

Co-Authored-By: Oz <oz-agent@warp.dev>