### PR TITLE
Move Memory (Research Preview) to bottom of Agents tab sidebar

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -247,12 +247,6 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 					],
 				},
 				{
-					label: 'Memory (Research Preview)',
-					items: [
-						{ slug: 'agent-platform/agent-memory', label: 'Agent Memory' },
-					],
-				},
-				{
 					label: 'Warp Agents',
 					items: [
 						{ slug: 'agent-platform/local-agents/overview', label: 'Warp Agents overview' },
@@ -403,6 +397,12 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 						},
 						{ slug: 'agent-platform/cloud-agents/team-access-billing-and-identity', label: 'Access, billing, and identity' },
 						{ slug: 'agent-platform/cloud-agents/faqs', label: 'Cloud agent FAQs' },
+					],
+				},
+				{
+					label: 'Memory (Research Preview)',
+					items: [
+						{ slug: 'agent-platform/agent-memory', label: 'Agent Memory' },
 					],
 				},
 			],


### PR DESCRIPTION
Reorders the Agents tab so the **Memory (Research Preview)** section sits at the bottom (right after **Oz Cloud Agents & Orchestration**) instead of in the #2 slot above **Warp Agents**. Matches the visual hierarchy of stable content first, research-preview content last.

Before:
1. Getting started
2. Memory (Research Preview) ← was here
3. Warp Agents
4. Third-Party CLI Agents
5. Oz Cloud Agents & Orchestration

After:
1. Getting started
2. Warp Agents
3. Third-Party CLI Agents
4. Oz Cloud Agents & Orchestration
5. Memory (Research Preview) ← now here

Validation: `npm run build` → 330 pages built cleanly.

Co-Authored-By: Oz <oz-agent@warp.dev>