### PR TITLE
docs(audit): tier 1 — terminology drift + orchestration cross-link

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -146,6 +146,7 @@ If your credit balance reaches zero, cloud agent runs will not be able to execut
 * [Oz Platform](/agent-platform/cloud-agents/platform/) — CLI, Oz API/SDK, orchestration, tasks, environments, hosts, integrations, and more.
 * [Harnesses](/agent-platform/cloud-agents/harnesses/) — pick between Warp Agent, Claude Code, and Codex for any cloud agent run.
 * [Agent identities](/agent-platform/cloud-agents/agents/) — team-scoped bot accounts that own and execute cloud agent runs.
+* [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/) — coordinate a parent agent and its child agents across local and cloud runs to build supervisor/worker, fan-out, critic, DAG, and swarm workflows.
 * [Skills as Agents](/agent-platform/cloud-agents/skills-as-agents/) — run agents based on reusable skill definitions from the CLI, web app, API, or on a schedule.
 * [Oz CLI](/reference/cli/) — shows how to run agents in non-interactive mode from CI, scripts, or remote machines, including auth and common commands.
 * [Environments](/agent-platform/cloud-agents/environments/) — explains how environments provide the runtime context (repo, image, startup commands) for agent tasks.

--- a/src/content/docs/agent-platform/cloud-agents/warp-hosting.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/warp-hosting.mdx
@@ -1,12 +1,12 @@
 ---
 title: Warp-hosted agents
 description: >-
-  Run Oz cloud agents on Warp's infrastructure. Warp handles scaling, isolation, and performance for agent execution.
+  Run cloud agents on Warp's infrastructure. Warp handles scaling, isolation, and performance for agent execution.
 sidebar:
   label: "Warp-hosted agents"
 ---
 
-Warp's managed infrastructure lets your team easily run Oz cloud agent workloads in fast and secure sandboxes.
+Warp's managed infrastructure lets your team run cloud agent workloads in fast, secure sandboxes.
 
 Use Warp-hosted agents to quickly get started with Oz, without needing to configure compute resources or maintain services. 
 

--- a/src/content/docs/enterprise/enterprise-features/analytics-api.mdx
+++ b/src/content/docs/enterprise/enterprise-features/analytics-api.mdx
@@ -136,7 +136,7 @@ In the grouped response, every leaf array is the same length as `period_list`, a
 
 ### `GET /api/v1/enterprises/analytics/users`
 
-Returns per-user aggregated usage, split into `local` (Warp app) and `cloud` (Oz cloud agents) sections. Results are paginated.
+Returns per-user aggregated usage, split into `local` (Warp app) and `cloud` (cloud agents) sections. Results are paginated.
 
 **Query parameters:**
 

--- a/src/content/docs/guides/agent-workflows/warp-for-product-managers.mdx
+++ b/src/content/docs/guides/agent-workflows/warp-for-product-managers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "5 AI agent workflows for product managers"
+title: "5 agent workflows for product managers"
 description: >-
   Five agent workflows that automate status updates, documentation, Slack search,
   and meeting prep for product managers.

--- a/src/content/docs/reference/cli/artifacts.mdx
+++ b/src/content/docs/reference/cli/artifacts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Artifacts
 description: >-
-  Get metadata for and download files produced by an Oz agent run using the
+  Get metadata for and download files produced by an agent run using the
   `oz artifact` subcommands.
 sidebar:
   label: "Artifacts"

--- a/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
+++ b/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
@@ -114,9 +114,9 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `AgentManagement.ConversationOpened` | User opened a conversation |
 | `AgentManagement.DetailsPanelContinueLocally` | User clicked Continue locally in the details panel |
 | `AgentManagement.DetailsViewed` | User clicked View details |
-| `AgentManagement.DismissSetupGuide` | User dismissed the ambient agent setup guide |
+| `AgentManagement.DismissSetupGuide` | User dismissed the cloud agent setup guide |
 | `AgentManagement.FilterChanged` | User changed a filter in the management view |
-| `AgentManagement.OpenSetupGuide` | User opened the ambient agent setup guide |
+| `AgentManagement.OpenSetupGuide` | User opened the cloud agent setup guide |
 | `AgentManagement.SessionLinkCopied` | User copied a session link |
 | `AgentManagement.SetupGuideDocsLink` | User clicked a docs URL in the setup guide |
 | `AgentManagement.SetupGuideStepCopy` | User copied a workflow step from the setup guide |
@@ -178,7 +178,7 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `AmbientAgent.ConcurrencyModal.Dismissed` | User dismissed the cloud agent capacity modal |
 | `AmbientAgent.ConcurrencyModal.Opened` | User opened the cloud agent capacity modal |
 | `AmbientAgent.ConcurrencyModal.UpgradeClicked` | User clicked the upgrade button in the cloud agent capacity modal |
-| `AmbientAgent.DispatchFailed` | Ambient agent failed to dispatch or encountered an error |
+| `AmbientAgent.DispatchFailed` | Cloud agent failed to dispatch or encountered an error |
 | `AmbientAgent.EnvironmentSettings.CreatedEnvironment` | User created a new environment |
 | `AmbientAgent.EnvironmentSettings.DeletedEnvironment` | User deleted an environment |
 | `AmbientAgent.EnvironmentSettings.Image.Suggested` | Docker image was suggested for an environment |
@@ -214,7 +214,7 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `CLI.Execute.Agent.List` | Listed agents from the Warp CLI |
 | `CLI.Execute.Agent.Profile.List` | Listed agent profiles from the Warp CLI |
 | `CLI.Execute.Agent.Run` | Ran an agent from the Warp CLI |
-| `CLI.Execute.Agent.RunAmbient` | Ran an ambient agent from the Warp CLI |
+| `CLI.Execute.Agent.RunAmbient` | Ran a cloud agent from the Warp CLI |
 | `CLI.Execute.Artifact.Download` | Downloaded an artifact from the Warp CLI |
 | `CLI.Execute.Artifact.Get` | Got artifact metadata from the Warp CLI |
 | `CLI.Execute.Artifact.Upload` | Uploaded an artifact from the Warp CLI |


### PR DESCRIPTION
Post-orchestration-launch audit, pass 1: clear the OZ-TERM and ambient-agent terminology drift that slipped through #68 + add a missing cross-link to the new #84 orchestration pages.

## Changes

### Stale 'Oz cloud agent' / 'Oz agent' prefixes
- `agent-platform/cloud-agents/warp-hosting.mdx:4,9` — frontmatter description + body. Also drops the ableist 'easily' per AGENTS.md style guide.
- `enterprise/enterprise-features/analytics-api.mdx:139` — 'cloud (Oz cloud agents)' → 'cloud (cloud agents)'.
- `reference/cli/artifacts.mdx:4` — 'produced by an Oz agent run' → 'by an agent run'.

### Retired 'ambient agent' terminology
- `support-and-community/privacy-and-security/privacy.mdx` (4×, telemetry-table descriptions L117, L119, L181, L217) — 'ambient agent' → 'cloud agent'. **Event names in the left column (AmbientAgent.*, CLI.Execute.Agent.RunAmbient) are unchanged** since they're emitted by product code.

### Redundant 'AI agent' prefix
- `guides/agent-workflows/warp-for-product-managers.mdx:2` — title '5 AI agent workflows…' → '5 agent workflows…'.

### Cross-link gap
- `agent-platform/cloud-agents/overview.mdx` — Learn more list was missing a link to Multi-agent orchestration (added after #84 landed).

## Out of scope (handled by in-flight PRs)
- `self-hosting/unmanaged.mdx` is being edited by **PR #105** (snapshot-declarations); its 2 remaining OZ-TERM warnings will be fixed there.
- All fast-follow handoff/agent-memory polish is happening on **PR #104**.

## Validation
- check_for_broken_links: 0 broken / 2577 internal links
- style_lint: 11 → 2 OZ-TERM warnings (drop of 9)
- npm run build: 332 pages built clean

Subsequent audit passes (casing sweep, blocklist→denylist) will follow as separate PRs.

Co-Authored-By: Oz <oz-agent@warp.dev>