### PR TITLE
docs(audit): tier 2/3/5 — feature-name + Github casing sweep

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/deployment-patterns.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/deployment-patterns.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deployment Patterns
+title: Deployment patterns
 description: >-
   Common architectures for deploying cloud agents, including CLI-only,
   Oz-hosted, and self-hosted execution patterns.

--- a/src/content/docs/agent-platform/cloud-agents/faqs.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/faqs.mdx
@@ -57,7 +57,7 @@ Yes. Cloud agent runs execute in a full Linux environment and behave like a loca
 
 The cloud agents platform supports self-hosting the **agent sandbox** (the execution environment) on your own infrastructure. The **control plane**—which handles orchestration, tracking, and auditability—remains Warp-managed and is not self-hosted.
 
-Self-hosted execution is available on **Enterprise** plans. See [Self-Hosting](/agent-platform/cloud-agents/self-hosting/) and [Deployment Patterns](/agent-platform/cloud-agents/deployment-patterns/) for details.
+Self-hosted execution is available on **Enterprise** plans. See [Self-hosting](/agent-platform/cloud-agents/self-hosting/) and [Deployment patterns](/agent-platform/cloud-agents/deployment-patterns/) for details.
 
 :::note
 [Bring Your Own Key (BYOK)](/support-and-community/plans-and-billing/bring-your-own-api-key/) does not apply to cloud agents. BYOK keys are stored locally on your device and cannot be passed to cloud-hosted or self-hosted agent runs. All cloud agent runs consume [Warp credits](/support-and-community/plans-and-billing/credits/).
@@ -203,7 +203,7 @@ With self-hosting, repositories are cloned and stored only on your infrastructur
 * **Execution plane (your infrastructure)** — Repository clones, build artifacts, runtime secrets, and container filesystem state stay on the machines you control.
 * **Control plane (Warp-hosted)** — Session transcripts (which include code context from agent interactions), orchestration metadata, and LLM inference route through Warp's backend under [Zero Data Retention (ZDR)](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr) agreements. Warp does not persistently store your source code or use it for model training.
 
-See [Self-Hosting](/agent-platform/cloud-agents/self-hosting/) for deployment options and [Security Overview](/enterprise/security-and-compliance/security-overview/) for full details.
+See [Self-hosting](/agent-platform/cloud-agents/self-hosting/) for deployment options and [Security Overview](/enterprise/security-and-compliance/security-overview/) for full details.
 
 ### Can I use `oz agent run` in CI or existing runners?
 
@@ -226,7 +226,7 @@ Yes. LLM inference routes through Warp's backend, which has [Zero Data Retention
 The [unmanaged architecture](/agent-platform/cloud-agents/self-hosting/unmanaged/) is well-suited for large monorepos because agents run directly in your pre-provisioned environment — there is no Docker image build or repo cloning step. For the [managed architecture](/agent-platform/cloud-agents/self-hosting/#managed-architecture), the Docker backend supports volume mounts (`-v` flag) to mount a pre-existing repo checkout from the host into task containers. With the Kubernetes backend, use `pod_template` to configure persistent volume claims or pre-populated storage for the same purpose.
 
 :::note
-The managed architecture supports three execution backends: **Docker** (default), **Kubernetes**, and **Direct** (no container runtime). The Kubernetes backend runs each task as a Kubernetes Job and includes a Helm chart for deployment. See [Self-Hosting](/agent-platform/cloud-agents/self-hosting/#choosing-a-managed-backend) for details on choosing a backend.
+The managed architecture supports three execution backends: **Docker** (default), **Kubernetes**, and **Direct** (no container runtime). The Kubernetes backend runs each task as a Kubernetes Job and includes a Helm chart for deployment. See [Self-hosting](/agent-platform/cloud-agents/self-hosting/#choosing-a-managed-backend) for details on choosing a backend.
 :::
 
 ### Do Kubernetes pods provide enough sandboxing for self-hosted agents?

--- a/src/content/docs/agent-platform/cloud-agents/managing-cloud-agents.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/managing-cloud-agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: Managing Cloud Agents
+title: Managing cloud agents
 description: >-
   Monitor and manage cloud agent activity across your team with Warp's
   centralized management view, including filtering, status tracking, and

--- a/src/content/docs/agent-platform/cloud-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/overview.mdx
@@ -57,7 +57,7 @@ Cloud agents run on the [Oz Platform](/agent-platform/cloud-agents/platform/), w
 
 The exact way tasks are triggered and executed depends on your deployment model (for example CLI-only, Warp-hosted orchestration, or self-hosted execution). Those options are covered in the [Deployment Patterns](/agent-platform/cloud-agents/deployment-patterns/) pages.
 
-For teams that need execution to stay within their network boundary, self-hosting supports two architectures: a **managed** worker daemon that lets Oz orchestrate agents in Docker containers on your machines, and an **unmanaged** mode where you run `oz agent run` directly in your CI, Kubernetes, or dev environment. See [Self-Hosting](/agent-platform/cloud-agents/self-hosting/) for details.
+For teams that need execution to stay within their network boundary, self-hosting supports two architectures: a **managed** worker daemon that lets Oz orchestrate agents in Docker containers on your machines, and an **unmanaged** mode where you run `oz agent run` directly in your CI, Kubernetes, or dev environment. See [Self-hosting](/agent-platform/cloud-agents/self-hosting/) for details.
 
 ### What you get by default
 

--- a/src/content/docs/agent-platform/cloud-agents/platform.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/platform.mdx
@@ -185,7 +185,7 @@ With self-hosting:
 * This is used when teams want code and execution to remain on their own systems rather than being cloned or executed in Warp's cloud.
 
 :::note
-**Enterprise feature**: Self-hosted execution requires an Enterprise plan. See [Self-Hosting](/agent-platform/cloud-agents/self-hosting/) for setup instructions.
+**Enterprise feature**: Self-hosted execution requires an Enterprise plan. See [Self-hosting](/agent-platform/cloud-agents/self-hosting/) for setup instructions.
 :::
 
 ---

--- a/src/content/docs/code/overview.mdx
+++ b/src/content/docs/code/overview.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 import VideoEmbed from '@components/VideoEmbed.astro';
 
-Warp's coding features help you go from prompt to production. They combine a dedicated coding agent — consistently ranked among the top on SWE-bench Verified — with a native code editor, inline diff review, codebase context, and project-level rules for accurate, context-aware code generation.
+Warp's coding features help you go from prompt to production. They combine a dedicated coding agent — consistently ranked among the top on SWE-bench Verified — with a native code editor, inline diff review, Codebase Context, and project-level rules for accurate, context-aware code generation.
 
 :::note
 On macOS and Linux SSH sessions, Warp's [SSH extension](/terminal/warpify/ssh/#installing-the-ssh-extension) brings the file tree, native file reads, and native code diffs to remote hosts. See [Feature support over SSH](/code/ssh-feature-support/) for the current support matrix.

--- a/src/content/docs/enterprise/getting-started/getting-started-enterprise.mdx
+++ b/src/content/docs/enterprise/getting-started/getting-started-enterprise.mdx
@@ -163,7 +163,7 @@ Once your team is set up:
 * **Agent Profiles** - Configure default [Agent Profiles](/agent-platform/capabilities/agent-profiles-permissions/) for different types of work to give teams appropriate autonomy and control
 * **BYOLLM** - Set up [Bring Your Own LLM](/enterprise/enterprise-features/bring-your-own-llm/) to route inference through your cloud infrastructure for data locality and cost control
 * **Monitor usage** - Review usage analytics in the Admin Panel to track adoption and measure engineering productivity gains
-* **Self-hosting** - Run agents on your own infrastructure to control where agents run and keep repository clones on your own machines. See [Self-Hosting](/agent-platform/cloud-agents/self-hosting/) for setup instructions
+* **Self-hosting** - Run agents on your own infrastructure to control where agents run and keep repository clones on your own machines. See [Self-hosting](/agent-platform/cloud-agents/self-hosting/) for setup instructions
 
 ## Troubleshooting
 

--- a/src/content/docs/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-analyze-pr-modify-ui.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-analyze-pr-modify-ui.mdx
@@ -49,7 +49,7 @@ In the demo, we run three parallel workflows:
        Analyze how many pull requests a team member has assigned.
 
            ```
-       Use the Github CLI tool to summarize all open PRs for review that are assigned to user. I'd like to see who is the author of the PR, when was it opened, how long has it been open for, which repo is it in, are there open an dunaddressed commens on it, and is it ready for review?
+       Use the GitHub CLI tool to summarize all open PRs for review that are assigned to user. I'd like to see who is the author of the PR, when was it opened, how long has it been open for, which repo is it in, are there open an dunaddressed commens on it, and is it ready for review?
        ```
        </TabItem>
      <TabItem label="Log Analysis">

--- a/src/content/docs/guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-railway.mdx
+++ b/src/content/docs/guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-railway.mdx
@@ -1,5 +1,5 @@
 ---
-title: Building a Real-time Chat App (Github MCP + Railway )
+title: Building a Real-time Chat App (GitHub MCP + Railway)
 description: >-
   Build and deploy a real-time chat app with Python, FastAPI, and JavaScript —
   from idea to production, all inside Warp.
@@ -229,6 +229,6 @@ The project: a **real-time chat application** built with **Python (FastAPI)** an
 
 ### Appendix
 
-* [Github MCP Server](https://github.com/github/github-mcp-server)
+* [GitHub MCP Server](https://github.com/github/github-mcp-server)
 * [Docker Desktop download](https://www.docker.com/products/docker-desktop/)
 * [Railway](https://railway.com/)

--- a/src/content/docs/guides/external-tools/github-mcp-summarizing-open-prs-and-creating-gh-issues.mdx
+++ b/src/content/docs/guides/external-tools/github-mcp-summarizing-open-prs-and-creating-gh-issues.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Github MCP: Summarizing Open PRs & Creating GH Issues"
+title: "GitHub MCP: Summarizing Open PRs & Creating GH Issues"
 description: >-
   Connect the GitHub MCP server to Warp to summarize open PRs, create issues
   from TODO comments, and automate repo management.

--- a/src/content/docs/reference/api-and-sdk/troubleshooting/errors/operation-not-supported.mdx
+++ b/src/content/docs/reference/api-and-sdk/troubleshooting/errors/operation-not-supported.mdx
@@ -55,5 +55,5 @@ This error is returned when:
 ## Related
 
 * [Cloud Agents Overview](/agent-platform/cloud-agents/overview/) — How cloud agent tasks work
-* [Self-Hosting](/agent-platform/cloud-agents/self-hosting/) — Self-hosted agent configuration
+* [Self-hosting](/agent-platform/cloud-agents/self-hosting/) — Self-hosted agent configuration
 * [Oz API & SDK](/reference/api-and-sdk/) — API reference for managing agent tasks

--- a/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
+++ b/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
@@ -102,7 +102,7 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `Agent Mode Setup Banner Accepted` | Agent Mode setup banner accepted |
 | `Agent Mode Setup Banner Dismissed` | Agent Mode setup banner dismissed |
 | `Agent Mode Setup Project Scoped Rules Action` | User clicked a button in the Agent Mode setup project scoped rules step |
-| `Agent Mode.Setup Codebase Context Action` | User clicked a button in the Agent Mode setup codebase context step |
+| `Agent Mode.Setup Codebase Context Action` | User clicked a button in the Agent Mode setup Codebase Context step |
 | `Agent Predict` | Completed an Agent Predict prediction |
 | `Agent Toolbar Dismissed` | User dismissed the use-agent toolbar |
 | `AgentManagement.AgentTypeSelectorOpened` | User opened the agent type selector from agent management |
@@ -144,7 +144,7 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `AgentMode.Code.SuggestedEditAcceptClicked` | User selected Accept for a code diff suggestion in Agent Mode |
 | `AgentMode.Code.SuggestedEditReceived` | Agent Mode suggested a code edit |
 | `AgentMode.Code.SuggestedEditResolved` | Agent Mode pending code edit suggestion resolved |
-| `AgentMode.CreatedAIBlock` | Created an AI block in agent mode |
+| `AgentMode.CreatedAIBlock` | Created an AI block in Agent Mode |
 | `AgentMode.Error` | Received an error when getting Agent Mode response |
 | `AgentMode.ExecutedWarpDrivePrompt` | Executed a saved prompt. |
 | `AgentMode.ExitedShellProcess` | An agent-requested command caused the shell process to exit |
@@ -153,7 +153,7 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `AgentMode.Grep.Failed` | The grep tool failed to complete |
 | `AgentMode.Grep.Succeeded` | The grep tool completed successfully |
 | `AgentMode.NaturalLanguageDetection.InputBufferSubmitted` | Input buffer submitted |
-| `AgentMode.OpenedCitation` | Opened a citation that was surfaced in agent mode |
+| `AgentMode.OpenedCitation` | Opened a citation that was surfaced in Agent Mode |
 | `AgentMode.Orchestration.TeamAgentCommunicationFailed` | Failed to send an orchestration message or lifecycle event for a TeamAgent |
 | `AgentMode.PotentialAutoDetectionFalsePositive` | Manually toggled input to shell mode after input was auto-detected as natural language. |
 | `AgentMode.QueryAttemptAtLImit` | Tried to send an Agent Mode query but they already reached the query limit |
@@ -304,8 +304,8 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `CodexModal.UseCodexClicked` | User clicked 'Use Codex' in the Codex modal |
 | `Command Correction Event` | Accepted command correction |
 | `Command File Run` | Opened a .cmd or unix executable file and ran it directly in Warp |
-| `Command Palette Search Accepted` | Accepted a command palette search result |
-| `Command Palette Search Exited` | Exited command palette search without accepting a result |
+| `Command Palette Search Accepted` | Accepted a Command Palette search result |
+| `Command Palette Search Exited` | Exited Command Palette search without accepting a result |
 | `Command Search Async Query Completed` | Finished searching for a command in the background |
 | `Command Search Exited` | Exited command search (universal search panel to search) without accepting a result |
 | `Command Search Filter Changed` | Changed command search filter |
@@ -510,7 +510,7 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `SSH Tmux Warpify Block Dismissed` | User dismissed an ssh tmux warpify block |
 | `Save Launch Config` | Saved current launch configuration of windows, tabs, and panes |
 | `Select App Icon` | Selected app icon |
-| `Select Command Palette Option` | Selected option from command palette (i.e. CMD-P) |
+| `Select Command Palette Option` | Selected option from Command Palette (i.e. CMD-P) |
 | `Select Cursor Type` | Selected cursor type |
 | `Select Navigation Palette Item` | Selected session from the Session Navigation Palette (search across panes, tabs, and windows) |
 | `Select Theme` | Selected theme |
@@ -561,7 +561,7 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `Thin Strokes Setting Changed` | Changed thin strokes setting in settings -> Appearance |
 | `Tier Limit Hit` | User hit the tier limit for a feature |
 | `Toggle Active AI Enablement` | Toggled active AI enablement. |
-| `Toggle Agent Mode Codebase Context` | Toggled on/off the enablement of codebase context usage for Agent Mode. |
+| `Toggle Agent Mode Codebase Context` | Toggled on/off the enablement of Codebase Context usage for Agent Mode. |
 | `Toggle Agent Mode Query Suggestions Setting` | Toggled on/off the prompt suggestions setting |
 | `Toggle Approvals Modal` | Opened or closed teams modal |
 | `Toggle Block Filter Case Sensitivity` | Toggled on/off case sensitivity within the block filter editor |
@@ -569,7 +569,7 @@ If you're a [Team](/knowledge-and-collaboration/teams/) admin, the deletion flow
 | `Toggle Block Filter Query` | Toggled on/off a block filter query |
 | `Toggle Block Filter Regex` | Toggled on/off regex within the block filter editor |
 | `Toggle Code Suggestions Setting` | Toggled on/off the code suggestions setting |
-| `Toggle Codebase Context Autoindexing` | Toggled on/off the enablement of autoindexing for codebase context. |
+| `Toggle Codebase Context Autoindexing` | Toggled on/off the enablement of autoindexing for Codebase Context. |
 | `Toggle Dim Inactive Panes` | Whether the dim inactive panes feature has been toggled |
 | `Toggle Focus Pane On Hover` | Toggled on/off focus pane on hover feature, which causes panes to automatically focus when hovering over them |
 | `Toggle Git Operations Autogen Setting` | Toggled on/off the git operations autogen setting |


### PR DESCRIPTION
Post-orchestration-launch audit, pass 2: align titles + link text + feature-name casing across docs.

## Changes

### Title sentence case
- `deployment-patterns.mdx:2` 'Deployment Patterns' → 'Deployment patterns'
- `managing-cloud-agents.mdx:2` 'Managing Cloud Agents' → 'Managing cloud agents'

Both match their existing sidebar labels.

### Body-text link sentence case
The Self-hosting page title is sentence case (`Self-hosting`), but seven links throughout the corpus used `[Self-Hosting]` (Title Case). One link also used `[Deployment Patterns]`. Fixed in:
- `enterprise/getting-started/getting-started-enterprise.mdx:166`
- `agent-platform/cloud-agents/platform.mdx:188`
- `agent-platform/cloud-agents/overview.mdx:60`
- `agent-platform/cloud-agents/faqs.mdx` (L60, L206, L229)
- `reference/api-and-sdk/troubleshooting/errors/operation-not-supported.mdx:58`

### Feature-name PRODUCT-CASING (Codebase Context / Agent Mode / Command Palette)
- `code/overview.mdx:9` — 'codebase context' → 'Codebase Context'
- `privacy.mdx` (8×) — telemetry table descriptions. Event names in the left column are emitted by product code and remain unchanged; descriptions in the right column now match the canonical feature-name casing.

### External-name casing (Github → GitHub)
- `guides/agent-workflows/how-to-run-3-agents-in-parallel-...mdx:52` — prompt example
- `guides/build-an-app-in-warp/building-a-real-time-chat-app-...mdx:2,232` — page title + appendix link (also dropped a stray trailing space)
- `guides/external-tools/github-mcp-summarizing-...mdx:2` — page title

## Intentionally skipped (false positives)
- `enterprise/index.mdx:12` 'Warp Terminal' — legitimate distinguishing usage (the bullet that distinguishes Warp Terminal from Oz). Per AGENTS.md: `Warp (not 'Warp Terminal' unless specifically distinguishing)` — this is the exception case.
- `sending-us-feedback.mdx:109,112` 'MacOS' — literal macOS app-bundle directory name in `/Applications/Warp.app/Contents/MacOS/<binary>`. Cannot change without breaking the path.
- `slash-commands.mdx:21` 'agent mode' — couldn't locate a lowercase "agent mode" on that line; appears to be a lint false positive.

## Validation
- check_for_broken_links: 0 broken / 2577 internal links
- style_lint: PRODUCT-CASING 11 → 2 (false positives), EXTERNAL-CASING 6 → 2 (false positives)
- npm run build: 332 pages built clean

## Stacking
This PR sits alongside #107 (Tier 1 terminology drift). Both target `main`; they touch overlapping files (`overview.mdx`, `privacy.mdx`) but disjoint regions. PR #107 can be merged first or after.

Tier 6 (blocklist → denylist sweep) will follow as a separate PR.

Co-Authored-By: Oz <oz-agent@warp.dev>