### PR TITLE
docs(audit): tier 6 — 'blocklist' (block list UI) → 'block list' to disambiguate

### DIFF
--- a/src/content/docs/agent-platform/capabilities/full-terminal-use.mdx
+++ b/src/content/docs/agent-platform/capabilities/full-terminal-use.mdx
@@ -107,14 +107,14 @@ The behavior differs based on where you start the long-running command:
     1. Run an interactive command (e.g., `python`, `psql`)
     2. Press `⌘↩` (macOS) or `Ctrl+Shift+Enter` (Windows/Linux), or use `⌘I` (macOS) / `Ctrl+I` (Windows/Linux), to tag in the agent
     3. The input switches to Agent Mode with full controls
-    4. When you exit, an agent conversation block appears in your terminal blocklist
+    4. When you exit, an agent conversation block appears in your terminal block list
     5. Click the block to reopen the full conversation with your LRC interaction context
   </TabItem>
   <TabItem label="From agent view">
     1. The agent runs an interactive command as part of your conversation
     2. Use `⌘↩` (macOS) or `Ctrl+Shift+Enter` (Windows/Linux) to tag in if the agent isn't already interacting
     3. The UI stays the same since you're already in agent view
-    4. When you exit, the interaction remains part of your conversation. No separate block is created in the terminal blocklist
+    4. When you exit, the interaction remains part of your conversation. No separate block is created in the terminal block list
     5. Commands run in agent view are automatically included as context
   </TabItem>
 </Tabs>

--- a/src/content/docs/agent-platform/local-agents/agent-context/blocks-as-context.mdx
+++ b/src/content/docs/agent-platform/local-agents/agent-context/blocks-as-context.mdx
@@ -12,7 +12,7 @@ Attach terminal output blocks to your agent prompts so the agent can understand 
 
 Warp’s Agent can use blocks from your Agent conversations as context to better understand your queries and generate more relevant responses.
 
-You can attach a block directly from the terminal blocklist by clicking the AI sparkles icon on it and selecting “Attach as context.”
+You can attach a block directly from the terminal block list by clicking the AI sparkles icon on it and selecting “Attach as context.”
 
 <figure>
 ![From a block of output, attach the block and ask Agent Mode to remove all untracked files.](../../../../../assets/agent-platform/remove_all_untracked_files.png)
@@ -77,8 +77,8 @@ The most common use case is to ask the AI to fix an error. You can attach the er
 
 Blocks in Warp belong to either the terminal view or a specific agent conversation:
 
-* **Terminal blocks** - Commands you run directly in the terminal. These always appear in your terminal blocklist and can be attached as context to multiple conversations.
-* **Agent conversation blocks** - Commands executed within an agent conversation (either by you or the agent). These only appear within that specific conversation and don't clutter your terminal blocklist.
+* **Terminal blocks** - Commands you run directly in the terminal. These always appear in your terminal block list and can be attached as context to multiple conversations.
+* **Agent conversation blocks** - Commands executed within an agent conversation (either by you or the agent). These only appear within that specific conversation and don't clutter your terminal block list.
 
 This separation keeps your terminal view clean while preserving full context within each conversation.
 

--- a/src/content/docs/agent-platform/local-agents/interacting-with-agents/conversation-forking.mdx
+++ b/src/content/docs/agent-platform/local-agents/interacting-with-agents/conversation-forking.mdx
@@ -41,7 +41,7 @@ You can also access this conversation view from the conversation chip in the cur
 
 #### **2. From the footer of the most recent AI response block**
 
-In any conversation in the blocklist, click the **fork button** in the footer of the most recent AI block. A new conversation opens in a separate pane with the full context of the original.
+In any conversation in the block list, click the **fork button** in the footer of the most recent AI block. A new conversation opens in a separate pane with the full context of the original.
 
 ![Fork conversation button in the footer of the most recent agent response block](../../../../../assets/agent-platform/conversation-forking-footer.png)
 

--- a/src/content/docs/agent-platform/local-agents/interacting-with-agents/index.mdx
+++ b/src/content/docs/agent-platform/local-agents/interacting-with-agents/index.mdx
@@ -142,9 +142,9 @@ If you switch models during a conversation, the context usage indicator updates 
 
 Warp automatically detects when your query has shifted to a new topic. When this happens, it suggests starting a new conversation instead of continuing in the same context.
 
-These options appear in the blocklist, where you can decide whether to branch off into a new conversation or keep going with the current one.
+These options appear in the block list, where you can decide whether to branch off into a new conversation or keep going with the current one.
 
-![Suggestion in the blocklist to start a new conversation when Warp detects a topic shift.](../../../../../assets/agent-platform/conversation-segmentation.png)
+![Suggestion in the block list to start a new conversation when Warp detects a topic shift.](../../../../../assets/agent-platform/conversation-segmentation.png)
 
 You can also create a new conversation manually at any time by using the keyboard shortcut, opening a new tab, or opening a new pane.
 

--- a/src/content/docs/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes.mdx
+++ b/src/content/docs/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes.mdx
@@ -98,14 +98,14 @@ Agent Mode-specific items include the model selector, autodetection toggle, Cont
 
 Blocks in Warp belong to either the terminal view or a specific agent conversation:
 
-* **Terminal blocks** - Commands you run directly in the terminal always appear in your terminal blocklist and can be attached as context to any conversation.
-* **Agent conversation blocks** - Commands executed within an agent conversation (either by you or the agent) only appear within that specific conversation and don't appear in the terminal blocklist.
+* **Terminal blocks** - Commands you run directly in the terminal always appear in your terminal block list and can be attached as context to any conversation.
+* **Agent conversation blocks** - Commands executed within an agent conversation (either by you or the agent) only appear within that specific conversation and don't appear in the terminal block list.
 
 In agent conversations, context is managed automatically, with optional manual attachment from terminal view:
 
 * **Automatic context** - Commands executed within an agent conversation are included as context for subsequent prompts.
 * **Manual attachment** - You can attach terminal blocks to bring in outputs from outside the conversation.
-* **Conversation scope** - Agent conversation blocks stay scoped to that conversation, while terminal blocks remain in the terminal blocklist.
+* **Conversation scope** - Agent conversation blocks stay scoped to that conversation, while terminal blocks remain in the terminal block list.
 
 This separation keeps your terminal view clean while preserving full context within each conversation. For shortcuts, pending vs. attached context, and block selection behavior, see [Blocks as Context](/agent-platform/local-agents/agent-context/blocks-as-context/).
 

--- a/src/content/docs/terminal/more-features/full-screen-apps.mdx
+++ b/src/content/docs/terminal/more-features/full-screen-apps.mdx
@@ -33,7 +33,7 @@ If you want a mouse event to go to Warp instead (for example, for text selection
 
 ## Padding
 
-Warp supports configuring how much padding surrounds full-screen apps. The default is 0 pixel padding, but this can be changed to a custom padding amount or to match the padding in the Blocklist.
+Warp supports configuring how much padding surrounds full-screen apps. The default is 0 pixel padding, but this can be changed to a custom padding amount or to match the padding in the block list.
 
 :::note
 Warp allows you to scale your terminal by fractions of a cell width | height. When your terminal size is not perfectly aligned to a cell width | height, the extra space appears as padding on the right | bottom.
@@ -42,7 +42,7 @@ Warp allows you to scale your terminal by fractions of a cell width | height. Wh
 ### How to access it
 
 * Go to **Settings** > **Appearance** > **Full-screen Apps** or from the [Command Palette](/terminal/command-palette/) search for "Appearance"
-  * `Use custom padding in alt-screen` is enabled by default, you can disable it to match the Blocklist padding
+  * `Use custom padding in alt-screen` is enabled by default, you can disable it to match the block list padding
     * Set the desired uniform padding (px) pixels, which is set to 0px by default
 
 :::caution

--- a/src/content/docs/terminal/more-features/text-selection.mdx
+++ b/src/content/docs/terminal/more-features/text-selection.mdx
@@ -14,7 +14,7 @@ description: >-
 <figcaption>Using smart selection to select a file path by double clicking.</figcaption>
 </figure>
 
-Double-click on text in the input or blocklist. The following patterns are recognized:
+Double-click on text in the input or block list. The following patterns are recognized:
 
 1. URLs
 2. File paths


### PR DESCRIPTION
Post-orchestration-launch audit, pass 3: clear the 'blocklist → denylist' lint warnings where the prose actually means the terminal's *block list* (the UI panel listing command blocks), not a denylist.

## Background

The `style_lint` rule `blocklist → denylist` (per AGENTS.md `allowlist/denylist (not 'whitelist'/'blocklist')`) was firing on 19 occurrences. On inspection, most of those refer to the **block list** (the UI panel listing terminal command blocks) — a distinct concept from a denylist. Fix is to space it as 'block list' (two words) so:
1. Prose is unambiguous to readers.
2. The lint rule no longer matches.

## Changes (12 occurrences across 7 files)

- `agent-platform/capabilities/full-terminal-use.mdx` (L110, L117)
- `agent-platform/local-agents/agent-context/blocks-as-context.mdx` (L15, L80, L81)
- `agent-platform/local-agents/interacting-with-agents/conversation-forking.mdx` (L44)
- `agent-platform/local-agents/interacting-with-agents/index.mdx` (L145, L147)
- `agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes.mdx` (L101, L102, L108)
- `terminal/more-features/full-screen-apps.mdx` (L36, L45)
- `terminal/more-features/text-selection.mdx` (L17)

## Intentionally skipped (literal UI feature names / image asset)

These need product verification before changing — they look like literal in-app UI labels, so updating the prose alone could create referential inaccuracy. Left as-is:

- `terminal/warpify/subshells.mdx` L44, L46 — 'Blocklisting commands' / 'add commands to the Blocklist' (the Warpify denylist feature)
- `support-and-community/privacy-and-security/privacy.mdx` L85, L87 — telemetry event descriptions referencing the in-app 'AI blocklist' UI
- `support-and-community/privacy-and-security/secret-redaction.mdx` L22 — refers to a literal Settings toggle: **Settings** > **Privacy** > **Secret redaction** > **Hide secrets in blocklist**
- `code/code-review.mdx` L53 — image filename `Blocklist-with-review-changes.png` (renaming the asset is a separate effort with git history considerations)

If the in-app UI has actually been renamed to 'denylist', a follow-up PR can sync both the docs and (where applicable) the image asset.

## Validation
- check_for_broken_links: 0 broken / 2577 internal links
- style_lint: DEPRECATED-TERM 19 → 5 (the 5 remaining are the skipped-by-design items)
- npm run build: 332 pages built clean

This is the third and final pass of the post-orchestration-launch audit. Sister PRs:
- #107 — Tier 1 terminology drift (Oz cloud agent / Oz agent / ambient agent / AI agent + orchestration cross-link)
- #108 — Tier 2/3/5 casing sweep (sentence-case feature names, Codebase Context / Agent Mode / Command Palette in privacy.mdx, Github → GitHub)

All three branch off `main` and edit disjoint files (or disjoint regions within shared files like `privacy.mdx`), so they can merge in any order without conflicting.

Co-Authored-By: Oz <oz-agent@warp.dev>