### PR TITLE
docs(pricing-may-2026): cross-page cleanup for user-scoped Reload + leave-team warnings

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx
@@ -81,7 +81,13 @@ Your team must meet the following requirements to run integrations:
   * Not supported: Pro, Turbo, Lightspeed, legacy Business.
 * Your team needs at least **20 credits** available to run cloud agents and integrations (any type of Warp credits work)
 
-When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits in a specific order. It starts with any [Cloud Agent Credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits) the user has, then moves to the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits. Enterprises may have different payment options and credit plans that affect this flow. If all applicable credit sources are exhausted, integrations and cloud agents will not work until credits are added.
+When a user triggers an agent through an integration (like Slack or Linear), the run draws from credits based on who the run is billed to:
+
+* **User-triggered runs on Build, Max, or Business** - Warp draws from any [cloud agent credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits) the user has, then the user's plan-included credits, then the user's Reload credits. Reload credits are scoped to the individual user and are not shared across the team.
+* **Team API key, scheduled, or agent identity runs on Build, Max, or Business** - Warp bills the team owner. The waterfall is: the owner's plan-included credits, then the owner's Reload credits. Attribution stays on the service account or agent identity that initiated the run, but billing rolls up to the owner. With auto-reload off, the request is blocked when both pools are depleted. With auto-reload on, usage can trigger a reload on the owner's pool subject to the team-wide monthly spend cap.
+* **Enterprise plans** - Runs draw from the team-scoped credit pool. When the pool is depleted, traffic falls to pay-as-you-go (PAYG) if enabled in the contract.
+
+If all applicable credit sources are exhausted and no auto-reload or PAYG path is available, integrations and cloud agents will not run until credits are added. See [Reload credits](/support-and-community/plans-and-billing/add-on-credits/) for the full self-serve waterfall and [platform credits](/support-and-community/plans-and-billing/platform-credits/) for the third bucket that applies to every cloud agent run.
 
 :::note
 If you're on an Enterprise plan, please reach out to [warp.dev/contact-sales](https://warp.dev/contact-sales) with any billing questions related to integrations.
@@ -211,14 +217,16 @@ How credits are consumed depends on how the agent run is triggered and authentic
 
 **User-triggered runs** (CLI with personal API key, Slack, Linear, or the Warp app):
 
-* Runs are tied to the triggering user's identity
-* Credits are consumed starting with any credit grants specifically allocated for cloud agent usage, then the user's base credits, followed by the team's Reload Credits, and finally the user's own Reload Credits
+* Runs are tied to the triggering user's identity.
+* On Build, Max, and Business plans, credits are consumed starting with any [cloud agent credits](/support-and-community/plans-and-billing/credits/#cloud-agent-credits) allocated to the user, then the user's plan-included credits, then the user's Reload credits. Reload credits are scoped to the individual user.
+* On Enterprise plans, runs draw from the team-scoped credit pool, falling back to pay-as-you-go (PAYG) when the pool is depleted, if enabled in the contract.
 
-**Team API key runs** (fully automated or headless workflows):
+**Team API key, scheduled, and agent identity runs** (fully automated or headless workflows):
 
-* Runs are not tied to any individual user
-* Only the team's Reload Credit pool is used—no individual base credits are available
-* Ideal for CI/CD pipelines, scheduled tasks, and other automated workflows
+* Runs are not tied to any individual user. Attribution stays on the service account or agent identity that initiated the run.
+* On Build, Max, and Business plans, Warp bills the team owner: the owner's plan-included credits, then the owner's Reload credits. With auto-reload off, the request is blocked when both pools are depleted. With auto-reload on, usage can trigger a reload on the owner's Reload pool subject to the team-wide monthly spend cap.
+* On Enterprise plans, these runs draw from the team-scoped credit pool, falling back to pay-as-you-go (PAYG) when the pool is depleted, if enabled in the contract.
+* Ideal for CI/CD pipelines, scheduled tasks, and other automated workflows.
 * For workflows that require code changes (opening pull requests, pushing branches, or writing to a repository), configure [team GitHub authorization](#team-github-authorization) so the agent can authenticate with the Oz by Warp GitHub App. Alternatively, use a [personal API key](/reference/cli/api-keys/) to authenticate as an individual user.
 
 For more details on creating and using API keys, see [API Keys](/reference/cli/api-keys/).
@@ -236,7 +244,17 @@ All triggers and instructions used by cloud agents are defined and controlled by
 
 #### Staying aware of usage
 
-Because triggers and instructions are configured by your team, any credits used when an agent runs are billed to your team's Reload Credit balance.
+Because triggers and instructions are configured by your team, the credits consumed when an agent runs are billed according to the model above:
 
-* It’s the team’s responsibility to manage triggers, confirm they behave as intended, and monitor usage.
-* Reviewing triggers, prompts, and agent behavior periodically helps ensure that credit usage aligns with expectations.
+* **Build, Max, Business** - User-triggered runs draw from the triggering user's pools (plan-included credits, then their Reload credits). Team API key, scheduled, and agent identity runs are billed to the team owner (the owner's plan-included credits, then the owner's Reload credits, subject to the team-wide spend cap when auto-reload is on).
+* **Enterprise** - All runs draw from the team-scoped credit pool, with PAYG as a fallback if enabled in the contract.
+
+It's the team's responsibility to manage triggers, confirm they behave as intended, and monitor usage. Reviewing triggers, prompts, and agent behavior periodically helps ensure that credit usage aligns with expectations.
+
+---
+
+## Related resources
+
+* [Reload credits](/support-and-community/plans-and-billing/add-on-credits/) - How user-scoped Reload credits, auto-reload, and the team-wide spend cap work on self-serve plans.
+* [Platform credits](/support-and-community/plans-and-billing/platform-credits/) - The third credit bucket that applies to every cloud agent run, alongside AI credits and compute credits.
+* [Credits overview](/support-and-community/plans-and-billing/credits/) - The full credit model across plans.

--- a/src/content/docs/enterprise/team-management/teams.mdx
+++ b/src/content/docs/enterprise/team-management/teams.mdx
@@ -64,6 +64,26 @@ If you've received an invite link, use it to sign up or log in and join the team
 If you're a Team Owner and choose to [delete your Warp account](/support-and-community/privacy-and-security/privacy/#delete-your-account-and-data), you'll need to assign a team member as the new owner before your account can be deleted.
 :::
 
+### Reload credit consequences when leaving or removing members
+
+On Build, Max, and Business plans, [Reload credits](/support-and-community/plans-and-billing/add-on-credits/) are scoped to the individual user under your team. Membership changes affect access to those credits:
+
+:::caution
+**Leaving the team.** If you leave this team, you'll lose access to any remaining Reload credits tied to it. If you rejoin the same team later, you'll regain access to any unused, non-expired credits.
+:::
+
+:::caution
+**An admin removes a member.** When an admin removes a member, that member loses access to any remaining Reload credits tied to this team. If they rejoin later, they'll regain access to any unused, non-expired credits.
+:::
+
+:::caution
+**An admin deletes the team.** Deleting this team will remove all members' access to any remaining Reload credits tied to it. Team members will no longer be able to use those credits.
+:::
+
+:::note
+Reload credits require an active subscription. Downgrading to the Free plan forfeits access to Reload credits tied to your team. Pre-launch pooled balances are grandfathered and drain first.
+:::
+
 ## Team discoverability
 
 Team admins can make their team discoverable to colleagues who share the same email domain. When enabled, new users with a matching domain can find and join the team without needing a direct invite link.

--- a/src/content/docs/knowledge-and-collaboration/teams.mdx
+++ b/src/content/docs/knowledge-and-collaboration/teams.mdx
@@ -65,6 +65,18 @@ If you have received an invite link, you can use that link to sign up or log in 
 
 If you’re a member of a team, you can visit **Settings** > **Teams** to leave a team at any time. Team admins (who created teams) may delete a team only after removing all team members.
 
+:::caution
+**Leaving a paid team forfeits access to Reload credits tied to it.** [Reload credits](/support-and-community/plans-and-billing/add-on-credits/) are scoped to your individual user under your team. If you leave a paid team, you lose access to any remaining Reload credits attributed to you. If you rejoin the same team later, you regain access to any unused, non-expired credits.
+:::
+
+:::caution
+**Deleting a team removes all members' access to Reload credits.** If an admin deletes the team, every member loses access to any remaining [Reload credits](/support-and-community/plans-and-billing/add-on-credits/) attributed to them under that team.
+:::
+
+:::note
+Reload credits require an active subscription. Downgrading to the Free plan also forfeits access to Reload credits.
+:::
+
 ## Team discoverability
 
 Team admins can make their teams discoverable to colleagues from the same email domain. This feature is available under **Settings** > **Teams** > **Make team discoverable**.

--- a/src/content/docs/reference/cli/api-keys.mdx
+++ b/src/content/docs/reference/cli/api-keys.mdx
@@ -43,10 +43,10 @@ Team keys without GitHub App authorization are the right fit for automated workf
 
 Warp supports two types of API keys, each with different billing and identity behavior:
 
-* **Personal API keys** - Cloud agent runs authenticate as you. These runs can use your personal base credits before drawing from team Add-on Credits, just like running an agent from the Warp app or triggering one via Slack or Linear.
-* **Team API keys** - Cloud agent runs are not tied to any individual user. These runs can only draw from your team's pool of Add-on Credits. They cannot use any individual's base credits. When [team GitHub authorization](/agent-platform/cloud-agents/team-access-billing-and-identity/#team-github-authorization) is configured, team key runs can also clone repositories and open pull requests using the Oz by Warp GitHub App.
+* **Personal API keys** - Cloud agent runs authenticate as you, just like running an agent from the Warp app or triggering one via Slack or Linear. On Build, Max, and Business plans, runs draw from your plan-included credits, then your Reload credits — both scoped to your individual user. On Enterprise plans, runs draw from the team-scoped credit pool (with pay-as-you-go fallback if enabled in the contract).
+* **Team API keys** - Cloud agent runs are not tied to any individual user. On Build, Max, and Business plans, Warp bills the team owner: the owner's plan-included credits, then the owner's Reload credits. With auto-reload on, usage can trigger a reload on the owner's pool subject to the team-wide monthly spend cap. On Enterprise plans, team API key runs draw from the team-scoped credit pool. When [team GitHub authorization](/agent-platform/cloud-agents/team-access-billing-and-identity/#team-github-authorization) is configured, team key runs can also clone repositories and open pull requests using the Oz by Warp GitHub App.
 
-Team API keys are useful for fully automated workflows, CI/CD pipelines, and scheduled tasks where no specific user context is needed. For billing details, see [Access, Billing, and Identity Permissions](/agent-platform/cloud-agents/team-access-billing-and-identity/).
+Team API keys are useful for fully automated workflows, CI/CD pipelines, and scheduled tasks where no specific user context is needed. For the full credit waterfall and how it interacts with Reload credits, see [Access, billing, and identity permissions](/agent-platform/cloud-agents/team-access-billing-and-identity/) and [Reload credits](/support-and-community/plans-and-billing/add-on-credits/).
 
 ## Authenticating with API keys
 


### PR DESCRIPTION
This is the 5th sibling PR of the May 2026 pricing launch. Siblings:

* #70 — May 2026 pricing: user-scoped Reload credits + service-account billing
* #71 — BYOK rewrite + new Custom inference endpoint page + sidebar entry
* #72 — BYOLLM reframe, plan summary, Enterprise billing, and plans-and-billing index
* #73 — Pricing FAQs overhaul for May 14, 2026 changes

This PR cleans up four cross-pages that were written under the **old pooled Add-on Credits model** and contained claims that will be incorrect once the May 14, 2026 changes ship. None of the per-plan monthly credit counts are hard-coded — readers are pointed at [warp.dev/pricing](https://warp.dev/pricing) and the new Reload credits / platform credits pages.

### Files changed

* `src/content/docs/agent-platform/cloud-agents/team-access-billing-and-identity.mdx` — Rewrote the integration credit waterfall, the user-triggered / team API key / scheduled / agent identity run bullets, and the "Staying aware of usage" summary. Added a Related resources section linking to Reload credits, platform credits, and the credits overview.
* `src/content/docs/reference/cli/api-keys.mdx` — Rewrote the Personal vs team API keys bullets so personal keys no longer claim to draw from team Add-on Credits, and team keys describe the team-owner waterfall (self-serve) and team-scoped pool (Enterprise).
* `src/content/docs/knowledge-and-collaboration/teams.mdx` — Added `:::caution` callouts to "Leaving and deleting teams" covering: leaving a paid team forfeits access to Reload credits (rejoining restores unused, non-expired ones), deleting a team removes everyone's access, and the active-subscription requirement.
* `src/content/docs/enterprise/team-management/teams.mdx` — Added an explicit "Reload credit consequences when leaving or removing members" subsection covering leaving, admin-removes-member, and admin-deletes-team scenarios, plus the active-subscription requirement.

### Model in one paragraph

On self-serve plans (Build, Max, Business), Reload credits are scoped to the individual user. User-triggered runs draw from the user's own pools (plan-included credits → user's Reload credits). Team API key, scheduled, and agent identity runs are billed to the team owner (owner's plan-included credits → owner's Reload credits), with auto-reload subject to a single team-wide monthly spend cap. On Enterprise plans, all runs draw from the team-scoped credit pool, with PAYG as a fallback if enabled in the contract. Leaving a paid team forfeits the leaving user's Reload credit access; rejoining restores any non-expired credits.

### Follow-up

`src/content/docs/agent-platform/cloud-agents/agents.mdx` (the new **Agent identities** page) is deferred from this PR. That file landed on `main` via the orchestration-launch PR #98 and is not yet present on the `hyc/plan-updates` umbrella (the umbrella is currently 14 commits behind `main`). The orchestrator will rebase the umbrella onto `main` after the four siblings (#70/#71/#72/#73) and this PR land, and will pick up the `agents.mdx` billing subsection then — either as part of the rebase commit or in a short follow-up PR.

_Conversation: https://staging.warp.dev/conversation/e425b99c-085f-4edc-8911-c277e14f196b_
_Run: https://oz.staging.warp.dev/runs/019e427e-b0e5-723d-8403-547bd920098e_

_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
