### PR TITLE
docs: use {{}} syntax for var interpolation in MCP config examples

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/mcp.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/mcp.mdx
@@ -59,7 +59,7 @@ You may define any number of MCP servers in a single config.
     "args": ["dbt-mcp"],
     "env": {
       "DBT_HOST": "https://example.us1.dbt.com",
-      "DBT_SERVICE_TOKEN": "${DBT_SERVICE_TOKEN}"
+      "DBT_SERVICE_TOKEN": "{{DBT_SERVICE_TOKEN}}"
     }
   }
 }
@@ -84,7 +84,7 @@ For repeatable cloud agent workflows, declare your MCP servers inside the agent 
       "args": ["dbt-mcp"],
       "env": {
         "DBT_HOST": "https://example.us1.dbt.com",
-        "DBT_SERVICE_TOKEN": "${DBT_SERVICE_TOKEN}"
+        "DBT_SERVICE_TOKEN": "{{DBT_SERVICE_TOKEN}}"
       }
     }
   }


### PR DESCRIPTION
## What
Changes `${DBT_SERVICE_TOKEN}` to `{{DBT_SERVICE_TOKEN}}` in both code snippets on the MCP Servers for cloud agents page.

## Why
We only support `{{ ... }}` syntax for secret interpolation in cloud runs, not `${ ... }`

## Related Issue

See comment on issue for details

Resolves: https://linear.app/warpdotdev/issue/REMOTE-1148/mcp-secret-variable-interpolation#comment-3a9309c4



Co-Authored-By: Oz <oz-agent@warp.dev>