### PR TITLE
docs: note unicode escape for upstream Mustache processors

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/mcp.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/mcp.mdx
@@ -65,6 +65,10 @@ You may define any number of MCP servers in a single config.
 }
 ```
 
+:::note
+If the config passes through a system that pre-processes `{{...}}` before it reaches Oz (for example, Jira/Atlassian Automation), use JSON unicode escapes for the braces: `\u007b\u007bMY_SECRET\u007d\u007d` decodes to `{{MY_SECRET}}`, which Oz resolves normally.
+:::
+
 ## Using MCP servers in an agent config file
 
 For repeatable cloud agent workflows, declare your MCP servers inside the agent config file passed to `-f / --file`:


### PR DESCRIPTION
Adds a `:::note` callout after the example configuration explaining the JSON unicode escape technique for systems (e.g. Jira/Atlassian Automation) that pre-process `{{...}}` before the payload reaches Oz.

Follows up on REMOTE-1148.

Co-Authored-By: Oz <oz-agent@warp.dev>
