### PR TITLE
Update link for supported models on Bedrock

### DIFF
--- a/src/content/docs/enterprise/enterprise-features/bring-your-own-llm.mdx
+++ b/src/content/docs/enterprise/enterprise-features/bring-your-own-llm.mdx
@@ -55,7 +55,7 @@ BYOLLM supports the intersection of models that Warp supports and models availab
 To determine which models you can use with BYOLLM:
 
 * [Model Choice](/agent-platform/inference/model-choice/) - Full list of Warp-supported models.
-* [Supported models in Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) - AWS Bedrock model availability.
+* [Supported models in Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html) - AWS Bedrock model availability.
 
 A model must appear on both lists to be available through BYOLLM.
 


### PR DESCRIPTION
## Summary
- Update the Bedrock supported models link to the latest destination. Current link no longer points to the right page.

Co-Authored-By: Oz <oz-agent@warp.dev>