### PR TITLE
docs: add BYOK billing redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3009,6 +3009,11 @@
       "statusCode": 308
     },
     {
+      "source": "/support-and-community/plans-and-billing/bring-your-own-api-key/:path*",
+      "destination": "/agent-platform/inference/bring-your-own-api-key/",
+      "statusCode": 308
+    },
+    {
       "source": "/support-and-community/support-and-billing/plans-and-pricing/bring-your-own-api-key",
       "destination": "/agent-platform/inference/bring-your-own-api-key/",
       "statusCode": 308


### PR DESCRIPTION
## Summary
Adds a redirect for the old Bring Your Own API Key billing URL so existing links resolve to the current BYOK documentation page.

## Changes
- Added a wildcard Vercel redirect from `/support-and-community/plans-and-billing/bring-your-own-api-key/:path*` to `/agent-platform/inference/bring-your-own-api-key/`.

## Validation
- `python3 -m json.tool vercel.json`
- `npm run build`

Co-Authored-By: Oz <oz-agent@warp.dev>
