### PR TITLE
docs(custom-inference): document local model tunneling via ngrok

### DIFF
--- a/src/content/docs/agent-platform/inference/custom-inference-endpoint.mdx
+++ b/src/content/docs/agent-platform/inference/custom-inference-endpoint.mdx
@@ -60,7 +60,7 @@ Warp routes inference requests through its servers, so endpoint URLs must be pub
 
 To route through a model running on your own machine (for example, Ollama, LM Studio, vLLM, or llama.cpp), expose it through a tunneling service like [ngrok](https://ngrok.com/) and use the public tunnel URL as the base URL in your endpoint configuration.
 
-For example, with a default Ollama install listening on port `11434`, run `ngrok http 11434` and use the resulting `https://*.ngrok-free.app` URL as your endpoint. Other tunneling services that produce a publicly reachable HTTPS URL (Cloudflare Tunnel, Tailscale Funnel, and similar) work the same way.
+For example, with a default Ollama install listening on port `11434`, run `ngrok http 11434` and use the resulting `https://*.ngrok-free.app/v1` URL as your endpoint. Other tunneling services that produce a publicly reachable HTTPS URL (Cloudflare Tunnel, Tailscale Funnel, and similar) work the same way.
 
 ## Billing behavior
 

--- a/src/content/docs/agent-platform/inference/custom-inference-endpoint.mdx
+++ b/src/content/docs/agent-platform/inference/custom-inference-endpoint.mdx
@@ -54,6 +54,14 @@ When you explicitly select an endpoint-routed model from the model picker, Warp 
 
 The configuration flow mirrors the [Bring Your Own API Key](/agent-platform/inference/bring-your-own-api-key/) setup, so the steps will feel familiar if you've already configured BYOK.
 
+## Using local models
+
+Warp routes inference requests through its servers, so endpoint URLs must be publicly accessible. `localhost`, `127.0.0.1`, and other private or local network URLs are rejected when configuring a custom inference endpoint.
+
+To route through a model running on your own machine (for example, Ollama, LM Studio, vLLM, or llama.cpp), expose it through a tunneling service like [ngrok](https://ngrok.com/) and use the public tunnel URL as the base URL in your endpoint configuration.
+
+For example, with a default Ollama install listening on port `11434`, run `ngrok http 11434` and use the resulting `https://*.ngrok-free.app` URL as your endpoint. Other tunneling services that produce a publicly reachable HTTPS URL (Cloudflare Tunnel, Tailscale Funnel, and similar) work the same way.
+
 ## Billing behavior
 
 ### Warp AI credits


### PR DESCRIPTION
Adds a "Using local models" section to the custom inference endpoint docs to address a recurring question (and the cluster of recent GitHub issues, e.g. [#11589](https://github.com/warpdotdev/warp/issues/11589)) about why `localhost` and private network URLs are rejected.

## What changed
- Explains that endpoint URLs must be publicly accessible because Warp routes inference requests through its servers.
- Calls out that `localhost` and other private/local URLs are rejected at configuration time.
- Documents the supported workaround: expose a local model server (Ollama, LM Studio, vLLM, llama.cpp) through a tunneling service like ngrok.
- Includes a concrete example using Ollama's default port `11434` with `ngrok http 11434`, and notes other tunneling services (Cloudflare Tunnel, Tailscale Funnel) work the same way.

## Why
Multiple users in the past week filed GitHub issues hitting this — they assumed they could point Warp at `http://localhost:11434/v1` for a local Ollama/LM Studio setup. Per Daniel: "the URLs must be publicly accessible, users can set up an ngrok tunnel to use local models. might be worth adding something about that to our docs."

## Note for reviewers
The "private/local network URLs" sentence preserves a `*********` placeholder for a redacted host pattern carried over from the source Slack/issue text. Happy to swap in a concrete example (e.g. `127.0.0.1`, `192.168.x.x`) before merge — flag in review if preferred.

_Conversation: https://staging.warp.dev/conversation/8adb8bd1-c7f5-4d69-8087-7eae2e699040_
_Run: https://oz.staging.warp.dev/runs/019e6595-8e80-786b-9a98-21ae29198ab8_

_This PR was generated with [Oz](https://warp.dev/oz)._
