### PR TITLE
Add Oz cloud agent videos to docs

### DIFF
--- a/src/content/docs/agent-platform/agent-memory/index.mdx
+++ b/src/content/docs/agent-platform/agent-memory/index.mdx
@@ -6,6 +6,8 @@ description: >-
 sidebar:
   label: "Agent Memory (Research Preview)"
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
+
 :::caution
 Agent Memory is in **research preview** and is enabled per team for design partners. [Join the waitlist](https://warp.dev/oz/agent-memory#waitlist) to request access for your team.
 :::
@@ -13,6 +15,10 @@ Agent Memory is in **research preview** and is enabled per team for design partn
 Agent Memory is a persistent memory system that lives on Oz and is shared across every supported agent harness, including the built-in Warp Agent, Claude Code, Codex, and others as they're added. Agents read from and write to this memory system as they run, so durable facts, decisions, and outcomes from one conversation are available to the next — regardless of which harness, machine, or teammate triggers the work.
 
 Memory creation and retrieval are asynchronous and run in the background, so they don't consume tokens or add latency to the active task.
+
+Watch this short preview to see Agent Memory in context.
+
+<VideoEmbed url="https://www.youtube.com/watch?v=ED9g1shmiEE" title="Agent Memory" />
 
 [Join the Agent Memory waitlist](https://warp.dev/oz/agent-memory#waitlist).
 

--- a/src/content/docs/agent-platform/cloud-agents/handoff/cloud-to-cloud.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/handoff/cloud-to-cloud.mdx
@@ -10,7 +10,7 @@ import VideoEmbed from '@components/VideoEmbed.astro';
 
 Cloud-to-cloud handoff in Warp lets you send follow-up instructions to a finished cloud agent run and continue it in a fresh cloud session. The run keeps the same conversation and restores the prior workspace state, so the agent can pick up where it left off instead of starting over.
 
-Watch this walkthrough to see how cloud-to-cloud handoff continues an Oz cloud agent run without losing the prior session context.
+Watch this walkthrough to see how cloud-to-cloud handoff continues a cloud agent run without losing the prior session context.
 
 <VideoEmbed url="https://www.youtube.com/watch?v=tcYZy0D6dMA" title="What is Cloud-to-cloud handoff?" />
 

--- a/src/content/docs/agent-platform/cloud-agents/handoff/cloud-to-cloud.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/handoff/cloud-to-cloud.mdx
@@ -6,8 +6,13 @@ description: >-
 sidebar:
   label: "Cloud to cloud"
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 Cloud-to-cloud handoff in Warp lets you send follow-up instructions to a finished cloud agent run and continue it in a fresh cloud session. The run keeps the same conversation and restores the prior workspace state, so the agent can pick up where it left off instead of starting over.
+
+Watch this walkthrough to see how cloud-to-cloud handoff continues an Oz cloud agent run without losing the prior session context.
+
+<VideoEmbed url="https://www.youtube.com/watch?v=tcYZy0D6dMA" title="What is Cloud-to-cloud handoff?" />
 
 Use this handoff direction when:
 

--- a/src/content/docs/agent-platform/cloud-agents/handoff/local-to-cloud.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/handoff/local-to-cloud.mdx
@@ -10,7 +10,7 @@ import VideoEmbed from '@components/VideoEmbed.astro';
 
 Local-to-cloud handoff in Warp promotes an active local Warp Agent conversation into a cloud agent run. Warp forks the conversation, snapshots your uncommitted workspace changes, and sends both to the cloud so the agent can continue the same task with the context and files it needs.
 
-Watch this walkthrough to see how to move a local Warp Agent conversation into an Oz cloud agent run.
+Watch this walkthrough to see how to move a local Warp Agent conversation into a cloud agent run.
 
 <VideoEmbed url="https://www.youtube.com/watch?v=9qpGYZ58Wck" title="How to hand off local agents to the cloud in Warp" />
 

--- a/src/content/docs/agent-platform/cloud-agents/handoff/local-to-cloud.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/handoff/local-to-cloud.mdx
@@ -6,8 +6,13 @@ description: >-
 sidebar:
   label: "Local to cloud"
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 Local-to-cloud handoff in Warp promotes an active local Warp Agent conversation into a cloud agent run. Warp forks the conversation, snapshots your uncommitted workspace changes, and sends both to the cloud so the agent can continue the same task with the context and files it needs.
+
+Watch this walkthrough to see how to move a local Warp Agent conversation into an Oz cloud agent run.
+
+<VideoEmbed url="https://www.youtube.com/watch?v=9qpGYZ58Wck" title="How to hand off local agents to the cloud in Warp" />
 
 Use this handoff direction when:
 

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -7,8 +7,13 @@ description: >-
 sidebar:
   label: "Overview"
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 Oz can run third-party agent harnesses as cloud agents alongside Warp Agent, including [Claude Code](/agent-platform/cloud-agents/harnesses/claude-code/) and [Codex](/agent-platform/cloud-agents/harnesses/codex/). You choose the harness (agent runtime) that fits the task; the platform around the run stays the same.
+
+Watch this walkthrough to see how to run Warp Agent, Claude Code, or Codex as an Oz cloud agent.
+
+<VideoEmbed url="https://www.youtube.com/watch?v=ZUYyuA5i1VU" title="How to run any agent in the cloud with Oz - Claude Code, Codex, or the Warp Agent" />
 
 ## What stays the same
 

--- a/src/content/docs/agent-platform/cloud-agents/orchestration/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/orchestration/index.mdx
@@ -4,8 +4,13 @@ description: Coordinate parent and child agents across local and cloud runs to b
 sidebar:
   label: "Orchestration"
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 Multi-agent orchestration lets one agent spawn and coordinate other agents to parallelize work, delegate specialized tasks, or verify another agent's output. The parent/child model works from the Warp app, the [Oz CLI](/reference/cli/), and the [Oz API](/reference/api-and-sdk/), and supports local, cloud, and mixed execution.
+
+Watch this walkthrough to see how an Oz cloud agent can coordinate a team of agents in the cloud.
+
+<VideoEmbed url="https://www.youtube.com/watch?v=qeR79bhyFOw" title="How to orchestrate a team of agents in the cloud with Warp" />
 
 This page covers the orchestration model and the patterns it supports. To learn how to start an orchestrated run, see [Running orchestrated agents](/agent-platform/cloud-agents/orchestration/multi-agent-runs/).
 

--- a/src/content/docs/agent-platform/cloud-agents/orchestration/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/orchestration/index.mdx
@@ -8,7 +8,7 @@ import VideoEmbed from '@components/VideoEmbed.astro';
 
 Multi-agent orchestration lets one agent spawn and coordinate other agents to parallelize work, delegate specialized tasks, or verify another agent's output. The parent/child model works from the Warp app, the [Oz CLI](/reference/cli/), and the [Oz API](/reference/api-and-sdk/), and supports local, cloud, and mixed execution.
 
-Watch this walkthrough to see how an Oz cloud agent can coordinate a team of agents in the cloud.
+Watch this walkthrough to see how a cloud agent can coordinate a team of agents in the cloud.
 
 <VideoEmbed url="https://www.youtube.com/watch?v=qeR79bhyFOw" title="How to orchestrate a team of agents in the cloud with Warp" />
 

--- a/src/content/docs/agent-platform/cloud-agents/orchestration/multi-agent-runs.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/orchestration/multi-agent-runs.mdx
@@ -4,8 +4,13 @@ description: Start multi-agent orchestrations from the Warp app, the Oz CLI, the
 sidebar:
   label: "Running orchestrated agents"
 ---
+import VideoEmbed from '@components/VideoEmbed.astro';
 
 An orchestrated run starts with a parent agent that spawns one or more child agents. You can start a parent from the Warp app, the Oz CLI, the Oz web app, or the Oz API. Use orchestrated runs to review a plan before fan-out, execute children locally or in the cloud, and inspect parent and child conversations as they work.
+
+Watch this walkthrough to see how to start and inspect an orchestrated agent run from Warp.
+
+<VideoEmbed url="https://www.youtube.com/watch?v=WNwnZybrp60" title="Orchestrate a team of agents in Warp" />
 
 ## Before you start
 


### PR DESCRIPTION
## Summary
- Add YouTube embeds for the narrated Oz cloud agent videos to the relevant docs pages for handoff, harnesses, and orchestration.
- Add the Agent Memory preview clip to the Agent Memory research preview page.
- Include short explanatory lead-ins before each video embed for context and accessibility.

## Validation
- `npm --prefix /Users/rachaelrenk/Documents/Warp/docs run typecheck`
- `npm --prefix /Users/rachaelrenk/Documents/Warp/docs run build`

Note: `npm run fmt` and `npm run lint` could not run locally because `trunk` is not installed or not on PATH.

## Oz artifacts
- Conversation: https://staging.warp.dev/conversation/868d5ae9-6660-4937-be6e-58cca3ae2d50
- Plan: https://staging.warp.dev/drive/notebook/hSWFp0dewD2tGUgkownGDU

Co-Authored-By: Oz <oz-agent@warp.dev>
