### PR TITLE
Remove incorrect oz-skills reference from orchestration docs

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/orchestration/multi-agent-runs.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/orchestration/multi-agent-runs.mdx
@@ -68,7 +68,7 @@ If you need to fan out from a script and want each child linked to a specific pa
 In the Oz web app's [**Runs** page](https://oz.warp.dev/runs):
 
 1. Click **New run** in the header.
-2. Select an environment and, optionally, a skill that performs orchestration. The [oz-skills repo](https://github.com/warpdotdev/oz-skills) includes orchestration skills like review swarms and fan-out runners.
+2. Select an environment and, optionally, a skill that performs orchestration.
 3. Enter the parent's prompt. Describe both the high-level task and the orchestration shape you want (number of children, parallelism, success criteria).
 4. Click **Run**.
 


### PR DESCRIPTION
## Summary

Safia flagged that the [Running orchestrated agents](https://docs.warp.dev/agent-platform/cloud-agents/orchestration/multi-agent-runs/#starting-an-orchestrated-run-from-the-oz-web-app) page claims the [oz-skills repo](https://github.com/warpdotdev/oz-skills) contains orchestration skills (review swarms, fan-out runners), but that isn't actually true today.

This PR removes the misleading second sentence in step 2 of the "Starting an orchestrated run from the Oz web app" section. The first sentence still mentions that a skill can optionally be selected — that part remains accurate for users with their own orchestration-capable skills.

## Before

> 2. Select an environment and, optionally, a skill that performs orchestration. The [oz-skills repo](https://github.com/warpdotdev/oz-skills) includes orchestration skills like review swarms and fan-out runners.

## After

> 2. Select an environment and, optionally, a skill that performs orchestration.

_Conversation: https://staging.warp.dev/conversation/3c7fa563-eaa8-4100-8ff8-b20c8a474523_
_Run: https://oz.staging.warp.dev/runs/019e6b88-558b-759f-9885-15f49ecc8b7d_

_This PR was generated with [Oz](https://warp.dev/oz)._
