### PR TITLE
docs: remove oz-skills orchestration reference

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/orchestration/multi-agent-runs.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/orchestration/multi-agent-runs.mdx
@@ -68,7 +68,7 @@ If you need to fan out from a script and want each child linked to a specific pa
 In the Oz web app's [**Runs** page](https://oz.warp.dev/runs):
 
 1. Click **New run** in the header.
-2. Select an environment and, optionally, a skill that performs orchestration. The [oz-skills repo](https://github.com/warpdotdev/oz-skills) includes orchestration skills like review swarms and fan-out runners.
+2. Select an environment and, optionally, a skill that performs orchestration.
 3. Enter the parent's prompt. Describe both the high-level task and the orchestration shape you want (number of children, parallelism, success criteria).
 4. Click **Run**.
 


### PR DESCRIPTION
## Summary

Removes the incorrect sentence that said the oz-skills repo includes orchestration skills like review swarms and fan-out runners.

## Related issues

Slack thread in `#growth-docs` requesting removal of the sentence from the multi-agent runs documentation.

## Validation

- `trunk check /workspace/docs/src/content/docs/agent-platform/cloud-agents/orchestration/multi-agent-runs.mdx` (could not run: `trunk` is not installed in the sandbox)
- `npm run typecheck --prefix /workspace/docs`
- `npm run build --prefix /workspace/docs`

## Screenshots

Not applicable; text-only documentation change.

## Follow-ups

None.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/6b9953ca-bde0-4f47-95d1-07f6059116bb_
_Run: https://oz.staging.warp.dev/runs/019e6b8b-03d5-75f0-b3cf-104d3b12fc4b_

_This PR was generated with [Oz](https://warp.dev/oz)._
