### PR TITLE
chore: ignore .trunk/tools cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ pnpm-debug.log*
 __pycache__/
 .vercel
 .env*.local
+
+# Trunk tools cache
+.trunk/tools


### PR DESCRIPTION
## Summary
Adds `.trunk/tools` to `.gitignore` to prevent the Trunk tools cache directory from being tracked.

## Changes

### .gitignore
- Added `.trunk/tools` under a new "Trunk tools cache" comment

Co-Authored-By: Oz <oz-agent@warp.dev>
