### PR TITLE
docs: add error pages for infrastructure_timeout and agent_process_failed

### DIFF
--- a/src/content/docs/reference/api-and-sdk/troubleshooting/errors/agent-process-failed.mdx
+++ b/src/content/docs/reference/api-and-sdk/troubleshooting/errors/agent-process-failed.mdx
@@ -5,10 +5,10 @@ description: >-
   or contact support if it recurs consistently.
 ---
 
-The `agent_process_failed` error occurs when the agent process exits with an unexpected failure during task execution.
+The `agent_process_failed` error occurs when the agent process exits unexpectedly after environment setup has completed, before the task reaches a normal terminal state.
 
 :::note
-This is classified as a **platform error** (task state → ERROR) rather than a user error. It differs from [`environment_setup_failed`](/reference/api-and-sdk/troubleshooting/errors/environment-setup-failed/), which indicates a failure during environment setup steps configured by the caller. `agent_process_failed` indicates a failure during the agent's active execution phase.
+This is classified as a **platform error** (task state → ERROR) rather than a user error. It differs from [`environment_setup_failed`](/reference/api-and-sdk/troubleshooting/errors/environment-setup-failed/), which covers failures that happen while initializing the environment (cloning the repo, running setup commands, starting MCP servers). `agent_process_failed` covers failures that happen during the agent's active execution phase.
 :::
 
 ---
@@ -25,9 +25,9 @@ This is classified as a **platform error** (task state → ERROR) rather than a 
 
 This error is returned when:
 
-* The agent process exits unexpectedly with a non-zero exit code after environment setup has completed
-* An unrecoverable runtime error occurs inside the agent process during task execution
-* The agent process is killed by the operating system (for example, due to an out-of-memory condition)
+* The agent process exits with a non-zero exit code after environment setup has completed
+* An unrecoverable runtime error occurs inside the agent process while it is handling the task
+* The agent process is terminated by the operating system (for example, due to an out-of-memory kill or a segmentation fault)
 
 ---
 
@@ -50,7 +50,7 @@ This error is returned when:
 ## How to resolve
 
 1. Retry the task. Occasional process failures are transient.
-2. If the error recurs consistently, check whether the task prompt or environment configuration is causing the agent to crash.
+2. If the error recurs consistently, look for triggers in the task itself: very large prompts or attached context, memory-heavy tools spawned by the agent, or setup steps that leave the environment in a degraded state.
 3. Contact [Warp support](/support-and-community/troubleshooting-and-support/sending-us-feedback/) and include the `trace_id` from the error response if the issue persists.
 
 ---

--- a/src/content/docs/reference/api-and-sdk/troubleshooting/errors/agent-process-failed.mdx
+++ b/src/content/docs/reference/api-and-sdk/troubleshooting/errors/agent-process-failed.mdx
@@ -1,0 +1,62 @@
+---
+title: agent_process_failed
+description: >-
+  The agent process exited unexpectedly during task execution. Retry the task
+  or contact support if it recurs consistently.
+---
+
+The `agent_process_failed` error occurs when the agent process exits with an unexpected failure during task execution.
+
+:::note
+This is classified as a **platform error** (task state → ERROR) rather than a user error. It differs from [`environment_setup_failed`](/reference/api-and-sdk/troubleshooting/errors/environment-setup-failed/), which indicates a failure during environment setup steps configured by the caller. `agent_process_failed` indicates a failure during the agent's active execution phase.
+:::
+
+---
+
+## Details
+
+* **HTTP Status:** `500 Internal Server Error`
+* **Retryable:** No
+* **Task State:** ERROR
+
+---
+
+## When does this occur?
+
+This error is returned when:
+
+* The agent process exits unexpectedly with a non-zero exit code after environment setup has completed
+* An unrecoverable runtime error occurs inside the agent process during task execution
+* The agent process is killed by the operating system (for example, due to an out-of-memory condition)
+
+---
+
+## Example response
+
+```json
+{
+  "type": "/reference/api-and-sdk/troubleshooting/errors/agent-process-failed/",
+  "title": "The agent process exited unexpectedly.",
+  "status": 500,
+  "instance": "/api/v1/agent/tasks",
+  "error": "The agent process exited unexpectedly.",
+  "retryable": false,
+  "trace_id": "abc123..."
+}
+```
+
+---
+
+## How to resolve
+
+1. Retry the task. Occasional process failures are transient.
+2. If the error recurs consistently, check whether the task prompt or environment configuration is causing the agent to crash.
+3. Contact [Warp support](/support-and-community/troubleshooting-and-support/sending-us-feedback/) and include the `trace_id` from the error response if the issue persists.
+
+---
+
+## Related
+
+* [Cloud Agents Overview](/agent-platform/cloud-agents/overview/) — How cloud agent tasks work
+* [environment_setup_failed](/reference/api-and-sdk/troubleshooting/errors/environment-setup-failed/) — Errors during environment setup
+* [internal_error](/reference/api-and-sdk/troubleshooting/errors/internal-error/) — Catch-all for unexpected server-side errors

--- a/src/content/docs/reference/api-and-sdk/troubleshooting/errors/index.mdx
+++ b/src/content/docs/reference/api-and-sdk/troubleshooting/errors/index.mdx
@@ -73,6 +73,8 @@ These indicate a Warp-side issue. When a cloud agent task encounters a platform 
 * [`authentication_required`](/reference/api-and-sdk/troubleshooting/errors/authentication-required/) — Invalid or expired API key
 * [`resource_unavailable`](/reference/api-and-sdk/troubleshooting/errors/resource-unavailable/) — Transient infrastructure issue (retryable)
 * [`internal_error`](/reference/api-and-sdk/troubleshooting/errors/internal-error/) — Unexpected server-side error (retryable)
+* [`infrastructure_timeout`](/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout/) — Task terminated after exceeding the maximum allowed runtime
+* [`agent_process_failed`](/reference/api-and-sdk/troubleshooting/errors/agent-process-failed/) — Agent process exited unexpectedly during task execution
 
 ---
 

--- a/src/content/docs/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout.mdx
+++ b/src/content/docs/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout.mdx
@@ -5,10 +5,10 @@ description: >-
   allowed runtime. Retry the task or contact support if it persists.
 ---
 
-The `infrastructure_timeout` error occurs when a task is forcibly terminated by the platform after remaining in a non-terminal state past the maximum allowed task age.
+The `infrastructure_timeout` error occurs when a cloud agent task runs past the platform's maximum allowed runtime and is forcibly terminated.
 
 :::note
-This is classified as a **platform error** (task state → ERROR) rather than a user error, because the timeout is enforced by Warp's infrastructure rather than by the task's own logic.
+This is classified as a **platform error** (task state → ERROR) rather than a user error, because the termination is performed by Warp's infrastructure rather than by the task itself.
 :::
 
 ---
@@ -25,9 +25,9 @@ This is classified as a **platform error** (task state → ERROR) rather than a 
 
 This error is returned when:
 
-* A task runs for longer than the platform's maximum allowed task age and is terminated by the periodic stale-task cleanup job
-* The agent process did not complete or report a terminal status within the allowed time window
-* A networking or infrastructure issue caused the task to stall silently without reporting completion
+* The task runs longer than the platform's maximum allowed runtime and is terminated by the periodic stale-task cleanup job
+* The agent process never reports a terminal status within that window (for example, the process is hung or stuck on a long-running command)
+* A networking or infrastructure issue causes the task to stall silently without reporting completion
 
 ---
 
@@ -49,8 +49,8 @@ This error is returned when:
 
 ## How to resolve
 
-1. Retry the task. If the task regularly times out, consider breaking it into smaller, shorter-running subtasks.
-2. Review the [environment configuration](/agent-platform/cloud-agents/environments/) for resource allocation or networking issues that could be causing the task to stall.
+1. Retry the task. If it regularly times out, break the work into smaller, shorter-running subtasks or scope the prompt down.
+2. Review the [environment configuration](/agent-platform/cloud-agents/environments/) for setup commands or MCP servers that block on user input, long downloads, or unresponsive network calls.
 3. Contact [Warp support](/support-and-community/troubleshooting-and-support/sending-us-feedback/) and include the `trace_id` from the error response if the issue persists.
 
 ---

--- a/src/content/docs/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout.mdx
+++ b/src/content/docs/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout.mdx
@@ -1,0 +1,62 @@
+---
+title: infrastructure_timeout
+description: >-
+  The task was forcibly terminated because it remained active past the maximum
+  allowed runtime. Retry the task or contact support if it persists.
+---
+
+The `infrastructure_timeout` error occurs when a task is forcibly terminated by the platform after remaining in a non-terminal state past the maximum allowed task age.
+
+:::note
+This is classified as a **platform error** (task state → ERROR) rather than a user error, because the timeout is enforced by Warp's infrastructure rather than by the task's own logic.
+:::
+
+---
+
+## Details
+
+* **HTTP Status:** `500 Internal Server Error`
+* **Retryable:** No
+* **Task State:** ERROR
+
+---
+
+## When does this occur?
+
+This error is returned when:
+
+* A task runs for longer than the platform's maximum allowed task age and is terminated by the periodic stale-task cleanup job
+* The agent process did not complete or report a terminal status within the allowed time window
+* A networking or infrastructure issue caused the task to stall silently without reporting completion
+
+---
+
+## Example response
+
+```json
+{
+  "type": "/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout/",
+  "title": "The task exceeded the maximum allowed runtime and was terminated.",
+  "status": 500,
+  "instance": "/api/v1/agent/tasks",
+  "error": "The task exceeded the maximum allowed runtime and was terminated.",
+  "retryable": false,
+  "trace_id": "abc123..."
+}
+```
+
+---
+
+## How to resolve
+
+1. Retry the task. If the task regularly times out, consider breaking it into smaller, shorter-running subtasks.
+2. Review the [environment configuration](/agent-platform/cloud-agents/environments/) for resource allocation or networking issues that could be causing the task to stall.
+3. Contact [Warp support](/support-and-community/troubleshooting-and-support/sending-us-feedback/) and include the `trace_id` from the error response if the issue persists.
+
+---
+
+## Related
+
+* [Cloud Agents Overview](/agent-platform/cloud-agents/overview/) — How cloud agent tasks work
+* [internal_error](/reference/api-and-sdk/troubleshooting/errors/internal-error/) — Other platform-level errors
+* [Cloud Agents FAQs](/agent-platform/cloud-agents/faqs/) — Common questions about cloud agents

--- a/src/content/docs/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout.mdx
+++ b/src/content/docs/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout.mdx
@@ -49,7 +49,7 @@ This error is returned when:
 
 ## How to resolve
 
-1. Retry the task. If it regularly times out, break the work into smaller, shorter-running subtasks or scope the prompt down.
+1. Retry the task. If it consistently times out, break the work into smaller, shorter-running subtasks or reduce the scope of the prompt.
 2. Review the [environment configuration](/agent-platform/cloud-agents/environments/) for setup commands or MCP servers that block on user input, long downloads, or unresponsive network calls.
 3. Contact [Warp support](/support-and-community/troubleshooting-and-support/sending-us-feedback/) and include the `trace_id` from the error response if the issue persists.
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -480,6 +480,8 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 										'reference/api-and-sdk/troubleshooting/errors/authentication-required',
 										'reference/api-and-sdk/troubleshooting/errors/resource-unavailable',
 										'reference/api-and-sdk/troubleshooting/errors/internal-error',
+										'reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout',
+										'reference/api-and-sdk/troubleshooting/errors/agent-process-failed',
 									],
 								},
 							],

--- a/vercel.json
+++ b/vercel.json
@@ -2489,8 +2489,18 @@
       "statusCode": 308
     },
     {
+      "source": "/reference/api-and-sdk/troubleshooting/errors/agent_process_failed",
+      "destination": "/reference/api-and-sdk/troubleshooting/errors/agent-process-failed/",
+      "statusCode": 308
+    },
+    {
       "source": "/reference/api-and-sdk/troubleshooting/errors/feature_not_available",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/feature-not-available/",
+      "statusCode": 308
+    },
+    {
+      "source": "/reference/api-and-sdk/troubleshooting/errors/infrastructure_timeout",
+      "destination": "/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout/",
       "statusCode": 308
     },
     {
@@ -6539,8 +6549,18 @@
       "statusCode": 308
     },
     {
+      "source": "/reference/api-and-sdk/troubleshooting/errors/agent_process_failed/",
+      "destination": "/reference/api-and-sdk/troubleshooting/errors/agent-process-failed/",
+      "statusCode": 308
+    },
+    {
       "source": "/reference/api-and-sdk/troubleshooting/errors/feature_not_available/",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/feature-not-available/",
+      "statusCode": 308
+    },
+    {
+      "source": "/reference/api-and-sdk/troubleshooting/errors/infrastructure_timeout/",
+      "destination": "/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout/",
       "statusCode": 308
     },
     {


### PR DESCRIPTION
## Summary
Adds documentation pages for two `platformerrors.go` error codes that ship on the public Oz API but had no corresponding page on docs.warp.dev:

- `infrastructure_timeout` — task forcibly terminated by the periodic stale-task job after exceeding the maximum allowed runtime.
- `agent_process_failed` — agent process exited unexpectedly during task execution (after environment setup completed).

Both are platform errors (task state → ERROR), HTTP 500, not retryable, mirroring how they're declared in `warp-server/logic/ai/ambient_agents/platformerrors/platformerrors.go` (see `NewInfrastructureTimeout` and `NewAgentProcessFailed`).

## Context
This is the docs.warp.dev (Astro Starlight) counterpart to the GitBook PR [warpdotdev/gitbook#924](https://github.com/warpdotdev/gitbook/pull/924). Astro Starlight is now the live docs source, so the same gap had to be filled here. Content follows existing error-page conventions (`authentication-required.mdx`, `internal-error.mdx`, `environment-setup-failed.mdx`) instead of the GitBook hint syntax / `https://docs.warp.dev/...` `type` URIs.

Bot review feedback from the GitBook PR is incorporated:
- No em dashes in the procedural "How to resolve" steps.
- Reworded the platform-vs-user-error callout on `infrastructure_timeout` to avoid implying the task is blameless ("enforced by Warp's infrastructure rather than by the task's own logic").
- Added a related-page link to `internal_error` from both pages, and to `environments` from `infrastructure_timeout`.

## Changes
- `src/content/docs/reference/api-and-sdk/troubleshooting/errors/agent-process-failed.mdx` (new)
- `src/content/docs/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout.mdx` (new)
- `src/content/docs/reference/api-and-sdk/troubleshooting/errors/index.mdx` — list both under Platform errors
- `src/sidebar.ts` — add to the Errors sidebar group after `internal-error`
- `vercel.json` — add underscore→hyphen 308 redirects for each code (both with and without trailing slash), matching every other error code

## Validation
- `python3 -c "import json; json.load(open('vercel.json'))"` passes.
- New error-page slugs match the canonical underscore codes from `platformerrors.go`.

_Conversation: https://staging.warp.dev/conversation/dae12801-fa4e-406c-8d65-c8010ad4cc39_
_Run: https://oz.staging.warp.dev/runs/019e6b9f-8f5c-7dd1-bd37-e57a8c6b2d1d_
_This PR was generated with [Oz](https://warp.dev/oz)._
