### PR TITLE
docs: expose agent followups endpoint

### DIFF
--- a/.agents/skills/sync-openapi-spec/references/sync-policy.md
+++ b/.agents/skills/sync-openapi-spec/references/sync-policy.md
@@ -22,9 +22,8 @@ The `/harness-support/*` endpoints form the worker-to-server contract used by Oz
 
 ## Excluded paths (within otherwise-public tags)
 
-These five `agent`-tag paths are excluded individually because the `agent` tag itself remains public:
+These four `agent`-tag paths are excluded individually because the `agent` tag itself remains public:
 
-- `/agent/runs/{runId}/followups` — internal followup-prompt mechanism used by the harness; not for direct customer use.
 - `/agent/runs/{runId}/handoff/attachments` — handoff plumbing tied to local-to-cloud session handoff.
 - `/agent/handoff/upload-snapshot` — handoff plumbing (snapshot upload from a local worker).
 - `/agent/conversations/{conversation_id}/fork` — conversation-forking primitive used by the harness, not stable public API.

--- a/.agents/skills/sync-openapi-spec/scripts/sync_openapi.py
+++ b/.agents/skills/sync-openapi-spec/scripts/sync_openapi.py
@@ -47,7 +47,6 @@ EXCLUDED_TAGS: frozenset[str] = frozenset({"memory_stores", "harness-support"})
 # the public API reference. Keep in sync with references/sync-policy.md.
 EXCLUDED_PATHS: frozenset[str] = frozenset(
     {
-        "/agent/runs/{runId}/followups",
         "/agent/runs/{runId}/handoff/attachments",
         "/agent/handoff/upload-snapshot",
         "/agent/conversations/{conversation_id}/fork",
@@ -459,7 +458,10 @@ def _self_test() -> int:
 
     out = transform(sample)
     paths = set(out["paths"].keys())
-    assert paths == {"/agent/run"}, f"unexpected paths: {paths}"
+    assert paths == {
+        "/agent/run",
+        "/agent/runs/{runId}/followups",
+    }, f"unexpected paths: {paths}"
 
     schemas = set(out["components"]["schemas"].keys())
     # Config and Mode are reachable transitively (allOf, items)

--- a/developers/agent-api-openapi.yaml
+++ b/developers/agent-api-openapi.yaml
@@ -638,6 +638,70 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /agent/runs/{runId}/followups:
+    post:
+      summary: Submit a follow-up message for a run
+      description: |
+        Send a follow-up message to an existing run. The server transparently
+        routes the message based on the current state of the run (still
+        queued, actively running, or ended). A 200 response means the follow-up
+        was accepted; updated run state can be observed via
+        `GET /agent/runs/{runId}`.
+      operationId: submitRunFollowup
+      tags:
+      - agent
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: runId
+        in: path
+        description: The unique identifier of the run
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunFollowupRequest'
+      responses:
+        '200':
+          description: Follow-up accepted
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Invalid request (empty message, no active sandbox without conversation ID, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: No permission to submit follow-ups for this run
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Run not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /agent/conversations/{conversation_id}:
     get:
       summary: Get normalized conversation
@@ -3312,6 +3376,23 @@ components:
       - authentication_required
       - resource_unavailable
       - internal_error
+    RunFollowupRequest:
+      type: object
+      description: Request body for submitting a follow-up message to an existing run.
+      required:
+      - message
+      properties:
+        message:
+          type: string
+          x-oapi-codegen-extra-tags:
+            binding: required
+          description: The follow-up message to send to the run.
+        mode:
+          $ref: '#/components/schemas/AgentRunMode'
+          description: |
+            Optional query mode for the follow-up. Defaults to `normal` when
+            omitted. The server does not infer mode from prompt prefixes such
+            as `/plan`.
     ListModelsResponse:
       type: object
       required:


### PR DESCRIPTION
## Summary

Expose `POST /agent/runs/{runId}/followups` in the public Agent API reference as a focused one-off update.

This PR:
- Removes `/agent/runs/{runId}/followups` from the OpenAPI sync exclusion policy.
- Updates the sync policy reference to list the remaining intentionally hidden `agent` paths.
- Regenerates `developers/agent-api-openapi.yaml` so Scalar renders the follow-up endpoint and `RunFollowupRequest` schema.

To keep this PR focused, the generated YAML was regenerated from the same `warp-server` source commit used by the last docs sync (`810f9bce554ff3c276b308e4cf741f0f39bc954b`) after removing only this exclusion, rather than pulling in unrelated current `warp-server` OpenAPI drift.

## Related issues

Slack request to make `POST /api/v1/agent/runs/{runId}/followups` visible in `docs.warp.dev/api#tag/agent`.

## Validation

- `python3 .agents/skills/sync-openapi-spec/scripts/sync_openapi.py --mode self-test` → `self-test: OK`
- Regenerated `developers/agent-api-openapi.yaml` with `--mode apply` → `All $refs resolve in the regenerated spec.`
- Verified `submitRunFollowup`, `/agent/runs/{runId}/followups`, and `RunFollowupRequest` are present in `developers/agent-api-openapi.yaml`.
- `npm ci`
- `npm run build` → 333 pages built successfully; only existing non-blocking prerender/header warnings were emitted.

## Screenshots

Not included; this is an OpenAPI spec update rendered by Scalar.

## Follow-ups

Current `warp-server` has additional OpenAPI drift beyond this endpoint (`client-events`, `timeline`, and schema changes). Those are intentionally out of scope for this one-off and can be handled by a separate full sync PR.

_Conversation: https://staging.warp.dev/conversation/f637f93c-9eed-4ce7-8580-296680a9b963_
_Run: https://oz.staging.warp.dev/runs/019e6f6c-a0c5-7d55-bb00-70ecc0beea75_
_This PR was generated with [Oz](https://warp.dev/oz)._
