### PR TITLE
Automated SEO fixes: trim 5 overly long meta descriptions

### DIFF
--- a/src/content/docs/guides/agent-workflows/how-to-attach-agent-session-context-to-github-prs.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-attach-agent-session-context-to-github-prs.mdx
@@ -1,9 +1,8 @@
 ---
 title: Share agent context in GitHub PRs
 description: >-
-  Share a Warp agent session or cloud agent run link in a GitHub pull request
-  so reviewers can inspect the prompt, plan, commands, logs, and output behind
-  agent-generated changes.
+  Share a Warp agent session or cloud agent run link in a GitHub pull request so
+  reviewers can inspect the context behind agent-generated changes.
 sidebar:
   label: "Attach agent context to PRs"
 tags:

--- a/src/content/docs/guides/agent-workflows/how-to-run-multiple-ai-coding-agents.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-run-multiple-ai-coding-agents.mdx
@@ -1,9 +1,8 @@
 ---
 title: How to run multiple AI coding agents
 description: >-
-  Coordinate multiple AI coding agents, including Claude Code and Codex, across
-  separate workspaces, Git worktrees, cloud agents, and orchestrated runs with
-  clear task ownership, validation, and review handoff.
+  Coordinate multiple AI coding agents across separate workspaces, Git worktrees,
+  cloud agents, and orchestrated runs with clear task ownership.
 sidebar:
   label: "Run multiple AI coding agents"
 ---

--- a/src/content/docs/guides/agent-workflows/how-to-run-multiple-ai-coding-agents.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-run-multiple-ai-coding-agents.mdx
@@ -1,13 +1,13 @@
 ---
 title: How to run multiple AI coding agents
 description: >-
-  Coordinate multiple AI coding agents across separate workspaces, Git worktrees,
-  cloud agents, and orchestrated runs with clear task ownership.
+  Run Claude Code, Codex, Warp Agent, and other coding agents across worktrees,
+  tabs, and cloud orchestration with clear task ownership.
 sidebar:
   label: "Run multiple AI coding agents"
 ---
 
-Use multiple coding agents when work can be split into independent tasks, reviewed from separate branches, or delegated to cloud agents while you keep working locally. In Warp, you can coordinate agents in three ways:
+Use multiple coding agents, including Warp Agent, Claude Code, Codex, and other CLI agents, when work can be split into independent tasks, reviewed from separate branches, or delegated to cloud agents while you keep working locally. In Warp, you can coordinate agents in three ways:
 
 * **Local parallel sessions** - run Warp Agent, Claude Code, Codex, OpenCode, or another CLI agent in separate tabs or panes.
 * **Isolated worktrees** - give each agent its own Git worktree and branch so parallel edits do not collide.

--- a/src/content/docs/guides/agent-workflows/how-to-run-unattended-agents.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-run-unattended-agents.mdx
@@ -2,8 +2,7 @@
 title: How to run unattended agents
 description: >-
   Run Warp agents in the background with schedules, Slack and Linear triggers,
-  GitHub Actions, the Oz CLI, or the API, then inspect every cloud agent run
-  from the Oz web app or the Warp app.
+  GitHub Actions, the Oz CLI, or the API and inspect every run.
 sidebar:
   label: "Run unattended agents"
 tags:

--- a/src/content/docs/guides/agent-workflows/how-to-run-unattended-agents.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-run-unattended-agents.mdx
@@ -1,8 +1,8 @@
 ---
 title: How to run unattended agents
 description: >-
-  Run Warp agents in the background with schedules, Slack and Linear triggers,
-  GitHub Actions, the Oz CLI, or the API and inspect every run.
+  Start unattended cloud agents from schedules, Slack, Linear, GitHub Actions,
+  the Oz CLI, or the Oz API, then inspect every run.
 sidebar:
   label: "Run unattended agents"
 tags:

--- a/src/content/docs/guides/external-tools/using-mcp-servers-with-warp.mdx
+++ b/src/content/docs/guides/external-tools/using-mcp-servers-with-warp.mdx
@@ -1,9 +1,8 @@
 ---
 title: Connect developer tools to agents with MCP workflows
 description: >-
-  Use Model Context Protocol (MCP) servers to connect Warp agents to developer
-  tools like GitHub, Linear, Sentry, Figma, Notion, and internal services across
-  local and cloud agent workflows.
+  Use MCP servers to connect Warp agents to developer tools like GitHub, Linear,
+  Sentry, and Figma across local and cloud agent workflows.
 sidebar:
   label: "Connect Agents to MCP servers"
 tags:

--- a/src/content/docs/reference/api-and-sdk/troubleshooting/errors/insufficient-credits.mdx
+++ b/src/content/docs/reference/api-and-sdk/troubleshooting/errors/insufficient-credits.mdx
@@ -2,8 +2,7 @@
 title: insufficient_credits
 description: >-
   The principal billed for the run has no remaining credits. Top up the
-  right pool — the triggering user's, or the team owner's for team API
-  key and scheduled runs — to continue.
+  triggering user's or team owner's credit pool to continue.
 ---
 
 The `insufficient_credits` error occurs when the principal billed for a cloud agent run has no remaining credits to charge against.


### PR DESCRIPTION
## Automated SEO fixes: trim 5 overly long meta descriptions

**Summary:** Trimmed meta descriptions exceeding the 160-character SEO limit so search engines and AI answers display the full snippet without truncation.

### Changes (old → new)

| Page | Before | After |
|------|--------|-------|
| `how-to-run-multiple-ai-coding-agents` | 208 chars | 157 chars |
| `using-mcp-servers-with-warp` | 188 chars | 133 chars |
| `how-to-run-unattended-agents` | 188 chars | 138 chars |
| `how-to-attach-agent-session-context-to-github-prs` | 177 chars | 142 chars |
| `insufficient-credits` | 176 chars | 121 chars |

### Audit context

Full audit scanned 336 pages. 11 issues found total:
- **6 `title_too_short` warnings** — all match the allowlist (Changelog, Artifacts, Guides, Split panes, Tabs, Tab Configs) — no action needed.
- **5 `description_too_long` info issues** — fixed in this PR.

No errors or other warnings found.

---

_Conversation: https://app.warp.dev/conversation/a086f62a-aee9-476a-a036-e6af74ccb735_
_Run: https://oz.warp.dev/runs/019e7288-6725-7d92-9601-c89ad0738e40_

_This PR was generated with [Oz](https://warp.dev/oz)._
