### PR TITLE
fix: update astro to resolve CVE-2026-45028

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@radix-ui/react-popover": "^1.1.15",
         "@vercel/analytics": "^2.0.0",
         "@vercel/speed-insights": "^2.0.0",
-        "astro": "^6.1.8",
+        "astro": "^6.1.10",
         "keymatch": "^1.0.5",
         "linkedom": "^0.18.12",
         "react": "^19.2.4",
@@ -6690,14 +6690,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.8.tgz",
-      "integrity": "sha512-6fT9M12U3fpi13DiPavNKDIoBflASTSxmKTEe+zXhWtlebQuOqfOnIrMWyRmlXp+mgDsojmw+fVFG9LUTzKSog==",
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.10.tgz",
+      "integrity": "sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/markdown-remark": "7.1.0",
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/markdown-remark": "7.1.1",
         "@astrojs/telemetry": "3.3.1",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -6729,7 +6729,7 @@
         "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "rehype": "^13.0.2",
         "semver": "^7.7.4",
         "shiki": "^4.0.2",
@@ -6742,9 +6742,9 @@
         "ultrahtml": "^1.6.0",
         "unifont": "~0.7.4",
         "unist-util-visit": "^5.1.0",
-        "unstorage": "^1.17.4",
+        "unstorage": "^1.17.5",
         "vfile": "^6.0.3",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
@@ -6776,6 +6776,44 @@
       },
       "peerDependencies": {
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/markdown-remark": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.1.tgz",
+      "integrity": "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/prism": "4.0.1",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "js-yaml": "^4.1.1",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.0",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
       }
     },
     "node_modules/astro/node_modules/@shikijs/core": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@vercel/analytics": "^2.0.0",
     "@vercel/speed-insights": "^2.0.0",
-    "astro": "^6.1.8",
+    "astro": "^6.1.10",
     "keymatch": "^1.0.5",
     "linkedom": "^0.18.12",
     "react": "^19.2.4",


### PR DESCRIPTION
## Summary
- Update direct dependency `astro` from `^6.1.8` to `^6.1.10`.
- Update `package-lock.json` so `astro` resolves to `6.1.10`, the patched version for CVE-2026-45028.
- No workaround or override was needed.

## Security
- Advisory: https://github.com/withastro/astro/security/advisories/GHSA-xr5h-phrj-8vxv
- GitHub Advisory: https://github.com/advisories/GHSA-xr5h-phrj-8vxv
- Dependabot alert: https://github.com/warpdotdev/docs/security/dependabot/8
- Dependency relationship: direct runtime dependency

## Verification
- `npx -y npm@10 audit --json` no longer reports `astro`.
- `npx -y npm@10 ci`
- `npx -y npm@10 run typecheck`
- `npx -y npm@10 run build`

_Conversation: https://staging.warp.dev/conversation/8e180e72-2d88-4a5f-b30b-1cd561dcca12_
_Run: https://oz.staging.warp.dev/runs/019e83e9-da97-7dab-8218-52c764eda608_
_This PR was generated with [Oz](https://warp.dev/oz)._
