### PR TITLE
Fix copy button alignment with page title

### DIFF
--- a/src/components/CopyPageButton.astro
+++ b/src/components/CopyPageButton.astro
@@ -219,7 +219,6 @@ const claudeUrl = `https://claude.ai/new?q=${prompt}`;
     position: relative;
     display: inline-flex;
     align-items: center;
-    margin-top: 1rem;
   }
 
   /* Matches the Search + Ask paired-chrome pills via the shared

--- a/src/components/CustomPageTitle.astro
+++ b/src/components/CustomPageTitle.astro
@@ -55,7 +55,7 @@ const eyebrow = topicLabel && parentGroup && parentGroup !== topicLabel
 <style>
   .page-title-row {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: space-between;
     gap: 1rem;
   }


### PR DESCRIPTION
## Problem
The page-level **Copy** button rendered in the gap between the H1 title and the page description, looking misaligned (it floated below the title's top edge).

## Cause
`CustomPageTitle.astro` laid out the title row with `align-items: flex-start`, while the button wrapper in `CopyPageButton.astro` added `margin-top: 1rem`. Together these pushed the button down so it sat between the header and the description instead of beside the title.

## Fix
- `CustomPageTitle.astro`: change `.page-title-row` to `align-items: center` so the button vertically centers against the H1.
- `CopyPageButton.astro`: remove the `margin-top: 1rem` offset on `.copy-dropdown-wrapper`.

The button now aligns vertically with the page title.

_Conversation: https://staging.warp.dev/conversation/55929c99-8257-4c20-b510-3f6f5bb757b5_
_Run: https://oz.staging.warp.dev/runs/019e8af6-1eab-7070-ab25-5744483c2dd5_

_This PR was generated with [Oz](https://warp.dev/oz)._
