### PR TITLE
docs: add AEO cross-links for agents and orchestration

### DIFF
--- a/src/content/docs/agent-platform/capabilities/planning.mdx
+++ b/src/content/docs/agent-platform/capabilities/planning.mdx
@@ -113,3 +113,4 @@ As the agent executes your plan, you'll review code changes and may want to scal
 
 * **[Interactive Code Review](/agent-platform/local-agents/interactive-code-review/)** - Leave inline comments on agent-generated diffs and have the agent revise in one pass.
 * **[Cloud Agents quickstart](/agent-platform/cloud-agents/quickstart/)** - Run agents in the cloud for longer tasks, background automation, or parallel work across repos.
+* **[Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/)** - When `/plan` proposes orchestration, a parent agent spawns child agents to parallelize work. Review the orchestration config in the plan card before children launch.

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/warp-agent.mdx
@@ -17,7 +17,7 @@ Warp Agent is the same agent runtime that powers Agent Mode in the Warp terminal
 * **Full terminal and tool access** - Runs commands, edits files, reads logs, executes tests, navigates repos, and calls MCP servers, giving cloud runs the same toolbelt Warp Agent uses locally.
 * **Platform-native context** - Reads [Codebase Context](/agent-platform/capabilities/codebase-context/), applies [Rules](/agent-platform/capabilities/rules/), reuses saved [Skills](/agent-platform/capabilities/skills/), and respects Memory and Warp Drive context with no extra setup.
 * **Multi-repo execution** - Clones every repo configured on the [environment](/agent-platform/cloud-agents/environments/) and works across them in a single run.
-* **Cross-harness orchestration parent** - A Warp Agent parent run can spawn Claude Code or Codex [subagents](/agent-platform/cloud-agents/overview/) and coordinate their outputs. Other harnesses cannot act as parents in a multi-harness orchestration.
+* **Cross-harness orchestration parent** - A Warp Agent parent run can spawn Claude Code or Codex [subagents](/agent-platform/cloud-agents/orchestration/) and coordinate their outputs. Other harnesses cannot act as parents in a multi-harness orchestration.
 * **No extra credentials** - Warp Agent uses your existing Warp account and credits. There's no separate API key to configure.
 
 ## How it works
@@ -38,7 +38,7 @@ Warp Agent is the orchestration host for multi-harness runs. A typical pattern l
 2. The parent dispatches Claude Code subagents for steps that need careful review and Codex subagents for high-volume edits.
 3. The parent collects results, resolves conflicts, and returns a single final output (a PR, a report, a Slack reply).
 
-Subagents run in the same environment as the parent and share the same secrets, MCP servers, and integrations. The transcript shows the full tree, so reviewers can see exactly which subagent did what.
+Subagents run in the same environment as the parent and share the same secrets, MCP servers, and integrations. The transcript shows the full tree, so reviewers can see exactly which subagent did what. For the full parent/child model, run state transitions, messaging, and common patterns, see [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/). To start an orchestrated run, see [Running orchestrated agents](/agent-platform/cloud-agents/orchestration/multi-agent-runs/).
 
 ## When to choose Warp Agent
 

--- a/src/content/docs/agent-platform/cloud-agents/platform.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/platform.mdx
@@ -79,7 +79,9 @@ oz agent run ...
 
 ### Warp Orchestrator
 
-The orchestration layer manages the lifecycle of cloud agent tasks. It creates tasks, tracks state transitions, and is the system of record for what’s running and what ran.
+The orchestration layer manages the lifecycle of cloud agent tasks. It creates tasks, tracks state transitions, and is the system of record for what's running and what ran.
+
+The orchestrator also powers [multi-agent orchestration](/agent-platform/cloud-agents/orchestration/), where a parent agent spawns and coordinates child agents across local and cloud runs. See [Running orchestrated agents](/agent-platform/cloud-agents/orchestration/multi-agent-runs/) for how to start orchestrated runs from the CLI, slash commands, the web app, or the API.
 
 #### What the orchestrator does
 

--- a/src/content/docs/agent-platform/cloud-agents/quickstart.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/quickstart.mdx
@@ -174,3 +174,4 @@ Now that you've run your first cloud agent, automate recurring work or connect a
 * **[Scheduled Agents quickstart](/agent-platform/cloud-agents/triggers/scheduled-agents-quickstart/)** - Set up an agent to run on a cron schedule for recurring tasks like weekly dependency checks.
 * **[Integrations quickstart](/agent-platform/cloud-agents/integrations/quickstart/)** - Connect Oz to Slack and Linear so your team can trigger agents from mentions and issues.
 * **[Skills](/agent-platform/capabilities/skills/)** - Turn successful agent workflows into reusable instructions you can schedule, trigger, or share.
+* **[Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/)** - Coordinate a parent agent and child agents to parallelize work, delegate specialized tasks, or verify output across local and cloud runs.

--- a/src/content/docs/agent-platform/cloud-agents/skills-as-agents.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/skills-as-agents.mdx
@@ -144,6 +144,7 @@ Suggested skills appear on the Agents page under the **Suggested** filter.
 * [Skills](/agent-platform/capabilities/skills/) — How to create skills and skill file format
 * [Environments](/agent-platform/cloud-agents/environments/) — Configure repositories and runtime context for cloud agents
 * [Scheduled Agents](/agent-platform/cloud-agents/triggers/scheduled-agents/) — Run agents automatically on a cron schedule
+* [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/) — Use skills within orchestrated workflows where a parent agent coordinates child agents
 * [Oz Web App](/agent-platform/cloud-agents/oz-web-app/) — Visual interface for managing cloud agents
 * [Oz CLI](/reference/cli/) — Command-line interface for running agents
 * [Oz API & SDK](/reference/api-and-sdk/) — Programmatic access to cloud agents


### PR DESCRIPTION
## Summary

Add internal cross-links between agent, cloud agent, and orchestration documentation pages where orchestration concepts are discussed or referenced but not linked to the actual orchestration docs.

## Source signals

- **Peec MCP**: Not available in this environment
- **GSC (Google Search Console)**: Not available (`GSC_SERVICE_ACCOUNT_CREDENTIALS_JSON` not set)
- **Docs-internal evidence**: All links are backed by content analysis — each edited page discusses orchestration features (subagents, `/plan` orchestration config, fan-out, parent/child model) without linking to the orchestration documentation

## Pages touched (5 files, 7 links added)

### `agent-platform/capabilities/planning.mdx`
- **Added**: Link to [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/) in "Next steps" section
- **Rationale**: `/plan` is a primary entry point for orchestration (the plan card surfaces an inline orchestration config). The orchestration docs (orchestration/index.mdx, multi-agent-runs.mdx) explicitly describe `/plan` as an orchestration entry point, but planning.mdx didn't link back.

### `agent-platform/cloud-agents/harnesses/warp-agent.mdx`
- **Fixed**: Changed `[subagents](/agent-platform/cloud-agents/overview/)` → `[subagents](/agent-platform/cloud-agents/orchestration/)` — the link target was the generic overview page, but subagents are documented on the orchestration page.
- **Added**: Two orchestration links at the end of the "Cross-harness orchestration" section, pointing to orchestration/index.mdx and orchestration/multi-agent-runs.mdx.
- **Rationale**: This page has a dedicated "Cross-harness orchestration" section describing orchestration patterns without any link to the orchestration documentation.

### `agent-platform/cloud-agents/quickstart.mdx`
- **Added**: Link to [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/) in "What to explore next" section
- **Rationale**: The quickstart mentions "Launch parallel cloud coding agents" as a use case but the next-steps section didn't include orchestration. Natural progression from first cloud agent.

### `agent-platform/cloud-agents/platform.mdx`
- **Added**: Orchestration docs cross-reference in the "Warp Orchestrator" section, linking to both orchestration/index.mdx and multi-agent-runs.mdx.
- **Rationale**: The section describes "The orchestration layer" without linking to the user-facing orchestration feature documentation.

### `agent-platform/cloud-agents/skills-as-agents.mdx`
- **Added**: Link to [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/) in "Related resources"
- **Rationale**: multi-agent-runs.mdx references selecting a "skill that performs orchestration" when starting a run from the Oz web app. The reverse link was missing.

## Rejected candidates

- **`agents.mdx`**: Focused on cloud agent identities/service accounts, not capabilities. Orchestration link would be tangential.
- **`handoff/index.mdx`**: Handoff and orchestration are distinct concepts. Handoff mentions "fan out variants" but in the context of local-to-cloud promotion, not multi-agent orchestration.
- **`scheduled-agents.mdx`**: Schedules and orchestration don't overlap directly.
- **`how-to-run-3-agents-in-parallel.mdx`**: Very short video-based guide with no Related/Next Steps section to extend.
- **`environments.mdx`**: Already links to relevant pages; orchestration isn't a natural cross-link from environment configuration.

## Validation

- `git diff --check` — clean (no whitespace errors)
- `npm run build` — succeeds (336 pages, 0 errors)
- All link targets verified to exist on disk

## Open questions

- Peec and GSC data were unavailable. If those tools become available, re-running this audit could surface additional high-value cross-link opportunities based on AI-search fanout queries and organic search terms.
- The `how-to-run-3-agents-in-parallel` guide could benefit from a Related Pages section linking to both orchestration and the comprehensive multi-agent guide, but adding a new section is a larger change than this PR's scope.

---

_Conversation: https://app.warp.dev/conversation/a76e6886-85d5-49c7-9cef-a497844260ea_
_Run: https://oz.warp.dev/runs/019e8eac-40e3-7d1a-b07c-69f5ab2426c2_

_This PR was generated with [Oz](https://warp.dev/oz)._
