### PR TITLE
Add internal cross-links for agent scheduling, monitoring, and triggers

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/agents.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/agents.mdx
@@ -58,7 +58,7 @@ When a team is over its plan limit (for example, after downgrading), the extra a
 
 * **Agents page** - The Agents page in the [Oz web app](/agent-platform/cloud-agents/oz-web-app/) is where teams view, create, edit, and delete cloud agents.
 * **Agent picker** - Forms that start a new run or schedule include an **Agent** dropdown. **Quick run** is the default (runs execute as the calling user); picking a cloud agent runs as the cloud agent instead.
-* **Run filters and detail** - The Runs view lets you filter by cloud agent, and individual run detail pages show which agent executed the run.
+* **Run filters and detail** - The [Runs view](/agent-platform/cloud-agents/managing-cloud-agents/) lets you filter by cloud agent, and [individual run detail pages](/agent-platform/cloud-agents/viewing-cloud-agent-runs/) show which agent executed the run.
 * **Admin Panel** - Billing usage in the [Admin Panel](/knowledge-and-collaboration/admin-panel/) attributes credits consumed by cloud agent runs to the team rather than to a person.
 
 ## Related pages

--- a/src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx
@@ -281,7 +281,7 @@ Each scheduled run behaves like a standard cloud agent run, with a few important
 * Runs execute automatically without human intervention.
 * All usage is billed to the team’s shared credit balance.
 
-If a scheduled run fails, it does not block future runs. Each execution is independent. Use the [API error reference](/reference/api-and-sdk/troubleshooting/errors/) to interpret any returned error code.
+If a scheduled run fails, it does not block future runs. Each execution is independent. Use the [API error reference](/reference/api-and-sdk/troubleshooting/errors/) to interpret any returned error code. To review what a scheduled run did, use the [Agent Management Panel](/agent-platform/cloud-agents/managing-cloud-agents/) to find the run by status or trigger, then open the session with [cloud agent session sharing](/agent-platform/cloud-agents/viewing-cloud-agent-runs/) to inspect the prompt, commands, logs, and output.
 
 ### Permissions and responsibility
 
@@ -300,6 +300,6 @@ Carefully review prompts and schedules before deploying them broadly, especially
 
 Scheduled Agents are best when work should happen on a predictable cadence.
 
-If you want an agent to run in response to an event, such as a Slack mention, PR update, or issue change, use triggered cloud agents instead.
+If you want an agent to run in response to an event, such as a Slack mention, PR update, or issue change, use [triggered cloud agents](/agent-platform/cloud-agents/integrations/) instead.
 
 Many teams use both together: triggers for reactive workflows, and Scheduled Agents for proactive maintenance.


### PR DESCRIPTION
## Summary

Adds 4 internal cross-links across 2 pages to improve navigation between agent scheduling, monitoring, and trigger docs.

### Source signals

- **Peec AEO snapshot** (`buzz:rachael/aeo-snapshot-pilot`, `aeo-snapshots/docs/agents-orchestration/latest.json`, generated 2026-06-04, window 2026-05-05 to 2026-06-04): high-volume prompt signals for monitoring/observing agents in real time, triggering agents from Slack/Linear/GitHub, and managing multiple agents.
- **Google Search Console** (2026-05-05 to 2026-06-03): confirmed traffic to `cloud-agents/overview`, `cloud-agents/agents`, and `cloud-agents/integrations/` pages; orchestration-related queries landing on the how-to-run-multiple-agents guide.

### Changes

**`scheduled-agents.mdx`** (2 links added):
1. Execution model section → linked to [Agent Management Panel](/agent-platform/cloud-agents/managing-cloud-agents/) and [cloud agent session sharing](/agent-platform/cloud-agents/viewing-cloud-agent-runs/) so readers can find run review surfaces after learning about scheduled run behavior.
2. "When to use Scheduled Agents vs triggers" section → linked "triggered cloud agents" to the [Integrations overview](/agent-platform/cloud-agents/integrations/) so the comparison has a concrete destination.

**`agents.mdx`** (2 links added):
3. "Where cloud agents appear in the product" section → linked "Runs view" to [Managing cloud agents](/agent-platform/cloud-agents/managing-cloud-agents/) and "individual run detail pages" to [Viewing cloud agent runs](/agent-platform/cloud-agents/viewing-cloud-agent-runs/).

### Pages inspected (no change needed)

- `cloud-agents/overview.mdx` — already well cross-linked to all relevant targets
- `cloud-agents/orchestration/index.mdx` — already links to managing, overview, deployment, multi-agent runs, and guide
- `cloud-agents/orchestration/multi-agent-runs.mdx` — already links to orchestration, managing, environments, CLI, API
- `cloud-agents/managing-cloud-agents.mdx` — already links to overview, orchestration, viewing runs, handoff, oz-web-app
- `cloud-agents/viewing-cloud-agent-runs.mdx` — already links to managing, session sharing, attach-session guide
- `cloud-agents/integrations/slack.mdx` — already links to viewing-cloud-agent-runs, oz-web-app
- `cloud-agents/integrations/linear.mdx` — already links to viewing-cloud-agent-runs, oz-web-app
- `cloud-agents/integrations/github-actions.mdx` — already links to unattended-agents guide, skills, API keys
- `cloud-agents/skills-as-agents.mdx` — already links to scheduled-agents, environments, CLI
- `cloud-agents/triggers/index.mdx` — already links to scheduled-agents, CLI, API, integrations
- `cloud-agents/triggers/scheduled-agents-quickstart.mdx` — already links to scheduled-agents, integrations-quickstart, unattended-agents guide
- `guides/agent-workflows/how-to-run-unattended-agents.mdx` — hub page, already cross-linked to all trigger types
- `guides/agent-workflows/how-to-run-multiple-ai-coding-agents.mdx` — already cross-linked to orchestration, managing, oz-web-app

### Rejected candidates

- `orchestration/index.mdx` line 32 mentions "Slack, Linear, a schedule, or the API" inline but the context is describing execution combinations, not recommending those pages — linking would be link-stuffing.
- `viewing-cloud-agent-runs.mdx` doesn't mention scheduled triggers, but adding a schedule link would be tangential to the page's focus on session sharing.
- `triggers/index.mdx` is a concise 4-bullet index page — adding monitoring links would change its purpose.

### Validation

- All 4 link target files verified to exist on disk
- `git diff --check` clean (no whitespace errors)

---

_Conversation: https://app.warp.dev/conversation/5a63bf1a-fe92-4d3a-b25c-5d69b0e866f6_
_Run: https://oz.warp.dev/runs/019e9342-db77-7e91-a63f-bfbe88c34da7_

_This PR was generated with [Oz](https://warp.dev/oz)._
