### PR TITLE
docs: add AEO cross-links for agents and orchestration

### DIFF
--- a/.agents/skills/aeo_crosslink_audit/SKILL.md
+++ b/.agents/skills/aeo_crosslink_audit/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: aeo_crosslink_audit
+description: Run a narrow AEO cross-link audit for Warp docs using Peec, Google Search Console, and existing docs. Use for recurring or scheduled agents that should identify high-confidence internal cross-linking improvements for agents, cloud agents, and orchestration docs.
+---
+
+# AEO cross-link audit
+
+Identify small, high-confidence internal cross-linking improvements for the Warp docs. This skill is designed for a recurring Oz scheduled agent that audits one narrow topic area, opens a small PR when there are safe changes, or writes a no-change report when there are not enough high-confidence opportunities.
+
+## Scope
+
+Use this skill only for the pilot topic area:
+- Agents
+- Cloud agents
+- Orchestration
+
+The audit should focus on one improvement type:
+- Internal cross-links between existing docs pages
+
+Do not:
+- Create new pages.
+- Rewrite large sections.
+- Make broad SEO or AEO recommendations.
+- Add keyword-stuffed text.
+- Force Peec or Google Search Console signals into docs when they do not support a useful reader journey.
+
+## Source data
+
+Use the smallest reliable set of source data needed to justify link changes:
+- **Peec MCP** - Review recent prompts, recommendations, source URLs, and query vocabulary related to agents, cloud agents, and orchestration.
+- **Google Search Console** - When available, use the environment's `GSC_SERVICE_ACCOUNT_CREDENTIALS_JSON` secret to inspect recent queries and pages related to agents, cloud agents, and orchestration.
+- **Docs repo** - Search existing pages under `src/content/docs/` for relevant source pages, link targets, and related terminology.
+
+If Peec or Google Search Console data is unavailable, say what could not be verified and proceed only with repo-grounded recommendations. Do not invent source signals.
+
+## Workflow
+
+1. **Gather source signals.** Use Peec MCP and Google Search Console data, when available, to identify relevant user language, prompts, recommendations, or pages.
+2. **Search existing docs.** Look for pages under `src/content/docs/` that already mention or imply related concepts in agents, cloud agents, or orchestration.
+3. **Identify link opportunities.** Find up to 5 internal cross-link opportunities where:
+   - The source page already mentions or implies the related concept.
+   - The target page exists.
+   - The link helps a reader continue a real workflow.
+   - The edit can be made with a small, natural copy change.
+4. **Make only safe edits.** Add links with minimal surrounding copy changes. Preserve the existing page structure and voice.
+5. **Run self-review.** Apply the quality gates in this skill before opening a PR or writing a no-change report.
+6. **Open a PR or report no changes.** Open a PR only when there are at least 2 high-confidence link additions. Otherwise, write a no-change report in the Oz run output.
+
+## Self-review before opening a PR
+
+Before opening a PR, verify every proposed change:
+- **Real signal** - Each link is backed by a Peec, Google Search Console, or existing-docs signal, not generic SEO advice.
+- **Reader value** - Each link helps a developer understand or complete a real workflow.
+- **Natural language** - The added link text reads naturally in context and is not keyword-stuffed.
+- **Existing target** - Every internal link points to an existing file under `src/content/docs/`.
+- **Navigation awareness** - Check `src/sidebar.ts` when a linked page is expected to appear in navigation.
+- **Small scope** - The diff is limited to cross-linking and small copy changes needed to make links natural.
+- **No broad rewrites** - Remove any edit that becomes a rewrite, strategy recommendation, or new content proposal.
+- **No duplication** - Do not add links that create repetitive related-links lists or duplicate nearby links.
+
+Run:
+
+```bash
+git diff --check
+```
+
+## PR requirements
+
+Open a PR only when there are at least 2 high-confidence link additions.
+
+Use this title format:
+
+```text
+docs: add AEO cross-links for agents and orchestration
+```
+
+The PR body must include an AEO brief. Use `.agents/skills/aeo_brief/SKILL.md` as the format and include:
+- **Goal** - Identify small internal cross-link improvements for agents, cloud agents, and orchestration docs.
+- **Source signals** - Peec prompts/recommendations, Google Search Console queries/pages, or existing-docs signals that justified the links.
+- **Pages touched** - Files edited and why.
+- **Links added** - Source page, target page, and rationale for each link.
+- **Open questions for human review** - Anything that affects product accuracy, terminology, or placement.
+
+Request review from docs and growth-docs reviewers where possible, including:
+- Rachael
+- Petra
+- Hong Yi
+- Danny
+- Other active reviewers in `#growth-docs`
+
+## No-change report
+
+If there are fewer than 2 high-confidence link opportunities, do not open a PR. Write a no-change report in the Oz run output so reviewers can inspect it from the Oz web app Runs page and shared session history.
+
+Use this format:
+
+```text
+## AEO cross-link audit no-change report
+
+**Topic area:** Agents, cloud agents, and orchestration.
+
+**Source signals reviewed:**
+- [Peec prompt, recommendation, source URL, or query vocabulary.]
+- [Google Search Console query, page, or trend.]
+- [Existing-docs signal.]
+
+**Docs pages inspected:**
+- `[path]` - [Why it was inspected.]
+
+**Candidate links rejected:**
+- `[source path]` → `[target path]` - [Why this was not high-confidence.]
+
+**Why no PR was opened:**
+- [Reason.]
+
+**Suggested prompt or skill improvement:**
+- [One specific improvement for the next run.]
+```
+
+For the pilot, no-change reports stay in the Oz run output. If team input is needed, share the Oz run link manually in `#growth-docs`.
+
+## Human review expectations
+
+The human reviewer should be able to understand the PR or no-change report without replaying the full run. Optimize the output for quick review:
+- Keep PRs small and focused.
+- Explain the source signal behind each link.
+- Flag any uncertainty directly.
+- Avoid hiding product or terminology questions in the diff.
+
+## Future expansion boundaries
+
+Do not implement future expansion ideas in this pilot skill. If the audit finds opportunities outside internal cross-linking, mention them only as follow-up recommendations in the PR body or no-change report.
+
+Possible future phases include:
+- Existing-doc improvements such as terminology additions, clearer headings, or better descriptions.
+- New-guide recommendations using AEO briefs before drafting.
+- Cross-linking across docs and marketing pages.
+- Broader Peec content-gap integration with Buzz's `peec-content-gap` workflow.
+- Lightweight trend reporting across scheduled runs.

--- a/.agents/skills/aeo_crosslink_audit/SKILL.md
+++ b/.agents/skills/aeo_crosslink_audit/SKILL.md
@@ -28,7 +28,7 @@ Do not:
 
 Use the smallest reliable set of source data needed to justify link changes:
 - **Peec MCP** - Review recent prompts, recommendations, source URLs, and query vocabulary related to agents, cloud agents, and orchestration.
-- **Google Search Console** - When available, use the environment's `GSC_SERVICE_ACCOUNT_CREDENTIALS_JSON` secret to inspect recent queries and pages related to agents, cloud agents, and orchestration.
+- **Google Search Console** - When available, use the environment's `GSC_SERVICE_ACCOUNT_CREDENTIALS_JSON` secret to inspect recent queries and pages related to agents, cloud agents, and orchestration. Never print, log, commit, or include the secret value in reports. If a GSC client requires a credentials file path, write the secret to a restricted temporary file, use it for the run, and remove it before finishing.
 - **Docs repo** - Search existing pages under `src/content/docs/` for relevant source pages, link targets, and related terminology.
 
 If Peec or Google Search Console data is unavailable, say what could not be verified and proceed only with repo-grounded recommendations. Do not invent source signals.
@@ -67,6 +67,7 @@ Before opening a PR, verify every proposed change:
 - **Anchor quality** - Link text is descriptive and specific; no raw URL anchors or generic anchors like "here," "this page," "learn more," or "read more."
 - **Link context** - The surrounding sentence explains why the destination is relevant when the link target is not obvious.
 - **Existing target** - Every internal link points to an existing file under `src/content/docs/`.
+- **Anchor and route validation** - If a link includes a heading anchor or route path, verify that the route and anchor resolve. Do not rely only on the target file existing.
 - **Navigation awareness** - Check `src/sidebar.ts` when a linked page is expected to appear in navigation.
 - **Small scope** - The diff is limited to cross-linking and small copy changes needed to make links natural.
 - **No broad rewrites** - Remove any edit that becomes a rewrite, strategy recommendation, or new content proposal.
@@ -76,6 +77,7 @@ Run:
 
 ```bash
 python3 .agents/skills/style_lint/style_lint.py --changed
+python3 .agents/skills/check_for_broken_links/check_links.py --internal-only
 git diff --check
 ```
 

--- a/.agents/skills/aeo_crosslink_audit/SKILL.md
+++ b/.agents/skills/aeo_crosslink_audit/SKILL.md
@@ -42,9 +42,21 @@ If Peec or Google Search Console data is unavailable, say what could not be veri
    - The target page exists.
    - The link helps a reader continue a real workflow.
    - The edit can be made with a small, natural copy change.
-4. **Make only safe edits.** Add links with minimal surrounding copy changes. Preserve the existing page structure and voice.
+4. **Make only safe edits.** Add links with minimal surrounding copy changes. Preserve the existing page structure and voice. Follow the link quality rules below when choosing anchor text and surrounding context.
 5. **Run self-review.** Apply the quality gates in this skill before opening a PR or writing a no-change report.
 6. **Open a PR or report no changes.** Open a PR only when there are at least 2 high-confidence link additions. Otherwise, write a no-change report in the Oz run output.
+
+## Link quality rules
+
+When adding links, follow the link style guidance in `AGENTS.md` and validate with `style_lint`.
+
+- **Use descriptive anchors** - Link meaningful destination text, not generic phrases like "here," "this page," "learn more," "read more," or raw URLs.
+- **Add context before the link when needed** - If the destination page is not obvious from the sentence, introduce why the reader should follow it. Do not drop a link into a sentence without explaining its relevance.
+- **Use natural destination-page phrasing** - Prefer wording like "the Runs page in the Oz web app," "the Scheduled Agents guide," or "the Slack integration guide" when naming a destination.
+- **Avoid redundant prefixes** - Do not add a bold term or label immediately before a link if the link text already provides the context.
+- **Keep links reader-first** - The link should help a developer continue the task or understand the concept, not exist only for SEO/AEO coverage.
+- **Avoid link stuffing** - Do not add multiple links to the same nearby destination or turn a paragraph into a dense cluster of links.
+- **Resolve redirects** - Link directly to the final destination page when known. Do not add redirecting URLs or old paths.
 
 ## Self-review before opening a PR
 
@@ -52,6 +64,8 @@ Before opening a PR, verify every proposed change:
 - **Real signal** - Each link is backed by a Peec, Google Search Console, or existing-docs signal, not generic SEO advice.
 - **Reader value** - Each link helps a developer understand or complete a real workflow.
 - **Natural language** - The added link text reads naturally in context and is not keyword-stuffed.
+- **Anchor quality** - Link text is descriptive and specific; no raw URL anchors or generic anchors like "here," "this page," "learn more," or "read more."
+- **Link context** - The surrounding sentence explains why the destination is relevant when the link target is not obvious.
 - **Existing target** - Every internal link points to an existing file under `src/content/docs/`.
 - **Navigation awareness** - Check `src/sidebar.ts` when a linked page is expected to appear in navigation.
 - **Small scope** - The diff is limited to cross-linking and small copy changes needed to make links natural.
@@ -61,6 +75,7 @@ Before opening a PR, verify every proposed change:
 Run:
 
 ```bash
+python3 .agents/skills/style_lint/style_lint.py --changed
 git diff --check
 ```
 

--- a/src/content/docs/agent-platform/cloud-agents/orchestration/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/orchestration/index.mdx
@@ -88,7 +88,7 @@ The parent (the "writer") proposes a solution, then spawns a critic child to rev
 
 ### Review swarm (cloud → cloud)
 
-A scheduled or webhook-triggered parent spawns one cloud child per open pull request to run reviews in parallel. Each child posts its findings as a comment and exits. The parent fans in the results and posts a summary back to the triggering system.
+A [scheduled](/agent-platform/cloud-agents/triggers/scheduled-agents/) or webhook-triggered parent spawns one cloud child per open pull request to run reviews in parallel. Each child posts its findings as a comment and exits. The parent fans in the results and posts a summary back to the triggering system.
 
 ### DAG
 

--- a/src/content/docs/agent-platform/cloud-agents/platform.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/platform.mdx
@@ -90,6 +90,7 @@ The orchestrator:
 * Tracks lifecycle state (created → running → completed/failed) and associated metadata.
 * Exposes task lifecycle operations via the [Oz CLI](/reference/cli/) and a [REST API](/reference/api-and-sdk/) (create tasks, query history, and inspect status/outputs).
 * Powers SDKs (TypeScript/Python) for programmatic usage on top of the orchestrator API.
+* Supports [multi-agent orchestration](/agent-platform/cloud-agents/orchestration/) for parent/child workflows, fan-out, and review swarms.
 
 #### When teams use the API/SDK
 

--- a/src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx
@@ -300,6 +300,6 @@ Carefully review prompts and schedules before deploying them broadly, especially
 
 Scheduled Agents are best when work should happen on a predictable cadence.
 
-If you want an agent to run in response to an event, such as a Slack mention, PR update, or issue change, use triggered cloud agents instead.
+If you want an agent to run in response to an event, such as a Slack mention, PR update, or issue change, use [integrations](/agent-platform/cloud-agents/integrations/) to trigger cloud agents instead.
 
-Many teams use both together: triggers for reactive workflows, and Scheduled Agents for proactive maintenance.
+Many teams use both together: [triggers](/agent-platform/cloud-agents/triggers/) for reactive workflows, and Scheduled Agents for proactive maintenance.


### PR DESCRIPTION
## AEO cross-link audit: agents and orchestration

### Goal
Identify small internal cross-linking improvements for agents, cloud agents, and orchestration docs, backed by Peec and Google Search Console signals.

### Source signals

**Peec (snapshot 2026-05-05 → 2026-06-04):**
- "how do I set up AI coding agents to run on a schedule or in the background?" (high volume)
- "what's the best platform for scheduling and managing AI coding agents across a team?" (high volume)
- "how do I trigger AI coding agents automatically from Slack, Linear, or GitHub?" (high volume)
- "what are the best tools for managing multiple AI coding agents?" (high volume)

**Google Search Console (2026-05-05 → 2026-06-03):**
- "warp orchestration" → 13 impressions hitting homepage and `/agent-platform/`, 0 clicks to orchestration page
- "oz orchestration platform" → impressions on `/agent-platform/cloud-agents/platform/`, not the orchestration page
- "scheduled agent" / "how can i schedule overnight batch agents" → hitting scheduled agents pages (5–7 impressions)

**Existing-docs signal:**
- `platform.mdx` "Warp Orchestrator" section describes orchestration lifecycle but never links to `/agent-platform/cloud-agents/orchestration/`
- `orchestration/index.mdx` "Review swarm" pattern mentions "A scheduled or webhook-triggered parent" with no link to scheduling docs
- `scheduled-agents.mdx` "When to use" section mentions "triggered cloud agents" and "triggers for reactive workflows" with no links

### Pages touched

- `src/content/docs/agent-platform/cloud-agents/platform.mdx` — Added bullet linking the Warp Orchestrator section to multi-agent orchestration docs. Reason: GSC shows orchestration queries hitting this page, but readers can't navigate to the orchestration docs from here.
- `src/content/docs/agent-platform/cloud-agents/orchestration/index.mdx` — Linked "scheduled" in the Review swarm pattern to the scheduled agents page. Reason: Peec prompt about scheduling agents maps directly to this pattern.
- `src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx` — Linked "triggered cloud agents" to integrations and "triggers" to triggers overview in the "When to use" section. Reason: Peec prompts about triggering from Slack/Linear/GitHub match this decision point.

### Links added

| Source page | Target page | Rationale |
|---|---|---|
| `platform.mdx` (Warp Orchestrator) | `/agent-platform/cloud-agents/orchestration/` | Orchestration queries land on platform page but can't navigate to orchestration docs |
| `orchestration/index.mdx` (Review swarm) | `/agent-platform/cloud-agents/triggers/scheduled-agents/` | Peec: high interest in scheduling + orchestration; pattern mentions scheduling without a link |
| `scheduled-agents.mdx` (When to use) | `/agent-platform/cloud-agents/integrations/` | Peec: high interest in triggering from Slack/Linear/GitHub; section mentions triggered agents without a link |
| `scheduled-agents.mdx` (When to use) | `/agent-platform/cloud-agents/triggers/` | Same section, connects reactive triggers to the overview page |

### Validation

- `style_lint --all`: 0 issues on changed files (419 pre-existing across repo)
- `check_links --internal-only`: 0 broken links (2890 internal links checked)
- `git diff --check`: clean

### Open questions for human review

- The platform.mdx orchestrator section describes the platform's lifecycle layer, not multi-agent orchestration specifically. The added bullet connects them — verify this is the right framing vs. a separate subsection.
- Should the orchestration page's "Review swarm" pattern also link to the integrations page for webhook-triggered parents, or is that too many links in one sentence?

---

_Conversation: https://app.warp.dev/conversation/476b8b48-9041-4498-86cf-a358b89434e4_
_Run: https://oz.warp.dev/runs/019e9377-0d17-7ccb-a5dc-34b701554b4d_

_This PR was generated with [Oz](https://warp.dev/oz)._
