### PR TITLE
Center width-constrained figures and harden default image centering

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -285,7 +285,7 @@ body {
 /* Link-wrapped images render as <p><a><img></a></p>. The inline <a>
    shrink-wraps the image, so auto margins on the <img> alone can't pull it
    to the page center — center the anchor's inline box via the paragraph. */
-.sl-markdown-content p:has(> a > img) {
+.sl-markdown-content p:has(> a > img):not(:where(table *)) {
   text-align: center;
 }
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -276,7 +276,7 @@ body {
    specificity, so the exclusion never fights the rest of the selector.
    Code-block figures are handled separately below. */
 .sl-markdown-content :not(table) > img:not(:where(table *)),
-.sl-markdown-content p > img {
+.sl-markdown-content p > img:not(:where(table *)) {
   display: block;
   margin-left: auto;
   margin-right: auto;

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -263,12 +263,30 @@ body {
   color: #faf9f6;
 }
 
-/* Center all images in content by default (excluding those inside tables) */
-.sl-markdown-content :not(table) > img,
+/* Center images in content by default.
+
+   Covers every standard embed pattern used in the docs:
+     * standalone markdown images  → <p><img>
+     * link-wrapped images         → <p><a><img></a></p>
+     * raw/standalone <img> in any other non-table wrapper
+
+   The `:not(:where(table *))` guard genuinely excludes images inside
+   tables (an in-cell image's parent is <td>, not <table>, so the old
+   `:not(table)` never actually excluded them). `:where()` has zero
+   specificity, so the exclusion never fights the rest of the selector.
+   Code-block figures are handled separately below. */
+.sl-markdown-content :not(table) > img:not(:where(table *)),
 .sl-markdown-content p > img {
   display: block;
   margin-left: auto;
   margin-right: auto;
+}
+
+/* Link-wrapped images render as <p><a><img></a></p>. The inline <a>
+   shrink-wraps the image, so auto margins on the <img> alone can't pull it
+   to the page center — center the anchor's inline box via the paragraph. */
+.sl-markdown-content p:has(> a > img) {
+  text-align: center;
 }
 
 /* Figures — centered block with image and optional caption.
@@ -280,9 +298,15 @@ body {
    language. Don't repeat surrounding prose or list everything visible.
 
    Exclude Expressive Code figures (code blocks) — they render inside a
-   `.expressive-code` wrapper and must not be center-aligned. */
+   `.expressive-code` wrapper and must not be center-aligned.
+
+   Horizontal margins are `auto` so a width-constrained figure (e.g.
+   `<figure style={{ maxWidth: "563px" }}>`) centers on the page. With
+   `margin: 1.5em 0` such a figure keeps zero side margins and sits flush
+   left, since `text-align: center` only centers content inside the box,
+   not the box itself. Full-width figures resolve auto margins to 0. */
 .sl-markdown-content figure:not(.expressive-code figure) {
-  margin: 1.5em 0;
+  margin: 1.5em auto;
   text-align: center;
 }
 


### PR DESCRIPTION
## What

Fixes the issue where many embedded images were not center-aligned on the page — most visibly on the **Prompt queueing** page.

## Root cause

Images in the docs are wrapped in `<figure>`. The figure rule in `src/styles/custom.css` used `margin: 1.5em 0`. For figures with a constrained width (e.g. `<figure style={{ maxWidth: "563px" }}>`), the zero horizontal margins kept the box flush left. The existing `text-align: center` only centers content *inside* the figure box, not the box itself — so a narrow figure sat on the left edge of the content column.

This `maxWidth` figure pattern is used across ~17 pages (prompt queueing, Oz web app, Code Review panel, managing cloud agents, handoff, MCP, and more), so they were all affected.

## Changes (`src/styles/custom.css`)

- **Center width-constrained figures**: change the figure margin from `1.5em 0` to `1.5em auto`. Full-width figures resolve auto margins to `0`, so they're unaffected.
- **Center link-wrapped images** (`<p><a><img></a></p>`): add a `p:has(> a > img)` rule that centers via the paragraph, since the inline `<a>` shrink-wraps the image and defeats `margin: auto` on the image alone.
- **Fix the table exclusion**: the old `:not(table) > img` never actually excluded in-table images (an in-cell image's parent is `<td>`, not `<table>`). Replaced with `:not(:where(table *))`, which uses zero-specificity `:where()` so it doesn't fight the rest of the selector.

`:has()` and `:where()` are already used elsewhere in the same stylesheet, so this stays within the existing browser-support baseline.

## Validation

- `npm run build` passes.
- No content/MDX files changed — CSS-only.

_Conversation: https://staging.warp.dev/conversation/08538da7-499e-4217-b64e-22d6167af5be_
_Run: https://oz.staging.warp.dev/runs/019e9524-466c-7542-9e6e-954819f2b4b0_

_This PR was generated with [Oz](https://warp.dev/oz)._
