### PR TITLE
docs: add AEO cross-links for agents and orchestration

### DIFF
--- a/src/content/docs/agent-platform/capabilities/planning.mdx
+++ b/src/content/docs/agent-platform/capabilities/planning.mdx
@@ -113,3 +113,4 @@ As the agent executes your plan, you'll review code changes and may want to scal
 
 * **[Interactive Code Review](/agent-platform/local-agents/interactive-code-review/)** - Leave inline comments on agent-generated diffs and have the agent revise in one pass.
 * **[Cloud Agents quickstart](/agent-platform/cloud-agents/quickstart/)** - Run agents in the cloud for longer tasks, background automation, or parallel work across repos.
+* **[Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/)** - When `/plan` detects that a task benefits from parallel work, it proposes an orchestration config that spawns child agents to divide the work.

--- a/src/content/docs/agent-platform/cloud-agents/environments.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/environments.mdx
@@ -64,7 +64,7 @@ Components in the execution flow:
 2. **Task** – Warp creates a tracked task for the run
 3. **Environment** – The task uses an environment to define execution context
 4. **Host** – The environment runs on a host (Warp-hosted or self-hosted infrastructure).
-5. **Agent execution** – The workflow runs in the prepared environment
+5. **Agent execution** – The workflow runs in the prepared environment. In [orchestrated runs](/agent-platform/cloud-agents/orchestration/), each child agent gets its own environment so that parallel agents are isolated from each other.
 6. **Outputs** – The run produces PRs, messages, reports, or transcripts
 
 :::note

--- a/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/harnesses/index.mdx
@@ -22,6 +22,7 @@ Third-party harnesses inherit the same Oz platform features as Warp Agent:
 * **Triggers** — Slack, Linear, schedules, CI, and API [triggers](/agent-platform/cloud-agents/triggers/) launch any harness.
 * **Environments and secrets** — Reuse the same [environments](/agent-platform/cloud-agents/environments/) and [agent secrets](/agent-platform/cloud-agents/secrets/).
 * **Skills and Rules** — Saved [Skills](/agent-platform/capabilities/skills/) and [Rules](/agent-platform/capabilities/rules/) apply across harnesses.
+* **Orchestration** — A parent agent running one harness can spawn child agents that run a [different harness](/agent-platform/cloud-agents/orchestration/#where-parent-and-child-agents-can-run).
 * **Observability** — Every run produces a transcript and shareable session in the [Oz dashboard](/agent-platform/cloud-agents/managing-cloud-agents/).
 
 ## Billing

--- a/src/content/docs/agent-platform/getting-started/agents-in-warp.mdx
+++ b/src/content/docs/agent-platform/getting-started/agents-in-warp.mdx
@@ -102,7 +102,7 @@ The same agent capabilities that power interactive conversations in Warp also ru
 
 * React to events from Slack, Linear, or GitHub
 * Run on schedules for recurring tasks like dependency updates
-* Execute in parallel across repos or tasks
+* Execute in parallel across repos or tasks using [multi-agent orchestration](/agent-platform/cloud-agents/orchestration/)
 * Produce tracked, auditable, shareable runs
 
 Cloud agents are ideal for work that doesn't need your immediate attention—PR reviews, issue triage, routine maintenance, and integration-driven workflows.


### PR DESCRIPTION
## AEO cross-link audit: agents, cloud agents, and orchestration

### Goal
Identify small internal cross-link improvements for agents, cloud agents, and orchestration docs — the pilot topic area for the AEO cross-link audit skill.

### Source signals

**Google Search Console (March–June 2026):**
- "warp multi agent" (18 impressions, 4 clicks) → lands on guides and getting-started pages but not the orchestration docs
- "cloud orchestration" / "warp orchestration" (11+ impressions) → lands on the Oz Platform page and homepage, not the orchestration page
- "ai coding agent orchestration" → lands on `agent-platform/` root

These queries indicate users searching for orchestration and multi-agent concepts are landing on pages that don't link to the orchestration docs.

**Existing-docs signals:**
- `planning.mdx` documents `/plan`, which is one of the two entry points for orchestration, but didn't link to orchestration
- `agents-in-warp.mdx` mentions "Execute in parallel across repos or tasks" without explaining how
- `harnesses/index.mdx` lists shared platform features but omitted orchestration, even though orchestration supports mixed harnesses
- `environments.mdx` describes the execution flow without mentioning how orchestration uses environments

**Peec:** Not available in this environment. Recommendations are grounded in GSC + repo signals only.

### Pages touched

| File | Why |
|------|-----|
| `capabilities/planning.mdx` | `/plan` proposes orchestration when beneficial — readers learning about planning should discover this |
| `getting-started/agents-in-warp.mdx` | "Parallel execution" bullet needed a path for the reader to learn how |
| `cloud-agents/harnesses/index.mdx` | Orchestration works across harnesses — readers evaluating harnesses should know this |
| `cloud-agents/environments.mdx` | Orchestrated child agents each get their own environment — readers configuring environments should understand this use case |

### Links added

| Source page | Target page | Reader next step |
|-------------|-------------|-----------------|
| `planning.mdx` → Next steps | `/agent-platform/cloud-agents/orchestration/` | A reader who just learned about `/plan` wants to know they can use it to coordinate multiple agents |
| `agents-in-warp.mdx` → From local to cloud | `/agent-platform/cloud-agents/orchestration/` | A reader exploring cloud agents wants to know how to run tasks in parallel |
| `harnesses/index.mdx` → What stays the same | `/agent-platform/cloud-agents/orchestration/#where-parent-and-child-agents-can-run` | A reader choosing a harness wants to know that a parent on Warp Agent can spawn children on Claude Code or Codex |
| `environments.mdx` → Execution flow | `/agent-platform/cloud-agents/orchestration/` | A reader configuring environments wants to understand that orchestrated children each get their own environment |

### Open questions for human review
- The harnesses link targets the `#where-parent-and-child-agents-can-run` anchor — verify this renders correctly in the live Astro build.
- The environments edit adds a clause to an existing numbered-list item. Confirm the sentence reads naturally in context.

---

_Conversation: https://app.warp.dev/conversation/3b0029f0-d95d-4f95-8fc6-8b13c681ed8f_
_Run: https://oz.warp.dev/runs/019e9702-c000-77a0-b913-10c63bc02ce1_

_This PR was generated with [Oz](https://warp.dev/oz)._
