### PR TITLE
docs: note teams can't be deleted with unused add-on credits

### DIFF
--- a/src/content/docs/enterprise/team-management/teams.mdx
+++ b/src/content/docs/enterprise/team-management/teams.mdx
@@ -60,6 +60,10 @@ If you've received an invite link, use it to sign up or log in and join the team
 * **Team Owners** - Can delete a team, but only after removing all other team members first.
 
 :::caution
+A team can't be deleted while it has unused add-on credits. Before you can delete the team, all add-on credits tied to it must be used up or expired. If you need to remove unused credits to delete the team, contact [support@warp.dev](mailto:support@warp.dev).
+:::
+
+:::caution
 If you're a Team Owner and choose to [delete your Warp account](/support-and-community/privacy-and-security/privacy/#delete-your-account-and-data), you'll need to assign a team member as the new owner before your account can be deleted.
 :::
 

--- a/src/content/docs/knowledge-and-collaboration/teams.mdx
+++ b/src/content/docs/knowledge-and-collaboration/teams.mdx
@@ -67,6 +67,10 @@ If you have received an invite link, you can use that link to sign up or log in 
 
 If you’re a member of a team, you can visit **Settings** > **Teams** to leave a team at any time. Team admins (who created teams) may delete a team only after removing all team members.
 
+:::caution
+A team can't be deleted while it has unused add-on credits. Before you can delete the team, all add-on credits tied to it must be used up or expired. If you need to remove unused credits to delete the team, contact [support@warp.dev](mailto:support@warp.dev).
+:::
+
 On Build, Max, and Business plans, [add-on credits](/support-and-community/plans-and-billing/add-on-credits/) are scoped to each individual user but **tied to the team** they were purchased under. Membership changes affect access:
 
 * **A user leaves a team** - You lose access to any add-on credits tied to that team. If you rejoin the same team later, you regain access to any unused, non-expired credits. The admin pays a prorated rate for your seat on rejoin.

--- a/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/add-on-credits.mdx
@@ -99,7 +99,7 @@ Add-on credits are tied to the team they were purchased under. The flows below d
 
 * **A user leaves a team** - You lose access to any add-on credits tied to that team. If you rejoin the same team later, you regain access to any unused, non-expired credits. The admin pays a prorated rate for your seat on rejoin.
 * **An admin removes a member** - That member loses access to any add-on credits tied to the team. If they rejoin later, they regain access to any unused, non-expired credits.
-* **An admin deletes the team** - Any remaining add-on credits tied to the team are no longer usable.
+* **An admin deletes the team** - Any remaining add-on credits must be used or removed before a team can be deleted. Please contact (support@warp.dev)[mailto:support@warp.dev], if you need help with this.
 
 :::note
 All unused add-on credits remain valid for 12 months from purchase, as long as you have an active subscription.


### PR DESCRIPTION
## Summary
Documents that a Warp team can't be deleted while it has unused add-on credits, matching the in-product message ("Your team cannot be deleted with unused add-on credits"). Adds a `:::caution` callout to the "Leaving and deleting teams" sections of both teams pages, explaining that add-on credits tied to the team must be used or expired before deletion, and pointing users to support@warp.dev if they need unused credits removed.

Files changed:
- `src/content/docs/knowledge-and-collaboration/teams.mdx`
- `src/content/docs/enterprise/team-management/teams.mdx`

## Related issues
Raised in #feedback-revenue Slack thread — a customer was stuck deleting a team due to unused add-on credits, and the behavior wasn't documented.

## Validation
Edits use the existing `:::caution` Starlight callout pattern already present in these files. No structural/navigation changes.

## Screenshots
N/A

## Follow-ups
None.

_Conversation: https://staging.warp.dev/conversation/e8e301a3-c2de-44b5-a863-cbe607e48ed4_
_Run: https://oz.staging.warp.dev/runs/019ead35-cdfc-78a0-b058-9662a3e4a0a1_

_This PR was generated with [Oz](https://warp.dev/oz)._
