### PR TITLE
docs: add Claude Fable 5 and its data retention requirement

### DIFF
--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -55,8 +55,13 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 
 #### Anthropic
 
+Claude Fable 5 is Anthropic's newest generally available model for autonomous, long-running coding and knowledge work.
+
 | Model | `model_id` | Variant |
 | --- | --- | --- |
+| Claude Fable 5 | `claude-5-fable-xhigh` | Default effort |
+| Claude Fable 5 | `claude-5-fable-high` | High effort |
+| Claude Fable 5 | `claude-5-fable-max` | Max effort |
 | Claude Opus 4.7 | `claude-4-7-opus-xhigh` | Default effort |
 | Claude Opus 4.7 | `claude-4-7-opus-high` | High effort |
 | Claude Opus 4.7 | `claude-4-7-opus-max` | Max effort |
@@ -69,6 +74,10 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 | Claude Sonnet 4.5 | `claude-4-5-sonnet` | Thinking off |
 | Claude Sonnet 4.5 | `claude-4-5-sonnet-thinking` | Thinking on |
 | Claude Haiku 4.5 | `claude-4-5-haiku` | — |
+
+:::caution
+Anthropic requires limited data retention for Claude Fable 5 for safety, abuse monitoring, and compliance reasons. As a result, Claude Fable 5 is **not available under Zero Data Retention (ZDR)**. This requirement is specific to Claude Fable 5 and does not change the ZDR behavior of any other supported model. For Enterprise teams, Claude Fable 5 is off by default and a workspace admin must enable it — see [Admin Panel](/enterprise/team-management/admin-panel/#models) and the [Security overview](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr).
+:::
 
 #### Google
 
@@ -133,3 +142,5 @@ Warp has executed **Zero Data Retention (ZDR)** agreements with these providers.
 * LLM providers commit to delete inputs and outputs after generating the relevant output, within a fixed time period.
 
 Warp enforces these commitments through both technical measures and contractual safeguards with the LLM providers.
+
+Zero data retention is available for supported models. Model availability may vary where providers require limited data retention for safety, abuse monitoring, or compliance reasons. For example, Anthropic requires limited data retention for [Claude Fable 5](#anthropic), so it is not available under ZDR; this applies only to that model and does not change the ZDR behavior of other supported models.

--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -74,7 +74,7 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 | Claude Haiku 4.5 | `claude-4-5-haiku` | — |
 
 :::caution
-Anthropic requires data retention for Claude Fable 5 for safety, abuse monitoring, and compliance reasons. As a result, Claude Fable 5 is **not available under Zero Data Retention (ZDR)**. This requirement is specific to Claude Fable 5 and does not change the ZDR behavior of any other supported model. For Enterprise teams, Claude Fable 5 is off by default and a workspace admin must enable it — see [Admin Panel](/enterprise/team-management/admin-panel/#models) and the [Security overview](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr).
+Anthropic requires data retention for Claude Fable 5 for safety, abuse monitoring, and compliance reasons, so it is **not available under Zero Data Retention (ZDR)**. This requirement is specific to Claude Fable 5 and doesn't change the ZDR behavior of any other supported model. For Enterprise teams, the model is off by default and a workspace admin must enable it — see the [Admin Panel](/enterprise/team-management/admin-panel/#models-settings) and the [Security overview](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr).
 :::
 
 #### Google

--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -55,8 +55,6 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 
 #### Anthropic
 
-Claude Fable 5 is Anthropic's newest generally available model for autonomous, long-running coding and knowledge work.
-
 | Model | `model_id` | Variant |
 | --- | --- | --- |
 | Claude Fable 5 | `claude-5-fable-xhigh` | Default effort |
@@ -76,7 +74,7 @@ Claude Fable 5 is Anthropic's newest generally available model for autonomous, l
 | Claude Haiku 4.5 | `claude-4-5-haiku` | — |
 
 :::caution
-Anthropic requires limited data retention for Claude Fable 5 for safety, abuse monitoring, and compliance reasons. As a result, Claude Fable 5 is **not available under Zero Data Retention (ZDR)**. This requirement is specific to Claude Fable 5 and does not change the ZDR behavior of any other supported model. For Enterprise teams, Claude Fable 5 is off by default and a workspace admin must enable it — see [Admin Panel](/enterprise/team-management/admin-panel/#models) and the [Security overview](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr).
+Anthropic requires data retention for Claude Fable 5 for safety, abuse monitoring, and compliance reasons. As a result, Claude Fable 5 is **not available under Zero Data Retention (ZDR)**. This requirement is specific to Claude Fable 5 and does not change the ZDR behavior of any other supported model. For Enterprise teams, Claude Fable 5 is off by default and a workspace admin must enable it — see [Admin Panel](/enterprise/team-management/admin-panel/#models) and the [Security overview](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr).
 :::
 
 #### Google
@@ -143,4 +141,4 @@ Warp has executed **Zero Data Retention (ZDR)** agreements with these providers.
 
 Warp enforces these commitments through both technical measures and contractual safeguards with the LLM providers.
 
-Zero data retention is available for supported models. Model availability may vary where providers require limited data retention for safety, abuse monitoring, or compliance reasons. For example, Anthropic requires limited data retention for [Claude Fable 5](#anthropic), so it is not available under ZDR; this applies only to that model and does not change the ZDR behavior of other supported models.
+Zero data retention is available for supported models. Model availability may vary where providers require data retention for safety, abuse monitoring, or compliance reasons.

--- a/src/content/docs/enterprise/security-and-compliance/security-overview.mdx
+++ b/src/content/docs/enterprise/security-and-compliance/security-overview.mdx
@@ -34,7 +34,7 @@ How data collection works by plan:
 Some product features — including cloud conversations and Oz runs — require storing conversation data to function. This data is stored to power the product experience and is separate from analytics or telemetry data collection.
 :::
 
-Some models carry provider-specific data retention requirements and are therefore not covered by ZDR. For example, Anthropic requires limited data retention for [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic) for safety, abuse monitoring, and compliance reasons. For Enterprise teams, these models are **off by default**; a workspace admin must explicitly enable them in the [Admin Panel](/enterprise/team-management/admin-panel/#models). This applies only to the affected model and does not change the ZDR behavior of other supported models.
+Some models carry provider-specific data retention requirements and are therefore not covered by ZDR. For example, Anthropic requires data retention for [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic). For Enterprise teams, these models are **off by default**; a workspace admin must explicitly enable them in the [Admin Panel](/enterprise/team-management/admin-panel/#models).
 
 Enterprise subscriptions also include:
 

--- a/src/content/docs/enterprise/security-and-compliance/security-overview.mdx
+++ b/src/content/docs/enterprise/security-and-compliance/security-overview.mdx
@@ -34,7 +34,7 @@ How data collection works by plan:
 Some product features — including cloud conversations and Oz runs — require storing conversation data to function. This data is stored to power the product experience and is separate from analytics or telemetry data collection.
 :::
 
-Some models carry provider-specific data retention requirements and are therefore not covered by ZDR. For example, Anthropic requires data retention for [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic). For Enterprise teams, these models are **off by default**; a workspace admin must explicitly enable them in the [Admin Panel](/enterprise/team-management/admin-panel/#models).
+Some models carry provider-specific data retention requirements and are therefore not covered by ZDR. For Enterprise teams, these models are **off by default**; a workspace admin must explicitly enable them in the [Admin Panel](/enterprise/team-management/admin-panel/#models-settings).
 
 Enterprise subscriptions also include:
 

--- a/src/content/docs/enterprise/security-and-compliance/security-overview.mdx
+++ b/src/content/docs/enterprise/security-and-compliance/security-overview.mdx
@@ -34,6 +34,8 @@ How data collection works by plan:
 Some product features — including cloud conversations and Oz runs — require storing conversation data to function. This data is stored to power the product experience and is separate from analytics or telemetry data collection.
 :::
 
+Some models carry provider-specific data retention requirements and are therefore not covered by ZDR. For example, Anthropic requires limited data retention for [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic) for safety, abuse monitoring, and compliance reasons. For Enterprise teams, these models are **off by default**; a workspace admin must explicitly enable them in the [Admin Panel](/enterprise/team-management/admin-panel/#models). This applies only to the affected model and does not change the ZDR behavior of other supported models.
+
 Enterprise subscriptions also include:
 
 * **Team-level enforcement** - Admins configure data collection and telemetry policies for the entire organization through the Admin Panel

--- a/src/content/docs/enterprise/team-management/admin-panel.mdx
+++ b/src/content/docs/enterprise/team-management/admin-panel.mdx
@@ -211,13 +211,13 @@ When enabled, agents understand your code patterns, architecture, and convention
 * Up to 200,000 files per repository
 * Team-wide indexing with centralized configuration
 
-### Models
+### Models settings
 
 Control which LLM models are available to your team and how inference is routed. From the **Models** page, admins can enable or disable individual models and configure [Bring Your Own LLM (BYOLLM)](/enterprise/enterprise-features/bring-your-own-llm/) routing through AWS Bedrock.
 
 **Models with provider-specific data retention requirements**
 
-Some models require data retention from the model provider and are therefore not available under [Zero Data Retention (ZDR)](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr). For Enterprise teams, these models are **disabled by default**. A workspace admin must explicitly enable them before team members can use them. For example, [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic) requires data retention.
+Some models require data retention from the model provider and are therefore not available under [Zero Data Retention (ZDR)](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr). For Enterprise teams, these models are **disabled by default**. A workspace admin must explicitly enable them before team members can use them.
 
 ### Billing settings
 

--- a/src/content/docs/enterprise/team-management/admin-panel.mdx
+++ b/src/content/docs/enterprise/team-management/admin-panel.mdx
@@ -110,7 +110,7 @@ For complete plan details, see [Warp pricing](https://www.warp.dev/pricing) or [
 
 ## Admin Panel sections
 
-The Admin Panel is organized into six main areas:
+The Admin Panel is organized into seven main areas:
 
 ### AI settings
 
@@ -210,6 +210,20 @@ When enabled, agents understand your code patterns, architecture, and convention
 * Unlimited repositories
 * Up to 200,000 files per repository
 * Team-wide indexing with centralized configuration
+
+### Models
+
+Control which LLM models are available to your team and how inference is routed. From the **Models** page, admins can enable or disable individual models and configure [Bring Your Own LLM (BYOLLM)](/enterprise/enterprise-features/bring-your-own-llm/) routing through AWS Bedrock.
+
+**Models with provider-specific data retention requirements**
+
+Some models require limited data retention from the model provider and are therefore not available under [Zero Data Retention (ZDR)](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr). For Enterprise teams, these models are **disabled by default**. A workspace admin must explicitly enable them before team members can use them.
+
+For example, [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic) requires data retention. When you enable it, Warp surfaces a helper note:
+
+> Anthropic requires data retention for this model for a limited time for safety, abuse monitoring, and compliance reasons.
+
+Leave these models disabled if your organization has strict ZDR requirements. Enabling a model applies only to that model and does not change the ZDR behavior of other supported models.
 
 ### Billing settings
 

--- a/src/content/docs/enterprise/team-management/admin-panel.mdx
+++ b/src/content/docs/enterprise/team-management/admin-panel.mdx
@@ -217,13 +217,7 @@ Control which LLM models are available to your team and how inference is routed.
 
 **Models with provider-specific data retention requirements**
 
-Some models require limited data retention from the model provider and are therefore not available under [Zero Data Retention (ZDR)](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr). For Enterprise teams, these models are **disabled by default**. A workspace admin must explicitly enable them before team members can use them.
-
-For example, [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic) requires data retention. When you enable it, Warp surfaces a helper note:
-
-> Anthropic requires data retention for this model for a limited time for safety, abuse monitoring, and compliance reasons.
-
-Leave these models disabled if your organization has strict ZDR requirements. Enabling a model applies only to that model and does not change the ZDR behavior of other supported models.
+Some models require data retention from the model provider and are therefore not available under [Zero Data Retention (ZDR)](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr). For Enterprise teams, these models are **disabled by default**. A workspace admin must explicitly enable them before team members can use them. For example, [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic) requires data retention.
 
 ### Billing settings
 

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -242,6 +242,8 @@ Warp integrates with multiple LLM providers — including Anthropic, OpenAI, Goo
 
 Warp enforces these commitments through both technical measures and contractual safeguards with the LLM providers.
 
+Zero data retention is available for supported models. Model availability may vary where providers require limited data retention for safety, abuse monitoring, or compliance reasons. For example, Anthropic requires limited data retention for [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic), so it isn't available under ZDR. This applies only to that model and doesn't change the ZDR behavior of other supported models.
+
 ### How can I enable Zero Data Retention in Warp?
 
 Zero Data Retention (ZDR) can be enabled in two ways:
@@ -251,7 +253,7 @@ Zero Data Retention (ZDR) can be enabled in two ways:
 
 To discuss organization-wide ZDR for your team, [contact our sales team](https://www.warp.dev/contact-sales).
 
-Regardless of plan, Warp never allows OpenAI, Anthropic, Google, or other model providers to store, retain, or train their models on your data — see [Does Warp have Zero Data Retention policies with LLM providers?](#does-warp-have-zero-data-retention-policies-with-llm-providers) for details.
+Regardless of plan, Warp never allows OpenAI, Anthropic, Google, or other model providers to store, retain, or train their models on your data — see [Does Warp have Zero Data Retention policies with LLM providers?](#does-warp-have-zero-data-retention-policies-with-llm-providers) for details. A small number of models are an exception where the provider requires limited data retention for safety, abuse monitoring, or compliance reasons (for example, [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic)); these are clearly identified and, for Enterprise teams, off by default.
 
 ### Can I bring my own API key?
 

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -253,7 +253,7 @@ Zero Data Retention (ZDR) can be enabled in two ways:
 
 To discuss organization-wide ZDR for your team, [contact our sales team](https://www.warp.dev/contact-sales).
 
-Regardless of plan, Warp never allows OpenAI, Anthropic, Google, or other model providers to store, retain, or train their models on your data — see [Does Warp have Zero Data Retention policies with LLM providers?](#does-warp-have-zero-data-retention-policies-with-llm-providers) for details. A small number of models are an exception where the provider requires data retention for safety, abuse monitoring, or compliance reasons (for example, [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic)); these are clearly identified and, for Enterprise teams, off by default.
+Regardless of plan, Warp never allows OpenAI, Anthropic, Google, or other model providers to store, retain, or train their models on your data — see [Does Warp have Zero Data Retention policies with LLM providers?](#does-warp-have-zero-data-retention-policies-with-llm-providers) for details.
 
 ### Can I bring my own API key?
 

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -242,7 +242,7 @@ Warp integrates with multiple LLM providers — including Anthropic, OpenAI, Goo
 
 Warp enforces these commitments through both technical measures and contractual safeguards with the LLM providers.
 
-Zero data retention is available for supported models. Model availability may vary where providers require limited data retention for safety, abuse monitoring, or compliance reasons. For example, Anthropic requires limited data retention for [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic), so it isn't available under ZDR. This applies only to that model and doesn't change the ZDR behavior of other supported models.
+Zero data retention is available for supported models. Model availability may vary where providers require data retention for safety, abuse monitoring, or compliance reasons.
 
 ### How can I enable Zero Data Retention in Warp?
 
@@ -253,7 +253,7 @@ Zero Data Retention (ZDR) can be enabled in two ways:
 
 To discuss organization-wide ZDR for your team, [contact our sales team](https://www.warp.dev/contact-sales).
 
-Regardless of plan, Warp never allows OpenAI, Anthropic, Google, or other model providers to store, retain, or train their models on your data — see [Does Warp have Zero Data Retention policies with LLM providers?](#does-warp-have-zero-data-retention-policies-with-llm-providers) for details. A small number of models are an exception where the provider requires limited data retention for safety, abuse monitoring, or compliance reasons (for example, [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic)); these are clearly identified and, for Enterprise teams, off by default.
+Regardless of plan, Warp never allows OpenAI, Anthropic, Google, or other model providers to store, retain, or train their models on your data — see [Does Warp have Zero Data Retention policies with LLM providers?](#does-warp-have-zero-data-retention-policies-with-llm-providers) for details. A small number of models are an exception where the provider requires data retention for safety, abuse monitoring, or compliance reasons (for example, [Claude Fable 5](/agent-platform/inference/model-choice/#anthropic)); these are clearly identified and, for Enterprise teams, off by default.
 
 ### Can I bring my own API key?
 


### PR DESCRIPTION
## Summary

Documents **Claude Fable 5** in the model choice docs. The central message: Anthropic requires limited data retention for this model (for safety, abuse monitoring, and compliance reasons), so unlike every other supported model, Claude Fable 5 is **not available under Zero Data Retention (ZDR)**.

All wording is kept high-level and public-appropriate.

## Changes

- **`agent-platform/inference/model-choice.mdx`** — Add Claude Fable 5 to the Anthropic model table (with `model_id`s), a `:::caution` callout explaining the data retention requirement / ZDR exclusion, and a general carveout sentence in the *Zero data retention policies* section.
- **`enterprise/security-and-compliance/security-overview.mdx`** — Note that some models carry provider-specific retention requirements and are off by default for Enterprise (admin opt-in), cross-linking model choice and the Admin Panel.
- **`enterprise/team-management/admin-panel.mdx`** — Add a **Models** section covering model-availability control and retention-required models (disabled by default, admin-enabled), including the generalized in-product helper text.
- **`support-and-community/plans-and-billing/pricing-faqs.mdx`** — Add the same ZDR carveout to the provider-ZDR Q&As so the absolute phrasing stays accurate.

Telemetry / "Help improve Warp" data-collection statements were intentionally left unchanged, since Fable 5's retention is provider-side and decoupled from those settings.

## Enterprise placement note

Per the request, this keeps the canonical model description + ZDR carveout in **model choice** and adds short, cross-linking notes in the **enterprise** docs (security overview + admin panel). Happy to consolidate to a single enterprise location if preferred.

## To confirm before merge

- Exact published `model_id`s / variant labels for Claude Fable 5 (the values mirror the existing Claude Opus 4.7 effort-level convention).

## Validation

- `npm run build` passes (337 pages built, no errors); new anchor links resolve.

_Conversation: https://staging.warp.dev/conversation/5b7bc03a-94ce-46cd-af27-5cf20a47bf17_
_Run: https://oz.staging.warp.dev/runs/019ead8f-d89d-71c6-9dec-f9f8bc4b692e_
_Plans_:
- _[Document Claude Fable 5 and its data retention requirement](https://staging.warp.dev/drive/notebook/ZSCapJQvcfDm83UJgsDg1u)_

_This PR was generated with [Oz](https://warp.dev/oz)._
