### PR TITLE
ci: add client on-call schedule ID to release docs workflow

### DIFF
--- a/.agents/skills/release_updates/scripts/run_release_updates.py
+++ b/.agents/skills/release_updates/scripts/run_release_updates.py
@@ -145,6 +145,14 @@ def parse_args() -> argparse.Namespace:
         help="Create pull requests as draft.",
     )
     parser.add_argument(
+        "--pr-auto-merge",
+        action="store_true",
+        help=(
+            "Enable auto-merge (squash) on the PR after creation and mark it ready "
+            "for review. Requires --create-pr. Incompatible with --pr-draft."
+        ),
+    )
+    parser.add_argument(
         "--assign-oncall-reviewer",
         "--assign-oncall-reviewers",
         dest="assign_oncall_reviewers",
@@ -501,6 +509,22 @@ def _assign_reviewers(
         )
 
 
+def _enable_auto_merge(
+    *,
+    repo_path: Path,
+    pr_url: str,
+) -> None:
+    # Mark ready for review first (required before auto-merge can be enabled).
+    _run_command(
+        ["gh", "pr", "ready", pr_url],
+        cwd=repo_path,
+    )
+    _run_command(
+        ["gh", "pr", "merge", "--auto", "--squash", pr_url],
+        cwd=repo_path,
+    )
+
+
 def _validate_args(args: argparse.Namespace) -> None:
     normalized_schedule_ids: list[str] = []
     for raw_schedule_id in args.oncall_schedule_ids:
@@ -515,6 +539,10 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ValueError(
             "--assign-oncall-reviewer requires --oncall-schedule-id.",
         )
+    if args.pr_auto_merge and not args.create_pr:
+        raise ValueError("--pr-auto-merge requires --create-pr.")
+    if args.pr_auto_merge and args.pr_draft:
+        raise ValueError("--pr-auto-merge is incompatible with --pr-draft.")
 
 
 def _maybe_create_pr(
@@ -594,6 +622,8 @@ def _maybe_create_pr(
                 "[dry-run] Would assign reviewers: "
                 + ", ".join(f"@{reviewer}" for reviewer in reviewers),
             )
+        if args.pr_auto_merge:
+            eprint("[dry-run] Would enable auto-merge (squash) on PR.")
         return
 
     if not args.skip_pr_push:
@@ -618,6 +648,10 @@ def _maybe_create_pr(
             "Assigned reviewers to PR: "
             + ", ".join(f"@{reviewer}" for reviewer in reviewers),
         )
+
+    if args.pr_auto_merge:
+        _enable_auto_merge(repo_path=docs_root, pr_url=pr_url)
+        eprint(f"Auto-merge (squash) enabled on PR: {pr_url}")
 
 
 def main() -> int:

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -69,7 +69,7 @@ jobs:
               raw = {
                   "channel_versions_ref": os.environ.get("DISPATCH_CHANNEL_VERSIONS_REF") or "main",
                   "task_set": os.environ.get("DISPATCH_TASK_SET") or "changelog",
-                  "create_draft_pr": os.environ.get("DISPATCH_CREATE_DRAFT_PR") or "true",
+                  "create_draft_pr": os.environ.get("DISPATCH_CREATE_DRAFT_PR") or "false",
                   "assign_oncall_reviewers": os.environ.get("DISPATCH_ASSIGN_ONCALL_REVIEWERS") or "false",
               }
           else:
@@ -140,7 +140,7 @@ jobs:
             3. Use `warpdotdev/channel-versions` at channel_versions_ref as the source of `channel_versions.json`.
             4. Create and switch to a release docs feature branch before invoking `run_release_updates.py --create-pr`; the script refuses to create a PR from `main`.
             5. Create or update a PR against `warpdotdev/docs` `main` only if generated changes exist.
-            6. Use a draft PR when the active trigger's create_draft_pr value is true.
+            6. Use a draft PR when create_draft_pr is true. Note: --pr-draft and --pr-auto-merge are mutually exclusive; never pass both.
             7. Assign on-call reviewers only when the active trigger's assign_oncall_reviewers value is true and the required Grafana schedule IDs and `GRAFANA_API_KEY` are available.
             8. Run `npm run build` before considering the PR ready for review.
             9. If no docs changes are needed, report a no-op result and do not open a PR.
@@ -151,4 +151,8 @@ jobs:
             - all tasks: `python3 .agents/skills/release_updates/scripts/run_release_updates.py --create-pr --pr-base main`
 
             Include `--pr-draft` when create_draft_pr is true.
-            Include `--assign-oncall-reviewer` and repeated `--oncall-schedule-id` values only when reviewer assignment is enabled and configured.
+            Always include `--pr-auto-merge` (marks the PR ready for review and enables squash auto-merge).
+            When assign_oncall_reviewers is true, include:
+              --assign-oncall-reviewer --oncall-schedule-id S1BRQ4BYUP5WN --oncall-max-reviewers 2
+            This resolves up to 2 reviewers (primary + secondary) from the client on-call schedule.
+            If GRAFANA_API_KEY is not set, skip reviewer assignment and log a warning.


### PR DESCRIPTION
## Summary

Follows up on #196. Replaces the vague `--oncall-schedule-id` placeholder in the oz agent prompt with the actual client on-call Grafana schedule ID (`S1BRQ4BYUP5WN`), matching what the independabot skill uses for client repo PRs.

Uses `--oncall-max-reviewers 2` to resolve both primary and secondary on-call from the same schedule. If `GRAFANA_API_KEY` is not present in prod Oz team secrets at run time, reviewer assignment is skipped gracefully.

## Prerequisites before this works end-to-end

- `GRAFANA_API_KEY` added to prod Oz team secrets (`oz secret create GRAFANA_API_KEY`)
- `DOCS_REPOSITORY_DISPATCH_TOKEN` added to `warpdotdev/channel-versions` secrets (platform team)
- channel-versions PR: warpdotdev/channel-versions#971

Co-Authored-By: Oz <oz-agent@warp.dev>