### PR TITLE
Fix broken external links (Sentry MCP endpoint, install script)

### DIFF
--- a/src/content/docs/agent-platform/capabilities/mcp.mdx
+++ b/src/content/docs/agent-platform/capabilities/mcp.mdx
@@ -289,12 +289,12 @@ Below are examples for popular Model Context Protocol (MCP) servers.
     }
     ```
 
-    **Sentry SSE Server (URL)**
+    **Sentry Streamable HTTP Server (URL)**
 
     ```json
     {
       "Sentry": {
-        "url": "https://mcp.sentry.dev/sse"
+        "url": "https://mcp.sentry.dev/mcp"
       }
     }
     ```

--- a/src/content/docs/enterprise/getting-started/getting-started-developers.mdx
+++ b/src/content/docs/enterprise/getting-started/getting-started-developers.mdx
@@ -22,7 +22,7 @@ Warp is available for macOS, Linux, and Windows.
 Visit the [Warp download page](https://www.warp.dev/download) and select your platform:
 
 * **macOS** - Download the `.dmg` installer (macOS 10.15 Catalina or later)
-* **Linux** - Download the `.deb`, `.rpm`, or use the install script
+* **Linux** - Download the `.deb`, `.rpm`, or AppImage
 * **Windows** - Download the `.exe` installer (Windows 10 or later)
 
 ### Install Warp
@@ -39,10 +39,9 @@ sudo dpkg -i warp-terminal_*.deb
 
 # Fedora/RHEL
 sudo rpm -i warp-terminal-*.rpm
-
-# Or use the install script
-curl -fsSL https://www.warp.dev/install.sh | bash
 ```
+
+For the full list of Linux installation options, including package-manager repositories, Arch, openSUSE, and AppImage, see the [installation and setup guide](/getting-started/quickstart/installation-and-setup/).
 
 **Windows:**
 1. Run the downloaded `.exe` installer.

--- a/src/content/docs/reference/cli/mcp-servers.mdx
+++ b/src/content/docs/reference/cli/mcp-servers.mdx
@@ -86,7 +86,7 @@ Pass `--mcp` multiple times to combine UUID references, inline JSON, and file-ba
 ```sh
 $ oz agent run \
   --mcp "1deb1b14-b6e5-4996-ae99-233b7555d2d0" \
-  --mcp '{"sentry": {"url": "https://mcp.sentry.dev/sse"}}' \
+  --mcp '{"sentry": {"url": "https://mcp.sentry.dev/mcp"}}' \
   --prompt "open a PR that fixes the top Sentry error"
 ```
 


### PR DESCRIPTION
## Summary
Fixes broken external links found while auditing the docs for dead links. All external URLs in `src/content/docs/` were checked; after filtering out rate-limited (`docs.warp.dev` HTTP 429), bot-blocked (returns 200 in a browser), and illustrative-example URLs inside code blocks, two genuinely broken links remained.

## Changes
- **Sentry MCP endpoint (HTTP 410 Gone):** The `https://mcp.sentry.dev/sse` endpoint is deprecated and now returns `410 Gone`. Updated the URL-based MCP config examples to the current Streamable HTTP endpoint `https://mcp.sentry.dev/mcp` (already used by the CLI-based examples in the same docs).
  - `agent-platform/capabilities/mcp.mdx`
  - `reference/cli/mcp-servers.mdx`
- **Non-existent Linux install script (HTTP 404):** `curl -fsSL https://www.warp.dev/install.sh | bash` points to a URL that returns `404`. The canonical install guide has no such script. Removed the install-script command from the enterprise developer getting-started guide and linked to the installation and setup guide for the full list of Linux install options.
  - `enterprise/getting-started/getting-started-developers.mdx`

## Notes
- The `warpdotdev/gitbook` repo is archived; the live docs are sourced from `warpdotdev/docs`, so these fixes target the active repo.
- Other flagged 404s were verified as intentional illustrative examples inside code blocks (e.g. a Warp Drive sharing URL used to teach ID structure, an example `iframe` embed snippet, and an `auth_url` value inside example JSON) and were left unchanged.

_Conversation: https://app.warp.dev/conversation/6478be8b-9831-4214-9164-33c3429dc1d6_
_Run: https://oz.warp.dev/runs/019eb27a-0f85-7746-b207-be6a2b7f5e22_

_This PR was generated with [Oz](https://warp.dev/oz)._
