### PR TITLE
docs: add AEO cross-links for agents and orchestration

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/integrations/linear.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/integrations/linear.mdx
@@ -39,6 +39,8 @@ Agents keep you informed through:
 
 Session sharing works in Warp or in a browser view and allows multiple teammates to watch the session.
 
+To monitor Linear-triggered runs alongside the rest of your team's agents, open the [Agent Management Panel](/agent-platform/cloud-agents/managing-cloud-agents/) in the Warp app, where integration-triggered runs appear in the **All** tab.
+
 ![Live cloud agent session shared from a Linear issue, viewed in Warp on Web.](../../../../../assets/agent-platform/linear-warp-on-web.png)
 
 #### Joining the remote session

--- a/src/content/docs/agent-platform/cloud-agents/integrations/slack.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/integrations/slack.mdx
@@ -55,6 +55,8 @@ Agents keep you informed directly in Slack via:
 
 [Cloud agent session sharing](/agent-platform/cloud-agents/viewing-cloud-agent-runs/) works in Warp or in your browser and supports multiple teammates joining the same live session.
 
+To monitor Slack-triggered runs alongside the rest of your team's agents, open the [Agent Management Panel](/agent-platform/cloud-agents/managing-cloud-agents/) in the Warp app, where integration-triggered runs appear in the **All** tab.
+
 ### Joining the live remote session
 
 Selecting **View Agent** opens the active agent session. Inside the session you’ll see:

--- a/src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx
@@ -156,7 +156,7 @@ Each completed run also includes links to:
 * The task created by the agent.
 * The full agent session, including logs and outputs.
 
-This makes it easy to review what ran, when it ran, and what the agent did.
+This makes it easy to review what ran, when it ran, and what the agent did. You can also monitor scheduled runs alongside your other agents in the [Agent Management Panel](/agent-platform/cloud-agents/managing-cloud-agents/) in the Warp app, where you can filter by the **Scheduled** source to isolate them.
 
 #### Viewing a specific Scheduled Agent
 


### PR DESCRIPTION
## AEO cross-link audit

Narrow AEO cross-link audit for the agents, cloud agents, and orchestration docs. Scope is limited to internal cross-links between existing pages — no new pages, rewrites, or broad SEO/AEO changes.

### Goal
Identify small, high-confidence internal cross-link improvements that help readers continue a real workflow in the agents, cloud agents, and orchestration docs.

### Source signals
- **Peec snapshot** (`agents-orchestration`, window 2026-05-05 to 2026-06-04). The highest-volume prompt is real-time observability: *"how do development teams track and observe what their AI coding agents are doing in real time?"* (volume: high), alongside *"how do I trigger AI coding agents automatically from Slack, Linear, or GitHub?"* and *"how do I set up AI coding agents to run on a schedule or in the background?"*. The snapshot's open question — *"Which docs page should be the canonical target for monitoring and reviewing cloud agent runs?"* — is resolved here in favor of the Agent Management Panel (Managing cloud agents), which the page itself describes as "the starting point for real-time agent observability in Warp."
- **Google Search Console** (last ~90 days, pages under `/agent-platform/cloud-agents`). The Linear integration page draws high search exposure (~1,980 impressions for "linear agents") and the cloud-agents overview is a top landing page, confirming the integration pages are real entry points where onward monitoring links serve readers. GSC credentials were read directly from the run secret, never written to disk, logged, or committed.
- **Existing docs**: The Slack, Linear, and Scheduled Agents pages all discuss monitoring/progress but none linked to the canonical observability surface (`managing-cloud-agents.mdx`).

### Pages touched
- `src/content/docs/agent-platform/cloud-agents/integrations/slack.mdx` — added a monitoring next-step link in the "Monitoring agent progress" section.
- `src/content/docs/agent-platform/cloud-agents/integrations/linear.mdx` — added a monitoring next-step link after the session-sharing paragraph.
- `src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx` — added a monitoring next-step link in the "Listing Scheduled Agents" review sentence.

### Links added
- `integrations/slack.mdx` → `managing-cloud-agents.mdx` ([Agent Management Panel]) — integration-triggered runs appear in the **All** tab.
- `integrations/linear.mdx` → `managing-cloud-agents.mdx` ([Agent Management Panel]) — integration-triggered runs appear in the **All** tab.
- `triggers/scheduled-agents.mdx` → `managing-cloud-agents.mdx` ([Agent Management Panel]) — filter by the **Scheduled** source to isolate scheduled runs.

Each page receives exactly one new link; anchor text is descriptive ("Agent Management Panel") and consistent with the existing `overview.mdx` usage.

### Reader next step
A reader who triggers an agent from Slack or Linear, or sets up a scheduled agent, next wants to know where they can track that run alongside the rest of their team's agents in real time. Each link sends them to the canonical management/observability surface, with a specific cue (the **All** tab for integration runs, the **Scheduled** source filter for scheduled runs) so the destination is immediately useful.

### Verification
- `style_lint` — no new issues from the added links (pre-existing header-case and screenshot-width findings on these pages are unrelated and left out of scope).
- `check_for_broken_links --internal-only` — 0 broken links (2,922 internal links checked).
- `git diff --check` — clean.

### Open questions for human review
- Should the integration and scheduled-agent monitoring links also point to the **Runs page in the Oz web app** as a second destination? I kept each page to a single link to avoid link clustering and favored the Agent Management Panel, which covers both surfaces.

### Follow-up recommendations (out of scope)
- Peec also flags UGC/owned-content opportunities (Reddit, YouTube, articles) around "AI coding agents" — these are content-creation, not cross-linking, follow-ups.
- The Slack and Linear pages have pre-existing style findings (Title Case sub-headers, missing standard screenshot `maxWidth`) that a separate style pass could address.

---
_Conversation: https://app.warp.dev/conversation/e117e119-4d2a-4806-91a9-7981841edb9b_
_Run: https://oz.warp.dev/runs/019eb7b8-ff75-72f2-9b5c-ea665b1c2bdc_

_This PR was generated with [Oz](https://warp.dev/oz)._
