### PR TITLE
docs: Add Bring your Grok subscription page and Grok models

### DIFF
--- a/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
+++ b/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
@@ -7,7 +7,7 @@ description: >-
 
 Warp supports **Bring Your Own API Key (BYOK)** for users who want to connect Warp's agents to their own Anthropic, OpenAI, or Google API accounts.
 
-This lets you use your own API keys for model access, giving you control over model selection, billing, and data routing. See [Model Choice](/agent-platform/inference/model-choice/) for a list of supported models.
+This lets you use your own API keys for model access, giving you control over model selection, billing, and data routing. See [Model Choice](/agent-platform/inference/model-choice/) for a list of supported models. For xAI's Grok models, you connect a [Grok subscription](/agent-platform/inference/grok-subscription/) instead of adding an API key.
 
 BYOK provides greater flexibility in model access and ensures Warp **never consumes your** [AI credits](/support-and-community/plans-and-billing/credits/) for requests routed through your own keys.
 
@@ -17,11 +17,12 @@ BYOK is available on Free and all eligible paid plans for individual users and o
 
 ## How BYOK differs from custom inference endpoints and BYOLLM
 
-Warp offers three ways to bring your own AI infrastructure. Use this table to pick the right one, and follow the links for full details.
+Warp offers several ways to bring your own AI infrastructure. Use this table to pick the right one, and follow the links for full details.
 
 | Name | Meaning | Plans |
 | --- | --- | --- |
 | **Bring Your Own API Key** (BYOK) | Use your own API key for OpenAI, Anthropic, or Google models. Keys are stored locally on your device. | Free and all eligible paid plans |
+| **[Bring your Grok subscription](/agent-platform/inference/grok-subscription/)** | Connect your Grok (SuperGrok) subscription to use Grok models through your xAI account. Tokens are stored locally on your device. | Free and all eligible paid plans |
 | **[Custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/)** | Connect Warp to an OpenAI-compatible endpoint such as OpenRouter, LiteLLM, z.ai, or an internal gateway. | Free and all eligible paid plans |
 | **[Bring Your Own LLM](/enterprise/enterprise-features/bring-your-own-llm/)** (BYOLLM) | Enterprise-managed inference through your cloud provider (AWS Bedrock today; Azure Foundry and Google Vertex coming soon), with Warp handling routing, orchestration, governance, and observability. | Enterprise only |
 
@@ -149,6 +150,7 @@ If your organization needs centrally managed model routing today, see [Bring You
 
 ## Related resources
 
+* [Bring your Grok subscription](/agent-platform/inference/grok-subscription/) — Use Grok models through your xAI account instead of Warp credits.
 * [Custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/) — Route Warp through any OpenAI-compatible endpoint, such as OpenRouter, LiteLLM, z.ai, or an internal gateway.
 * [Bring Your Own LLM](/enterprise/enterprise-features/bring-your-own-llm/) — Enterprise-managed inference through your cloud provider or approved infrastructure.
 * [Model Choice](/agent-platform/inference/model-choice/) — Full list of supported models and `model_id` values.

--- a/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
+++ b/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
@@ -22,9 +22,9 @@ Warp offers several ways to bring your own AI infrastructure. Use this table to 
 | Name | Meaning | Plans |
 | --- | --- | --- |
 | **Bring Your Own API Key** (BYOK) | Use your own API key for OpenAI, Anthropic, or Google models. Keys are stored locally on your device. | Free and all eligible paid plans |
-| **[Bring your Grok subscription](/agent-platform/inference/grok-subscription/)** | Connect your Grok (SuperGrok) subscription to use Grok models through your xAI account. Tokens are stored locally on your device. | Free and all eligible paid plans |
 | **[Custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/)** | Connect Warp to an OpenAI-compatible endpoint such as OpenRouter, LiteLLM, z.ai, or an internal gateway. | Free and all eligible paid plans |
 | **[Bring Your Own LLM](/enterprise/enterprise-features/bring-your-own-llm/)** (BYOLLM) | Enterprise-managed inference through your cloud provider (AWS Bedrock today; Azure Foundry and Google Vertex coming soon), with Warp handling routing, orchestration, governance, and observability. | Enterprise only |
+| **[Bring your Grok subscription](/agent-platform/inference/grok-subscription/)** | Connect your Grok (SuperGrok) subscription to use Grok models through your xAI account. Tokens are stored locally on your device. | Free and all eligible paid plans |
 
 See [Warp pricing](https://www.warp.dev/pricing) for current plan availability.
 
@@ -150,8 +150,8 @@ If your organization needs centrally managed model routing today, see [Bring You
 
 ## Related resources
 
-* [Bring your Grok subscription](/agent-platform/inference/grok-subscription/) — Use Grok models through your xAI account instead of Warp credits.
 * [Custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/) — Route Warp through any OpenAI-compatible endpoint, such as OpenRouter, LiteLLM, z.ai, or an internal gateway.
 * [Bring Your Own LLM](/enterprise/enterprise-features/bring-your-own-llm/) — Enterprise-managed inference through your cloud provider or approved infrastructure.
+* [Bring your Grok subscription](/agent-platform/inference/grok-subscription/) — Use Grok models through your xAI account instead of Warp credits.
 * [Model Choice](/agent-platform/inference/model-choice/) — Full list of supported models and `model_id` values.
 * [Credits](/support-and-community/plans-and-billing/credits/) — How Warp credits work and when they're consumed.

--- a/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
+++ b/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
@@ -7,7 +7,7 @@ description: >-
 
 Warp supports **Bring Your Own API Key (BYOK)** for users who want to connect Warp's agents to their own Anthropic, OpenAI, or Google API accounts.
 
-This lets you use your own API keys for model access, giving you control over model selection, billing, and data routing. See [Model Choice](/agent-platform/inference/model-choice/) for a list of supported models. For xAI's Grok models, you connect a [Grok subscription](/agent-platform/inference/grok-subscription/) instead of adding an API key.
+This lets you use your own API keys for model access, giving you control over model selection, billing, and data routing. See [Model Choice](/agent-platform/inference/model-choice/) for a list of supported models. For xAI's Grok models, you connect a [SuperGrok subscription](/agent-platform/inference/grok-subscription/) instead of adding an API key.
 
 BYOK provides greater flexibility in model access and ensures Warp **never consumes your** [AI credits](/support-and-community/plans-and-billing/credits/) for requests routed through your own keys.
 
@@ -24,7 +24,7 @@ Warp offers several ways to bring your own AI infrastructure. Use this table to 
 | **Bring Your Own API Key** (BYOK) | Use your own API key for OpenAI, Anthropic, or Google models. Keys are stored locally on your device. | Free and all eligible paid plans |
 | **[Custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/)** | Connect Warp to an OpenAI-compatible endpoint such as OpenRouter, LiteLLM, z.ai, or an internal gateway. | Free and all eligible paid plans |
 | **[Bring Your Own LLM](/enterprise/enterprise-features/bring-your-own-llm/)** (BYOLLM) | Enterprise-managed inference through your cloud provider (AWS Bedrock today; Azure Foundry and Google Vertex coming soon), with Warp handling routing, orchestration, governance, and observability. | Enterprise only |
-| **[Bring your Grok subscription](/agent-platform/inference/grok-subscription/)** | Connect your Grok (SuperGrok) subscription to use Grok models through your xAI account. Tokens are stored locally on your device. | Free and all eligible paid plans |
+| **[SuperGrok subscription](/agent-platform/inference/grok-subscription/)** | Connect your SuperGrok subscription to use Grok models through your xAI account. Tokens are stored locally on your device. | Free and all eligible paid plans |
 
 See [Warp pricing](https://www.warp.dev/pricing) for current plan availability.
 
@@ -152,6 +152,6 @@ If your organization needs centrally managed model routing today, see [Bring You
 
 * [Custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/) — Route Warp through any OpenAI-compatible endpoint, such as OpenRouter, LiteLLM, z.ai, or an internal gateway.
 * [Bring Your Own LLM](/enterprise/enterprise-features/bring-your-own-llm/) — Enterprise-managed inference through your cloud provider or approved infrastructure.
-* [Bring your Grok subscription](/agent-platform/inference/grok-subscription/) — Use Grok models through your xAI account instead of Warp credits.
+* [SuperGrok subscription](/agent-platform/inference/grok-subscription/) — Use Grok models through your xAI account instead of Warp credits.
 * [Model Choice](/agent-platform/inference/model-choice/) — Full list of supported models and `model_id` values.
 * [Credits](/support-and-community/plans-and-billing/credits/) — How Warp credits work and when they're consumed.

--- a/src/content/docs/agent-platform/inference/grok-subscription.mdx
+++ b/src/content/docs/agent-platform/inference/grok-subscription.mdx
@@ -17,7 +17,7 @@ Like BYOK, connecting a Grok subscription is available on Free and all eligible 
 
 ## How it works
 
-When you connect your subscription, Warp opens your browser to xAI's consent screen and completes a standard OAuth login. Warp receives OAuth tokens for your xAI account and stores them **only on your device** (in your OS keychain or equivalent secure storage), never on Warp's servers. Warp refreshes the tokens automatically in the background, so you only need to connect once.
+When you connect your subscription, Warp opens your browser to xAI's consent screen and completes a standard OAuth login. Warp receives OAuth tokens for your xAI account and stores them **only on your device** (in your OS keychain or equivalent secure storage), never on Warp's servers. Warp refreshes the tokens automatically in the background, so you typically only need to connect once.
 
 When you send a prompt with a Grok model selected and a subscription connected:
 
@@ -34,7 +34,7 @@ Once connected, supported Grok models show a **key icon** in the model picker, i
 1. In the Warp app, open **Settings** and search for `SuperGrok` to jump to the **Connect SuperGrok subscription** row in your AI settings.
 2. Click **Connect**. Warp opens your browser to xAI's consent screen and shows a toast with a **Copy URL** fallback in case the browser doesn't open.
 3. Approve the connection in your browser. The page confirms with "Grok connected," and back in Warp the row shows a "Connected on..." timestamp.
-4. Select a Grok model from the model picker in your prompt input — for example, **Grok 4.3** or **Grok Build 0.1** with the key icon. Connecting a subscription doesn't change your selected model, so this last step is what actually routes your requests through your subscription. See [Model choice](/agent-platform/inference/model-choice/) for the full list of models.
+4. Select a Grok model with the key icon from the model picker in your prompt input, such as **Grok 4.3** or **Grok Build 0.1**. Connecting a subscription doesn't change your selected model, so this last step is what actually routes your requests through your subscription. See [Model choice](/agent-platform/inference/model-choice/) for the full list of models.
 
 ## Usage and billing behavior
 
@@ -68,7 +68,7 @@ To disconnect, open **Settings**, search for `SuperGrok`, and click **Disconnect
 
 ### "Couldn't start Grok login"
 
-Warp listens on a fixed local port for the browser to complete the connection. This error means the port is busy — usually another connection attempt is still in progress, or another app that uses the same xAI login flow (like Grok CLI) is running. Close the other app or wait for the other attempt to finish, then click **Connect** again.
+Warp listens on a fixed local port for the browser to complete the connection. This error means the port is busy: usually another connection attempt is still in progress, or another app that uses the same xAI login flow (like Grok CLI) is running. Close the other app or wait for the other attempt to finish, then click **Connect** again.
 
 ### The browser never opened
 

--- a/src/content/docs/agent-platform/inference/grok-subscription.mdx
+++ b/src/content/docs/agent-platform/inference/grok-subscription.mdx
@@ -1,0 +1,90 @@
+---
+title: Bring your Grok subscription
+sidebar:
+  label: "Grok subscription"
+description: >-
+  Connect your Grok (SuperGrok) subscription to Warp and use Grok models like
+  Grok 4.3 and Grok Build 0.1 through your xAI account instead of Warp credits.
+---
+
+Warp lets you connect your **Grok subscription** (SuperGrok) to use Grok models in Warp's agents through your xAI account. If you already subscribe to Grok, you can run Grok models like Grok 4.3 and Grok Build 0.1 in Warp without consuming your Warp [credits](/support-and-community/plans-and-billing/credits/).
+
+Connecting a subscription works like [Bring Your Own API Key (BYOK)](/agent-platform/inference/bring-your-own-api-key/), except you sign in to your xAI account instead of pasting an API key. There is no xAI API key field in Warp today — the subscription is the way to bring your own Grok access.
+
+:::note
+Like BYOK, connecting a Grok subscription is available on Free and all eligible paid plans for individual users and organizations with 10 or fewer employees, subject to Warp's [Terms of Service](https://www.warp.dev/legal/terms-of-service). Larger organizations need a Business or Enterprise plan, and workspace admins can disable BYO keys for their organization. See [Warp pricing](https://www.warp.dev/pricing) for current availability.
+:::
+
+## How it works
+
+When you connect your subscription, Warp opens your browser to xAI's consent screen and completes a standard OAuth login. Warp receives OAuth tokens for your xAI account and stores them **only on your device** (in your OS keychain or equivalent secure storage), never on Warp's servers. Warp refreshes the tokens automatically in the background, so you only need to connect once.
+
+When you send a prompt with a Grok model selected and a subscription connected:
+
+1. Your local Warp client sends the access token to Warp's backend along with your prompt.
+2. Warp's agent harness assembles the full request and uses your token in-flight to call xAI, authenticating as your xAI account instead of Warp's.
+3. xAI's response streams back through Warp's backend to your client.
+
+Your token passes through Warp's servers on each request but is used only in-flight to call xAI, then discarded — the same model as [BYOK](/agent-platform/inference/bring-your-own-api-key/#how-byok-works).
+
+Once connected, supported Grok models show a **key icon** in the model picker, indicating requests will route through your xAI account. Usage and rate limits for these requests are governed by your Grok subscription with xAI.
+
+## Connecting your Grok subscription
+
+1. In the Warp app, open **Settings** and search for `SuperGrok` to jump to the **Connect SuperGrok subscription** row in your AI settings.
+2. Click **Connect**. Warp opens your browser to xAI's consent screen and shows a toast with a **Copy URL** fallback in case the browser doesn't open.
+3. Approve the connection in your browser. The page confirms with "Grok connected," and back in Warp the row shows a "Connected on..." timestamp.
+4. Select a Grok model from the model picker in your prompt input — for example, **Grok 4.3** or **Grok Build 0.1** with the key icon. Connecting a subscription doesn't change your selected model, so this last step is what actually routes your requests through your subscription. See [Model choice](/agent-platform/inference/model-choice/) for the full list of models.
+
+## Usage and billing behavior
+
+When a Grok model with the key icon is selected:
+
+* Warp **does not consume** any of your [credits](/support-and-community/plans-and-billing/credits/) for the request.
+* Inference runs through your xAI account, within your Grok subscription's usage limits.
+* If a request fails because your subscription hits a limit, Warp does not retry with Warp credits unless you enable **Warp credit fallback** in the same settings section. See [failover and fallback behavior](/agent-platform/inference/bring-your-own-api-key/#failover-and-fallback-behavior).
+
+### Auto models
+
+Warp's **Auto** models always use Warp's own inference and **always consume Warp credits**, even with a Grok subscription connected. Auto never routes requests through your subscription. To use your subscription, select a specific Grok model from the model picker.
+
+:::caution
+A connected Grok subscription does not apply to [Cloud Agents](/agent-platform/cloud-agents/overview/). Because tokens are stored locally on your device, they are not available to cloud-hosted agent runs, which always consume [Warp credits](/support-and-community/plans-and-billing/credits/).
+:::
+
+:::note
+On Business and Enterprise plans, local agent runs that use a connected subscription still consume [platform credits](/support-and-community/plans-and-billing/platform-credits/) for Warp's platform infrastructure, the same as BYOK.
+:::
+
+### Zero data retention (ZDR)
+
+Warp has Zero Data Retention agreements with its contracted LLM providers, including xAI, for Warp-managed inference. When you connect your own subscription, data retention on xAI's side is governed by your own xAI account and its terms — Warp cannot enforce ZDR for requests sent through your subscription. Warp itself never stores your tokens on its servers.
+
+## Disconnecting
+
+To disconnect, open **Settings**, search for `SuperGrok`, and click **Disconnect**. Warp removes the tokens from your device's secure storage, and Grok models go back to running on Warp credits.
+
+## Troubleshooting
+
+### "Couldn't start Grok login"
+
+Warp listens on a fixed local port for the browser to complete the connection. This error means the port is busy — usually another connection attempt is still in progress, or another app that uses the same xAI login flow (like Grok CLI) is running. Close the other app or wait for the other attempt to finish, then click **Connect** again.
+
+### The browser never opened
+
+Click **Copy URL** on the toast that appears after clicking **Connect**, then paste the URL into your browser manually.
+
+### "Couldn't connect SuperGrok: timed out waiting for the Grok authorization callback"
+
+Warp waits 5 minutes for you to approve the connection in your browser. Click **Connect** and approve the consent screen within that window.
+
+### The Connect button is disabled
+
+The button follows the same policy as BYO API keys: it's disabled when AI is turned off in your settings, or when BYO keys aren't available on your plan or have been disabled by your workspace admin. See the [BYOK availability note](/agent-platform/inference/bring-your-own-api-key/) for details.
+
+## Related resources
+
+* [Model choice](/agent-platform/inference/model-choice/) — Full list of supported models, including Grok 4.3 and Grok Build 0.1.
+* [Bring Your Own API Key](/agent-platform/inference/bring-your-own-api-key/) — Use your own Anthropic, OpenAI, or Google API keys.
+* [Custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/) — Route Warp through any OpenAI-compatible endpoint.
+* [Credits](/support-and-community/plans-and-billing/credits/) — How Warp credits work and when they're consumed.

--- a/src/content/docs/agent-platform/inference/grok-subscription.mdx
+++ b/src/content/docs/agent-platform/inference/grok-subscription.mdx
@@ -1,18 +1,16 @@
 ---
-title: Bring your Grok subscription
-sidebar:
-  label: "Grok subscription"
+title: SuperGrok subscription
 description: >-
-  Connect your Grok (SuperGrok) subscription to Warp and use Grok models like
-  Grok 4.3 and Grok Build 0.1 through your xAI account instead of Warp credits.
+  Connect your SuperGrok subscription to Warp and use Grok models through
+  your xAI account instead of Warp credits.
 ---
 
-Warp lets you connect your **Grok subscription** (SuperGrok) to use Grok models in Warp's agents through your xAI account. If you already subscribe to Grok, you can run Grok models like Grok 4.3 and Grok Build 0.1 in Warp without consuming your Warp [credits](/support-and-community/plans-and-billing/credits/).
+Warp lets you connect your **SuperGrok subscription** to use Grok models in Warp's agents through your xAI account. If you already subscribe to Grok, you can run Grok models in Warp without consuming your Warp [credits](/support-and-community/plans-and-billing/credits/).
 
 Connecting a subscription works like [Bring Your Own API Key (BYOK)](/agent-platform/inference/bring-your-own-api-key/), except you sign in to your xAI account instead of pasting an API key. There is no xAI API key field in Warp today — the subscription is the way to bring your own Grok access.
 
 :::note
-Like BYOK, connecting a Grok subscription is available on Free and all eligible paid plans for individual users and organizations with 10 or fewer employees, subject to Warp's [Terms of Service](https://www.warp.dev/legal/terms-of-service). Larger organizations need a Business or Enterprise plan, and workspace admins can disable BYO keys for their organization. See [Warp pricing](https://www.warp.dev/pricing) for current availability.
+Like BYOK, connecting a SuperGrok subscription is available on Free and all eligible paid plans for individual users and organizations with 10 or fewer employees, subject to Warp's [Terms of Service](https://www.warp.dev/legal/terms-of-service). See [Warp pricing](https://www.warp.dev/pricing) for current availability.
 :::
 
 ## How it works
@@ -27,33 +25,29 @@ When you send a prompt with a Grok model selected and a subscription connected:
 
 Your token passes through Warp's servers on each request but is used only in-flight to call xAI, then discarded — the same model as [BYOK](/agent-platform/inference/bring-your-own-api-key/#how-byok-works).
 
-Once connected, supported Grok models show a **key icon** in the model picker, indicating requests will route through your xAI account. Usage and rate limits for these requests are governed by your Grok subscription with xAI.
+Once connected, supported Grok models show a **key icon** in the model picker, indicating requests will route through your xAI account. Usage and rate limits for these requests are governed by your SuperGrok subscription with xAI.
 
-## Connecting your Grok subscription
+## Connecting your SuperGrok subscription
 
 1. In the Warp app, open **Settings** and search for `SuperGrok` to jump to the **Connect SuperGrok subscription** row in your AI settings.
 2. Click **Connect**. Warp opens your browser to xAI's consent screen and shows a toast with a **Copy URL** fallback in case the browser doesn't open.
 3. Approve the connection in your browser. The page confirms with "Grok connected," and back in Warp the row shows a "Connected on..." timestamp.
-4. Select a Grok model with the key icon from the model picker in your prompt input, such as **Grok 4.3** or **Grok Build 0.1**. Connecting a subscription doesn't change your selected model, so this last step is what actually routes your requests through your subscription. See [Model choice](/agent-platform/inference/model-choice/) for the full list of models.
+4. Select a Grok model with the key icon from the model picker in your prompt input. Connecting a subscription doesn't change your selected model, so this last step is what actually routes your requests through your subscription. See [Model choice](/agent-platform/inference/model-choice/) for the list of available models.
 
 ## Usage and billing behavior
 
 When a Grok model with the key icon is selected:
 
 * Warp **does not consume** any of your [credits](/support-and-community/plans-and-billing/credits/) for the request.
-* Inference runs through your xAI account, within your Grok subscription's usage limits.
+* Inference runs through your xAI account, within your SuperGrok subscription's usage limits.
 * If a request fails because your subscription hits a limit, Warp does not retry with Warp credits unless you enable **Warp credit fallback** in the same settings section. See [failover and fallback behavior](/agent-platform/inference/bring-your-own-api-key/#failover-and-fallback-behavior).
 
 ### Auto models
 
-Warp's **Auto** models always use Warp's own inference and **always consume Warp credits**, even with a Grok subscription connected. Auto never routes requests through your subscription. To use your subscription, select a specific Grok model from the model picker.
+Warp's **Auto** models always use Warp's own inference and **always consume Warp credits**, even with a SuperGrok subscription connected. Auto never routes requests through your subscription. To use your subscription, select a specific Grok model from the model picker.
 
 :::caution
-A connected Grok subscription does not apply to [Cloud Agents](/agent-platform/cloud-agents/overview/). Because tokens are stored locally on your device, they are not available to cloud-hosted agent runs, which always consume [Warp credits](/support-and-community/plans-and-billing/credits/).
-:::
-
-:::note
-On Business and Enterprise plans, local agent runs that use a connected subscription still consume [platform credits](/support-and-community/plans-and-billing/platform-credits/) for Warp's platform infrastructure, the same as BYOK.
+A connected SuperGrok subscription does not apply to [Cloud Agents](/agent-platform/cloud-agents/overview/). Because tokens are stored locally on your device, they are not available to cloud-hosted agent runs, which always consume [Warp credits](/support-and-community/plans-and-billing/credits/).
 :::
 
 ### Zero data retention (ZDR)
@@ -78,13 +72,9 @@ Click **Copy URL** on the toast that appears after clicking **Connect**, then pa
 
 Warp waits 5 minutes for you to approve the connection in your browser. Click **Connect** and approve the consent screen within that window.
 
-### The Connect button is disabled
-
-The button follows the same policy as BYO API keys: it's disabled when AI is turned off in your settings, or when BYO keys aren't available on your plan or have been disabled by your workspace admin. See the [BYOK availability note](/agent-platform/inference/bring-your-own-api-key/) for details.
-
 ## Related resources
 
-* [Model choice](/agent-platform/inference/model-choice/) — Full list of supported models, including Grok 4.3 and Grok Build 0.1.
+* [Model choice](/agent-platform/inference/model-choice/) — Full list of supported models and `model_id` values.
 * [Bring Your Own API Key](/agent-platform/inference/bring-your-own-api-key/) — Use your own Anthropic, OpenAI, or Google API keys.
 * [Custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/) — Route Warp through any OpenAI-compatible endpoint.
 * [Credits](/support-and-community/plans-and-billing/credits/) — How Warp credits work and when they're consumed.

--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -92,7 +92,7 @@ Anthropic requires data retention for Claude Fable 5 for safety, abuse monitorin
 | Grok 4.3 | `grok-4-3-high` | High |
 | Grok Build 0.1 | `grok-build-0.1` | — |
 
-You can run Grok models through your own Grok (SuperGrok) subscription instead of Warp credits by connecting your xAI account. See [Bring your Grok subscription](/agent-platform/inference/grok-subscription/).
+You can run Grok models through your own SuperGrok subscription instead of Warp credits by connecting your xAI account. See [SuperGrok subscription](/agent-platform/inference/grok-subscription/).
 
 #### Hosted models (via [Fireworks AI](https://fireworks.ai))
 

--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -83,6 +83,17 @@ Anthropic requires data retention for Claude Fable 5 for safety, abuse monitorin
 | --- | --- |
 | Gemini 3.1 Pro | `gemini-3.1-pro` |
 
+#### xAI
+
+| Model | `model_id` | Reasoning Level |
+| --- | --- | --- |
+| Grok 4.3 | `grok-4-3-low` | Low |
+| Grok 4.3 | `grok-4-3-medium` | Medium |
+| Grok 4.3 | `grok-4-3-high` | High |
+| Grok Build 0.1 | `grok-build-0.1` | — |
+
+You can run Grok models through your own Grok (SuperGrok) subscription instead of Warp credits by connecting your xAI account. See [Bring your Grok subscription](/agent-platform/inference/grok-subscription/).
+
 #### Hosted models (via [Fireworks AI](https://fireworks.ai))
 
 Warp also supports leading open source models hosted via Fireworks AI, so you can run them from inside Warp without setting up your own inference infrastructure.

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -304,7 +304,7 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 								{ slug: 'agent-platform/inference/model-choice', label: 'Model choice' },
 								'agent-platform/inference/bring-your-own-api-key',
 								{ slug: 'agent-platform/inference/custom-inference-endpoint', label: 'Custom inference endpoint' },
-								{ slug: 'agent-platform/inference/grok-subscription', label: 'Grok subscription' },
+								{ slug: 'agent-platform/inference/grok-subscription', label: 'SuperGrok subscription' },
 							],
 						},
 						{ slug: 'agent-platform/local-agents/interactive-code-review', label: 'Interactive code review' },

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -303,8 +303,8 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 							items: [
 								{ slug: 'agent-platform/inference/model-choice', label: 'Model choice' },
 								'agent-platform/inference/bring-your-own-api-key',
-								{ slug: 'agent-platform/inference/grok-subscription', label: 'Grok subscription' },
 								{ slug: 'agent-platform/inference/custom-inference-endpoint', label: 'Custom inference endpoint' },
+								{ slug: 'agent-platform/inference/grok-subscription', label: 'Grok subscription' },
 							],
 						},
 						{ slug: 'agent-platform/local-agents/interactive-code-review', label: 'Interactive code review' },

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -303,6 +303,7 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 							items: [
 								{ slug: 'agent-platform/inference/model-choice', label: 'Model choice' },
 								'agent-platform/inference/bring-your-own-api-key',
+								{ slug: 'agent-platform/inference/grok-subscription', label: 'Grok subscription' },
 								{ slug: 'agent-platform/inference/custom-inference-endpoint', label: 'Custom inference endpoint' },
 							],
 						},


### PR DESCRIPTION
## Summary
Adds documentation for connecting a Grok (SuperGrok) subscription to Warp, and documents the newly available Grok models (Grok 4.3 and Grok Build 0.1).

## Changes

### src/content/docs/agent-platform/inference/grok-subscription.mdx (new)
- Feature doc for the Bring your Grok subscription flow: what it is, how it works (browser OAuth, tokens stored locally in secure storage, automatic refresh), and step-by-step connection instructions ending with selecting a Grok model
- Usage and billing behavior: key icon, no Warp credits consumed, Auto models always use Warp credits, Warp credit fallback, Cloud Agents caveat, platform credits note
- ZDR note, disconnect instructions, and troubleshooting (callback port in use, browser fallback, authorization timeout, disabled Connect button)

### src/content/docs/agent-platform/inference/model-choice.mdx
- Added an xAI section listing Grok 4.3 (`grok-4-3-low`, `grok-4-3-medium`, `grok-4-3-high`) and Grok Build 0.1 (`grok-build-0.1`), with a pointer to the new subscription page

### src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
- Added the Grok subscription to the BYO-options comparison table, intro, and Related resources

### src/sidebar.ts
- Added the new page to the "Inference & providers" group

## Notes for reviewers
- Validated with `style_lint.py --changed` (only pre-existing warnings remain), the internal link checker, and a full `npm run build` (339 pages)
- No screenshots yet; the settings UI shots can be added in a follow-up once final assets are available

_Conversation: https://staging.warp.dev/conversation/5d3f25b5-d656-4777-a4f3-19422a2e6dd9_
_Run: https://oz.staging.warp.dev/runs/019eb7ae-d24c-70a4-a39e-9ab7b4710b76_
_Plans_:
- _[Docs for Bring-Your-Grok-Subscription (SuperGrok) launch](https://staging.warp.dev/drive/notebook/ioZYlAPfdepFt04hd54goI)_

_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
