### PR TITLE
ci: use DOCS_AGENT_GRAFANA_TOKEN for on-call reviewer assignment

### DIFF
--- a/.agents/skills/release_updates/SKILL.md
+++ b/.agents/skills/release_updates/SKILL.md
@@ -39,7 +39,7 @@ They support the following:
 
 - Resolver script path (default):
   `.agents/skills/release_updates/scripts/resolve_oncall_reviewers.py`
-- `GRAFANA_API_KEY` environment variable.
+- `DOCS_AGENT_GRAFANA_TOKEN` environment variable.
 
 ### Recommended
 
@@ -185,7 +185,7 @@ python3 .agents/skills/release_updates/scripts/run_release_updates.py \
 
 Notes:
 
-- Requires `GRAFANA_API_KEY` in the environment.
+- Requires `DOCS_AGENT_GRAFANA_TOKEN` in the environment.
 - Uses resolver script (by default):
   `.agents/skills/release_updates/scripts/resolve_oncall_reviewers.py`
 - Repeat `--oncall-schedule-id` to resolve one reviewer per schedule, in order.

--- a/.agents/skills/release_updates/scripts/resolve_oncall_reviewers.py
+++ b/.agents/skills/release_updates/scripts/resolve_oncall_reviewers.py
@@ -321,9 +321,9 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    api_key = os.environ.get("GRAFANA_API_KEY")
+    api_key = os.environ.get("DOCS_AGENT_GRAFANA_TOKEN")
     if not api_key:
-        print("GRAFANA_API_KEY env var required", file=sys.stderr)
+        print("DOCS_AGENT_GRAFANA_TOKEN env var required", file=sys.stderr)
         return 1
 
     users = get_oncall_users(

--- a/.agents/skills/release_updates/scripts/setup_environment.py
+++ b/.agents/skills/release_updates/scripts/setup_environment.py
@@ -179,7 +179,7 @@ def main() -> int:
     checks: dict[str, Any] = {
         "commands": {},
         "gh_authenticated": None,
-        "grafana_api_key_present": None,
+        "docs_agent_grafana_token_present": None,
         "oncall_resolver_exists": None,
         "local_channel_versions_present": None,
     }
@@ -252,10 +252,10 @@ def main() -> int:
             f"{resolver_path}. Pass --oncall-resolver-script.",
         )
 
-    grafana_api_key_present = bool(os.environ.get("GRAFANA_API_KEY"))
-    checks["grafana_api_key_present"] = grafana_api_key_present
-    if args.require_oncall_reviewer and not grafana_api_key_present:
-        errors.append("Missing required env var for reviewer assignment: GRAFANA_API_KEY")
+    docs_agent_grafana_token_present = bool(os.environ.get("DOCS_AGENT_GRAFANA_TOKEN"))
+    checks["docs_agent_grafana_token_present"] = docs_agent_grafana_token_present
+    if args.require_oncall_reviewer and not docs_agent_grafana_token_present:
+        errors.append("Missing required env var for reviewer assignment: DOCS_AGENT_GRAFANA_TOKEN")
 
     report: dict[str, Any] = {
         "generated_at_utc": utc_now_iso(),

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -120,6 +120,8 @@ jobs:
       # 1. workflow_dispatch succeeds.
       # 2. the channel-versions dispatch sender is tested.
       # 3. required secrets, variables, and cross-repo permissions are configured.
+      # WARP_AGENT_PROFILE should be set to the Docs Agent on prod Oz (oz.warp.dev).
+      # That agent has DOCS_AGENT_GRAFANA_TOKEN configured for on-call reviewer assignment.
       - name: Run release docs update with Oz
         uses: warpdotdev/oz-agent-action@v1
         with:
@@ -141,7 +143,7 @@ jobs:
             4. Create and switch to a release docs feature branch before invoking `run_release_updates.py --create-pr`; the script refuses to create a PR from `main`.
             5. Create or update a PR against `warpdotdev/docs` `main` only if generated changes exist.
             6. Use a draft PR when create_draft_pr is true. Note: --pr-draft and --pr-auto-merge are mutually exclusive; never pass both.
-            7. Assign on-call reviewers only when the active trigger's assign_oncall_reviewers value is true and the required Grafana schedule IDs and `GRAFANA_API_KEY` are available.
+            7. Assign on-call reviewers only when the active trigger's assign_oncall_reviewers value is true and `DOCS_AGENT_GRAFANA_TOKEN` is available in the environment.
             8. Run `npm run build` before considering the PR ready for review.
             9. If no docs changes are needed, report a no-op result and do not open a PR.
 
@@ -151,8 +153,8 @@ jobs:
             - all tasks: `python3 .agents/skills/release_updates/scripts/run_release_updates.py --create-pr --pr-base main`
 
             Include `--pr-draft` when create_draft_pr is true.
-            Always include `--pr-auto-merge` (marks the PR ready for review and enables squash auto-merge).
+            Include `--pr-auto-merge` when create_draft_pr is false (enables squash auto-merge and marks PR ready for review).
+            Never pass both --pr-draft and --pr-auto-merge together.
             When assign_oncall_reviewers is true, include:
               --assign-oncall-reviewer --oncall-schedule-id S1BRQ4BYUP5WN --oncall-max-reviewers 2
             This resolves up to 2 reviewers (primary + secondary) from the client on-call schedule.
-            If GRAFANA_API_KEY is not set, skip reviewer assignment and log a warning.

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -143,7 +143,7 @@ jobs:
             4. Create and switch to a release docs feature branch before invoking `run_release_updates.py --create-pr`; the script refuses to create a PR from `main`.
             5. Create or update a PR against `warpdotdev/docs` `main` only if generated changes exist.
             6. Use a draft PR when create_draft_pr is true. Note: --pr-draft and --pr-auto-merge are mutually exclusive; never pass both.
-            7. Assign on-call reviewers only when the active trigger's assign_oncall_reviewers value is true and `DOCS_AGENT_GRAFANA_TOKEN` is available in the environment.
+            7. Assign on-call reviewers only when the active trigger's assign_oncall_reviewers value is true, the required Grafana schedule IDs are configured, and `DOCS_AGENT_GRAFANA_TOKEN` is available in the environment.
             8. Run `npm run build` before considering the PR ready for review.
             9. If no docs changes are needed, report a no-op result and do not open a PR.
 


### PR DESCRIPTION
## Summary

Updates the release docs workflow and scripts to use `DOCS_AGENT_GRAFANA_TOKEN` (configured on the Docs Agent in prod Oz) instead of `GRAFANA_API_KEY` for resolving on-call reviewers. Also fixes the `--pr-auto-merge` / `--pr-draft` mutual exclusion bug on manual dispatch, updates the environment report key name for accurate release debugging, and removes stale `GRAFANA_API_KEY` references from all operational guidance.

## Changes

- `release-docs-update.yml`: rule 7 now references `DOCS_AGENT_GRAFANA_TOKEN`; `--pr-auto-merge` is only included when `create_draft_pr` is false (fixes incompatibility with `--pr-draft` on manual dispatch); agent profile comment updated
- `resolve_oncall_reviewers.py`: reads `DOCS_AGENT_GRAFANA_TOKEN` instead of `GRAFANA_API_KEY`
- `setup_environment.py`: checks `DOCS_AGENT_GRAFANA_TOKEN`; renames check key from `grafana_api_key_present` → `docs_agent_grafana_token_present` so environment reports are accurate during debugging
- `SKILL.md`: requirements and notes updated to reference `DOCS_AGENT_GRAFANA_TOKEN`

## Setup already completed ✅

- **Grafana service account**: with **IRM: Schedules Reader** role. Token attached to Docs Agent on prod Oz as `DOCS_AGENT_GRAFANA_TOKEN`.
- **`WARP_AGENT_PROFILE`**: set to as a GitHub Actions repository variable in `warpdotdev/docs`
- **`DOCS_REPOSITORY_DISPATCH_TOKEN`**: added to `warpdotdev/channel-versions` secrets (unblocks channel-versions PR #971)
- **`WARP_API_KEY`**: already present in `warpdotdev/docs` secrets

## Remaining to merge

1. This PR (#205)
2. channel-versions PR: warpdotdev/channel-versions#971

Once both are merged, the next Thursday stable release will automatically trigger a changelog PR with client on-call reviewers assigned and squash auto-merge enabled.

Co-Authored-By: Oz <oz-agent@warp.dev>