### PR TITLE
docs: add AEO cross-links for agents and orchestration

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/faqs.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/faqs.mdx
@@ -116,7 +116,7 @@ To learn more about how secrets work in practice, see [Cloud Agent Secrets](/age
 
 The cloud agents platform is intentionally flexible. As the developer, you decide how agents should branch, coordinate, and resolve conflicts.
 
-Interactive agents can plan work and spawn subagents to parallelize tasks. Cloud agents provide the building blocks for running and coordinating multiple concurrent agents, rather than enforcing a fixed workflow.
+Interactive agents can plan work and spawn subagents to parallelize tasks. Cloud agents provide the building blocks for [multi-agent orchestration](/agent-platform/cloud-agents/orchestration/), running and coordinating multiple concurrent agents, rather than enforcing a fixed workflow.
 
 ### Why focus on orchestration primitives instead of immediately adopting new agent standards?
 
@@ -168,7 +168,7 @@ Agents are strongest when they can continuously validate progress (tests, lint, 
 
 Yes. A common cloud agent workflow:
 
-- When a ticket/issue is created (via integration trigger), a cloud agent gathers context (recent changes, logs/metrics links, ownership).
+- When a ticket/issue is created (via an [integration trigger](/agent-platform/cloud-agents/integrations/)), a cloud agent gathers context (recent changes, logs/metrics links, ownership).
 - Proposes labels/priority and likely causes.
 - Drafts next steps or a response.
 - Asks clarifying questions back to the reporter when needed.
@@ -182,7 +182,7 @@ Yes. Scheduled dependency bumps are a classic cloud agent use case:
 - Resolve simple conflicts.
 - Attach a risk summary (optional).
 
-This is usually implemented as a scheduled **cloud agent** producing recurring **runs**.
+This is usually implemented as a [scheduled cloud agent](/agent-platform/cloud-agents/triggers/scheduled-agents/) producing recurring **runs**.
 
 ### Can cloud agents keep docs up to date?
 


### PR DESCRIPTION
## AEO cross-link audit brief

**Goal**
Identify small, high-confidence internal cross-link improvements for the agents, cloud agents, and orchestration docs. Scope is limited to internal cross-links between existing pages — no new pages, rewrites, or broad SEO changes.

**Source signals**
- **Peec snapshot** (`buzz/aeo-snapshots/docs/agents-orchestration/latest.json`, window 2026-05-05 → 2026-06-04). High-volume prompt clusters:
  - "what are the best tools for managing multiple AI coding agents?" / "AI agent orchestration platforms" → orchestration.
  - "how do I set up AI coding agents to run on a schedule or in the background?" → scheduled agents.
  - "how do I trigger AI coding agents automatically from Slack, Linear, or GitHub?" → integrations.
- **Existing-docs signal**: The Cloud Agent FAQs (`faqs.mdx`) discuss multi-agent coordination, scheduled recurring runs, and integration-triggered triage in prose, but the page links to **none** of the canonical orchestration, scheduled agents, or integrations pages. This is the clearest gap in an otherwise densely cross-linked topic area.
- **Google Search Console**: Credentials were present in the environment, but no GSC query data was incorporated into this run; recommendations are grounded in Peec signals and existing-docs structure. The secret value was never printed, logged, or committed.

**Pages touched**
- `src/content/docs/agent-platform/cloud-agents/faqs.mdx` — added three inline cross-links in three separate Q&A sections, each pointing to a distinct canonical destination that the answer already describes.

**Links added**
1. FAQ "How do agents handle branching, merge conflicts, and multi-agent coordination" → [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/). The answer describes "running and coordinating multiple concurrent agents" — the orchestration page is the canonical home for that model.
2. FAQ "Can cloud agents do dependency upgrades?" → [Scheduled Agents](/agent-platform/cloud-agents/triggers/scheduled-agents/). The answer says the workflow is "usually implemented as a scheduled cloud agent producing recurring runs."
3. FAQ "Can cloud agents triage issues / tickets automatically?" → [Integrations](/agent-platform/cloud-agents/integrations/). The answer references work created "via an integration trigger."

**Reader next step**
- A reader on the FAQ who wants to coordinate multiple agents can jump straight to the orchestration model and patterns.
- A reader interested in recurring dependency upgrades can go directly to schedule setup (CLI and web app).
- A reader exploring automated issue triage can reach the integrations setup that fires those triggers.

**Open questions for human review**
- Link density: all three links land on `faqs.mdx`. They sit in three distant Q&A sections of a hub page and point to three distinct destinations, so this stays within the audit's hub-page allowance, but reviewers may prefer to distribute some links to other pages in a follow-up.
- Two pre-existing `style_lint` HEADER-CASE warnings on `faqs.mdx` (lines 52, 81) are false positives (proper nouns: ChatGPT, Docker, Playwright) and were left untouched to keep this PR scoped to cross-linking.

**Follow-up recommendations (out of scope for this pilot)**
- Consider an inline orchestration link in `overview.mdx`'s "more parallelism" bullet (currently only linked in the "Learn more" list).
- Peec UGC recommendations (Reddit/YouTube on "AI coding agents") are content-creation opportunities outside internal cross-linking.

_Conversation: https://app.warp.dev/conversation/8b970481-22fc-4d40-938a-25d92b867b62_
_Run: https://oz.warp.dev/runs/019ebb0f-45f5-751e-b905-d3208979e5f8_

_This PR was generated with [Oz](https://warp.dev/oz)._
