### PR TITLE
Document long-running command auto-queue and empty-input Enter send-now

### DIFF
--- a/src/content/docs/agent-platform/capabilities/full-terminal-use.mdx
+++ b/src/content/docs/agent-platform/capabilities/full-terminal-use.mdx
@@ -98,11 +98,11 @@ This makes it easy to:
 * Step in for delicate or security-sensitive actions
 * Then let the agent continue once the critical step is done
 
-#### Prompts queue while the agent drives the command
+#### Prompts queue while the agent drives a command it started
 
-By default, prompts you submit while the agent is driving a long-running command are queued instead of steering the agent mid-command. They appear in the queued prompts panel with a *(queued until the command finishes)* suffix, and Warp sends them to the agent automatically when the command finishes.
+When the agent starts a long-running command itself, prompts you submit while it drives that command are queued by default instead of steering the agent mid-command. They appear in the queued prompts panel with a *(queued until the command finishes)* suffix, and Warp sends them to the agent automatically when the command finishes. This applies only to commands the agent started; if you start a command and tag the agent in, your prompts keep steering the agent immediately.
 
-To steer the agent immediately instead, toggle auto-queue off for the remainder of the command, or change the **Default long-running command submission mode** setting in the Warp app under **Settings** > **Agents** > **Warp Agent** > **Input**. For the full behavior, including the setting's options and when it applies, see [Queueing during long-running commands](/agent-platform/local-agents/interacting-with-agents/prompt-queueing/#queueing-during-long-running-commands).
+To steer the agent immediately during an agent-started command, toggle auto-queue off for the remainder of the command, or change the **Default long-running command submission mode** setting in the Warp app under **Settings** > **Agents** > **Warp Agent** > **Input**. For the full behavior, including the setting's options and when it applies, see [Queueing during long-running commands](/agent-platform/local-agents/interacting-with-agents/prompt-queueing/#queueing-during-long-running-commands).
 
 #### Long-running commands in terminal vs agent view
 

--- a/src/content/docs/agent-platform/capabilities/full-terminal-use.mdx
+++ b/src/content/docs/agent-platform/capabilities/full-terminal-use.mdx
@@ -98,6 +98,12 @@ This makes it easy to:
 * Step in for delicate or security-sensitive actions
 * Then let the agent continue once the critical step is done
 
+#### Prompts queue while the agent drives the command
+
+By default, prompts you submit while the agent is driving a long-running command are queued instead of steering the agent mid-command. They appear in the queued prompts panel with a *(queued until the command finishes)* suffix, and Warp sends them to the agent automatically when the command finishes.
+
+To steer the agent immediately instead, toggle auto-queue off for the remainder of the command, or change the **Default long-running command submission mode** setting in the Warp app under **Settings** > **Agents** > **Warp Agent** > **Input**. For the full behavior, including the setting's options and when it applies, see [Queueing during long-running commands](/agent-platform/local-agents/interacting-with-agents/prompt-queueing/#queueing-during-long-running-commands).
+
 #### Long-running commands in terminal vs agent view
 
 The behavior differs based on where you start the long-running command:

--- a/src/content/docs/agent-platform/local-agents/interacting-with-agents/prompt-queueing.mdx
+++ b/src/content/docs/agent-platform/local-agents/interacting-with-agents/prompt-queueing.mdx
@@ -31,13 +31,13 @@ Queued prompts use the same submission flow as prompts you send manually, so sla
 
 A few things to know:
 
-* **Shell commands are never queued.** If you submit in shell mode, Warp runs the command in the terminal immediately, regardless of your auto-queue setting. The exception is while an agent is driving a long-running command—see [Queueing during long-running commands](#queueing-during-long-running-commands).
+* **Shell commands are never queued.** If you submit in shell mode, Warp runs the command in the terminal immediately, regardless of your auto-queue setting. The exception is while an agent is driving a long-running command. See [Queueing during long-running commands](#queueing-during-long-running-commands).
 * **Queues don't persist across restarts.** A conversation's queue is cleared when the conversation is deleted or cleared, and queues do not persist after an app restart.
 * **One prompt is in flight at a time.** Warp waits for the current response to finish before sending the next queued prompt.
 
 ## Queueing a prompt
 
-There are three ways to queue prompts yourself. The auto-queue toggle and `/queue` act on the active conversation; the default submission mode setting controls what happens app-wide. Warp also queues prompts automatically while an agent is driving a long-running command—see [Queueing during long-running commands](#queueing-during-long-running-commands).
+There are three ways to queue prompts yourself. The auto-queue toggle and `/queue` act on the active conversation; the default submission mode setting controls what happens app-wide. Warp also queues prompts automatically while an agent is driving a long-running command. See [Queueing during long-running commands](#queueing-during-long-running-commands).
 
 ### Auto-queue toggle
 
@@ -75,7 +75,7 @@ By default, submitting a prompt while the agent is responding interrupts the cur
 
 This setting is the default for conversations that you haven't explicitly toggled. The per-conversation auto-queue toggle always overrides it for that conversation.
 
-When **Interrupt response** is selected, a second dropdown, **Default long-running command submission mode**, appears directly below it. It controls what happens while an agent is driving a long-running command—see [Queueing during long-running commands](#queueing-during-long-running-commands).
+When **Interrupt response** is selected, a second dropdown, **Default long-running command submission mode**, appears directly below it. It controls what happens while an agent is driving a long-running command. See [Queueing during long-running commands](#queueing-during-long-running-commands).
 
 <figure style={{ maxWidth: "563px" }}>
 ![The Default prompt submission mode dropdown in Agent input settings, open to show 'Interrupt response' and 'Queue until response finishes.'](../../../../../assets/agent-platform/prompt-submission-mode-setting.png)
@@ -84,19 +84,19 @@ When **Interrupt response** is selected, a second dropdown, **Default long-runni
 
 ## Queueing during long-running commands
 
-When an agent is driving a long-running command—a dev server, REPL, database shell, or other interactive program it has attached to via [Full Terminal Use](/agent-platform/capabilities/full-terminal-use/)—prompts you submit are queued by default instead of steering the agent mid-command. Warp sends them to the agent automatically when the command finishes.
+When an agent is driving a long-running command (a dev server, REPL, database shell, or other interactive program it has attached to via [Full Terminal Use](/agent-platform/capabilities/full-terminal-use/)), prompts you submit are queued by default instead of steering the agent mid-command. Warp sends them to the agent automatically when the command finishes.
 
 While the agent is in control of the command (including while it's blocked waiting for an approval):
 
-* **Prompts queue instead of interrupting.** Submitting a prompt adds it to the conversation's queue and clears the input so you can keep typing. These rows show an italic *(queued until the command finishes)* suffix after the prompt text, marking that they fire when the command ends rather than when the full response finishes.
-* **Queued prompts send at command end.** When the command finishes, all of the suffixed prompts are sent to the agent immediately, in queue order—even if you manually took over the command before it finished. Prompts queued other ways (`/queue`, the auto-queue toggle, or the queue default mode) are untouched and still send under the normal end-of-response rules.
-* **Shell commands queue as regular commands.** Shell commands you submit during the command are queued without the suffix and run in the terminal as usual; they are not sent to the agent when the command ends.
-* **The UI reflects the queue state.** The auto-queue toggle in the warping indicator shows its active, accent-colored state, and the empty input's ghost text shows the queue hint instead of the steer hint.
+* **Prompts queue instead of interrupting.** Submitting a prompt adds it to the conversation's queue and clears the input so you can keep typing. These rows show an italic *(queued until the command finishes)* suffix after the prompt text, indicating they fire when the command ends rather than when the full response finishes.
+* **Queued prompts send at command end.** When the command finishes, all the suffixed prompts are sent to the agent immediately, in queue order, even if you manually took over the command before it finished. Prompts queued in other ways (`/queue`, the auto-queue toggle, or the queue default mode) are untouched and still send under the normal end-of-response rules.
+* **Shell commands queue as regular commands.** Shell commands you submit during a long-running command are queued without the suffix and run in the terminal as usual; they are not sent to the agent when the command ends.
+* **The UI reflects the queue state.** The auto-queue toggle in the warping indicator appears in its active, accent-colored state, and the empty input's ghost text shows the queue hint instead of the steer hint.
 * **All queue interactions still work.** You can reorder, edit, delete, use send now, or press `Enter` on an empty input to send the top row early.
 
-This queueing is per-conversation and derived from the running command rather than a sticky toggle: when the command ends or control transfers back to you, the conversation reverts to whatever queue state it had before the command—its own toggle state, or the app-wide default. It only applies while the agent is in control of the command, not while you are in control before the agent takes over or after a takeover.
+This queueing is per-conversation and derived from the running command rather than a sticky toggle: when the command ends or control transfers back to you, the conversation reverts to whatever queue state it had before the command (its own toggle state, or the app-wide default). It applies only while the agent is in control of the command, not while you are.
 
-To steer the agent mid-command instead, turn the auto-queue toggle off—click the clock-plus icon, or press `⌘+Shift+J` (macOS) or `Ctrl+Shift+J` (Windows/Linux). Prompts then send immediately for the remainder of that command only; the override doesn't change the conversation's persistent toggle state, and the next agent-controlled command auto-queues again. Toggling it back on re-enables queueing for the rest of the command.
+To steer the agent mid-command instead, turn the auto-queue toggle off: click the clock-plus icon, or press `⌘+Shift+J` (macOS) or `Ctrl+Shift+J` (Windows/Linux). Prompts then send immediately for the remainder of that command only; the override doesn't change the conversation's persistent toggle state, and the next agent-controlled command auto-queues again. Toggling it back on re-enables queueing for the rest of the command.
 
 ### Change the long-running command submission mode
 
@@ -118,7 +118,7 @@ When a conversation has at least one queued prompt, the queued prompts panel app
 Hovering a row reveals controls for that prompt:
 
 * **Reorder** - Drag a row up or down by its handle to change the order. The row at the top of the list always sends next.
-* **Send now** - Click the up-arrow icon to send that prompt immediately instead of waiting for the agent to finish the current response. You can also press `Enter` while the input box is empty to send the top row—see below.
+* **Send now** - Click the up-arrow icon to send that prompt immediately instead of waiting for the agent to finish the current response. You can also press `Enter` while the input box is empty to send the top row. See [Send the next prompt with Enter](#send-the-next-prompt-with-enter) below.
 * **Edit** - Click the pencil icon to edit the prompt inline. Press `Enter` to save your changes or `Esc` to cancel.
 * **Delete** - Click the trash icon to remove the prompt from the queue. If the input is empty, Warp moves the deleted prompt into the input so you can revise and resend it. If the input already has text, the deleted prompt is discarded.
 
@@ -131,11 +131,11 @@ Deleting the last prompt removes the panel, since the queue is now empty.
 
 ### Send the next prompt with Enter
 
-When the queued prompts panel is showing and the input box is empty, pressing `Enter` sends the row at the top of the queue immediately—exactly like clicking that row's send now button. Each press sends one row: the remaining rows stay queued, and pressing `Enter` again sends the new top row, until the queue is empty. The input stays empty throughout.
+When the queued prompts panel is showing and the input box is empty, pressing `Enter` sends the row at the top of the queue immediately, exactly like clicking that row's send now button. Each press sends one row: the remaining rows stay queued, and pressing `Enter` again sends the new top row, until the queue is empty. The input stays empty throughout.
 
 This works for both row types: queued prompts are sent to the agent, and queued shell commands run in the terminal. If the input has any text, `Enter` keeps its normal behavior and submits the typed input, leaving the queue untouched. `Enter` also keeps its normal behavior while the CLI agent Rich Input composer is open.
 
-The panel header advertises this shortcut: next to the queued count, an **⏎ to send** hint appears whenever pressing `Enter` would send the top row. The hint is hidden when it wouldn't—for example while you're editing a row inline, while the input has text, or when the top row is a cloud run's locked initial prompt. That locked prompt can never be sent this way; `Enter` does nothing while it sits at the head of the queue, and the rows behind it wait until it's removed.
+The panel header shows this shortcut: next to the queued count, an **⏎ to send** hint appears whenever pressing `Enter` would send the top row. The hint is hidden when it wouldn't, for example while you're editing a row inline, while the input has text, or when the top row is a cloud run's locked initial prompt. That locked prompt can never be sent this way; `Enter` does nothing while it sits at the head of the queue, and the rows behind it wait until it's removed.
 
 ## When sending pauses
 

--- a/src/content/docs/agent-platform/local-agents/interacting-with-agents/prompt-queueing.mdx
+++ b/src/content/docs/agent-platform/local-agents/interacting-with-agents/prompt-queueing.mdx
@@ -18,6 +18,8 @@ Prompt queueing lets you line up follow-up prompts while an agent is still worki
 * **`/queue` slash command** - Queue a single follow-up prompt inline, without switching modes.
 * **Queued prompts panel** - View, reorder, edit, and remove every pending prompt from one collapsible panel above the input.
 * **Automatic sequential sending** - Queued prompts fire one at a time as the agent finishes each response, in the order you set.
+* **Send the next prompt with Enter** - When the input is empty, press `Enter` to send the top queued row immediately.
+* **Auto-queue during long-running commands** - By default, prompts submitted while an agent is driving a long-running command are queued and sent when the command finishes.
 * **Per-conversation queues** - Each conversation keeps its own queue and auto-queue state, which persist when you leave and re-enter the conversation.
 * **Cloud agent support** - Queue follow-ups for cloud agents, even while the environment is still setting up.
 
@@ -29,13 +31,13 @@ Queued prompts use the same submission flow as prompts you send manually, so sla
 
 A few things to know:
 
-* **Shell commands are never queued.** If you submit in shell mode, Warp runs the command in the terminal immediately, regardless of your auto-queue setting.
+* **Shell commands are never queued.** If you submit in shell mode, Warp runs the command in the terminal immediately, regardless of your auto-queue setting. The exception is while an agent is driving a long-running command—see [Queueing during long-running commands](#queueing-during-long-running-commands).
 * **Queues don't persist across restarts.** A conversation's queue is cleared when the conversation is deleted or cleared, and queues do not persist after an app restart.
 * **One prompt is in flight at a time.** Warp waits for the current response to finish before sending the next queued prompt.
 
 ## Queueing a prompt
 
-There are three ways to queue prompts. The auto-queue toggle and `/queue` act on the active conversation; the default submission mode setting controls what happens app-wide.
+There are three ways to queue prompts yourself. The auto-queue toggle and `/queue` act on the active conversation; the default submission mode setting controls what happens app-wide. Warp also queues prompts automatically while an agent is driving a long-running command—see [Queueing during long-running commands](#queueing-during-long-running-commands).
 
 ### Auto-queue toggle
 
@@ -73,10 +75,41 @@ By default, submitting a prompt while the agent is responding interrupts the cur
 
 This setting is the default for conversations that you haven't explicitly toggled. The per-conversation auto-queue toggle always overrides it for that conversation.
 
+When **Interrupt response** is selected, a second dropdown, **Default long-running command submission mode**, appears directly below it. It controls what happens while an agent is driving a long-running command—see [Queueing during long-running commands](#queueing-during-long-running-commands).
+
 <figure style={{ maxWidth: "563px" }}>
 ![The Default prompt submission mode dropdown in Agent input settings, open to show 'Interrupt response' and 'Queue until response finishes.'](../../../../../assets/agent-platform/prompt-submission-mode-setting.png)
 <figcaption>The Default prompt submission mode setting under Agent input settings.</figcaption>
 </figure>
+
+## Queueing during long-running commands
+
+When an agent is driving a long-running command—a dev server, REPL, database shell, or other interactive program it has attached to via [Full Terminal Use](/agent-platform/capabilities/full-terminal-use/)—prompts you submit are queued by default instead of steering the agent mid-command. Warp sends them to the agent automatically when the command finishes.
+
+While the agent is in control of the command (including while it's blocked waiting for an approval):
+
+* **Prompts queue instead of interrupting.** Submitting a prompt adds it to the conversation's queue and clears the input so you can keep typing. These rows show an italic *(queued until the command finishes)* suffix after the prompt text, marking that they fire when the command ends rather than when the full response finishes.
+* **Queued prompts send at command end.** When the command finishes, all of the suffixed prompts are sent to the agent immediately, in queue order—even if you manually took over the command before it finished. Prompts queued other ways (`/queue`, the auto-queue toggle, or the queue default mode) are untouched and still send under the normal end-of-response rules.
+* **Shell commands queue as regular commands.** Shell commands you submit during the command are queued without the suffix and run in the terminal as usual; they are not sent to the agent when the command ends.
+* **The UI reflects the queue state.** The auto-queue toggle in the warping indicator shows its active, accent-colored state, and the empty input's ghost text shows the queue hint instead of the steer hint.
+* **All queue interactions still work.** You can reorder, edit, delete, use send now, or press `Enter` on an empty input to send the top row early.
+
+This queueing is per-conversation and derived from the running command rather than a sticky toggle: when the command ends or control transfers back to you, the conversation reverts to whatever queue state it had before the command—its own toggle state, or the app-wide default. It only applies while the agent is in control of the command, not while you are in control before the agent takes over or after a takeover.
+
+To steer the agent mid-command instead, turn the auto-queue toggle off—click the clock-plus icon, or press `⌘+Shift+J` (macOS) or `Ctrl+Shift+J` (Windows/Linux). Prompts then send immediately for the remainder of that command only; the override doesn't change the conversation's persistent toggle state, and the next agent-controlled command auto-queues again. Toggling it back on re-enables queueing for the rest of the command.
+
+### Change the long-running command submission mode
+
+You can change this behavior app-wide:
+
+1. In the Warp app, go to **Settings** > **Agents** > **Warp Agent** > **Input**.
+2. For **Default long-running command submission mode**, choose one of:
+   * **Queue until command finishes** - Queue prompts submitted while an agent is driving a long-running command, and send them to the agent when the command finishes (the default).
+   * **Send immediately** - Send the prompt to the agent right away, steering it mid-command.
+
+The dropdown appears directly below **Default prompt submission mode**, and only when that setting is **Interrupt response**. When the default prompt submission mode is **Queue until response finishes**, this setting is hidden and ignored, because prompts already queue until the entire response finishes.
+
+Changing the setting takes effect immediately, including in the middle of a running command. You can also change it from the Command Palette using **Set long-running command submission: send immediately** or **Set long-running command submission: queue until command finishes**, which are available while the default prompt submission mode is **Interrupt response**.
 
 ## Managing queued prompts
 
@@ -85,7 +118,7 @@ When a conversation has at least one queued prompt, the queued prompts panel app
 Hovering a row reveals controls for that prompt:
 
 * **Reorder** - Drag a row up or down by its handle to change the order. The row at the top of the list always sends next.
-* **Send now** - Click the up-arrow icon to send that prompt immediately instead of waiting for the agent to finish the current response.
+* **Send now** - Click the up-arrow icon to send that prompt immediately instead of waiting for the agent to finish the current response. You can also press `Enter` while the input box is empty to send the top row—see below.
 * **Edit** - Click the pencil icon to edit the prompt inline. Press `Enter` to save your changes or `Esc` to cancel.
 * **Delete** - Click the trash icon to remove the prompt from the queue. If the input is empty, Warp moves the deleted prompt into the input so you can revise and resend it. If the input already has text, the deleted prompt is discarded.
 
@@ -95,6 +128,14 @@ Hovering a row reveals controls for that prompt:
 </figure>
 
 Deleting the last prompt removes the panel, since the queue is now empty.
+
+### Send the next prompt with Enter
+
+When the queued prompts panel is showing and the input box is empty, pressing `Enter` sends the row at the top of the queue immediately—exactly like clicking that row's send now button. Each press sends one row: the remaining rows stay queued, and pressing `Enter` again sends the new top row, until the queue is empty. The input stays empty throughout.
+
+This works for both row types: queued prompts are sent to the agent, and queued shell commands run in the terminal. If the input has any text, `Enter` keeps its normal behavior and submits the typed input, leaving the queue untouched. `Enter` also keeps its normal behavior while the CLI agent Rich Input composer is open.
+
+The panel header advertises this shortcut: next to the queued count, an **⏎ to send** hint appears whenever pressing `Enter` would send the top row. The hint is hidden when it wouldn't—for example while you're editing a row inline, while the input has text, or when the top row is a cloud run's locked initial prompt. That locked prompt can never be sent this way; `Enter` does nothing while it sits at the head of the queue, and the rows behind it wait until it's removed.
 
 ## When sending pauses
 
@@ -125,5 +166,6 @@ Because cloud conversations keep running after you leave the agent view, their q
 ## Related pages
 
 * [Slash Commands](/agent-platform/capabilities/slash-commands/) - The full list of built-in commands, including `/queue`.
+* [Full Terminal Use](/agent-platform/capabilities/full-terminal-use/) - How agents attach to and drive interactive long-running commands.
 * [Terminal and Agent modes](/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/) - How input is routed between the terminal and the agent.
 * [Cloud agents overview](/agent-platform/cloud-agents/overview/) - Run agents in the cloud from any trigger.

--- a/src/content/docs/agent-platform/local-agents/interacting-with-agents/prompt-queueing.mdx
+++ b/src/content/docs/agent-platform/local-agents/interacting-with-agents/prompt-queueing.mdx
@@ -19,7 +19,7 @@ Prompt queueing lets you line up follow-up prompts while an agent is still worki
 * **Queued prompts panel** - View, reorder, edit, and remove every pending prompt from one collapsible panel above the input.
 * **Automatic sequential sending** - Queued prompts fire one at a time as the agent finishes each response, in the order you set.
 * **Send the next prompt with Enter** - When the input is empty, press `Enter` to send the top queued row immediately.
-* **Auto-queue during long-running commands** - By default, prompts submitted while an agent is driving a long-running command are queued and sent when the command finishes.
+* **Auto-queue during long-running commands** - By default, prompts submitted while an agent is driving a long-running command it started are queued and sent when the command finishes.
 * **Per-conversation queues** - Each conversation keeps its own queue and auto-queue state, which persist when you leave and re-enter the conversation.
 * **Cloud agent support** - Queue follow-ups for cloud agents, even while the environment is still setting up.
 
@@ -84,19 +84,19 @@ When **Interrupt response** is selected, a second dropdown, **Default long-runni
 
 ## Queueing during long-running commands
 
-When an agent is driving a long-running command (a dev server, REPL, database shell, or other interactive program it has attached to via [Full Terminal Use](/agent-platform/capabilities/full-terminal-use/)), prompts you submit are queued by default instead of steering the agent mid-command. Warp sends them to the agent automatically when the command finishes.
+When an agent is driving a long-running command it started (a dev server, REPL, database shell, or other interactive program it launched through [Full Terminal Use](/agent-platform/capabilities/full-terminal-use/)), prompts you submit are queued by default instead of steering the agent mid-command. Warp sends them to the agent automatically when the command finishes. This auto-queueing applies only to commands the agent started; if you start a command yourself and tag the agent in, your prompts keep steering the agent immediately.
 
 While the agent is in control of the command (including while it's blocked waiting for an approval):
 
 * **Prompts queue instead of interrupting.** Submitting a prompt adds it to the conversation's queue and clears the input so you can keep typing. These rows show an italic *(queued until the command finishes)* suffix after the prompt text, indicating they fire when the command ends rather than when the full response finishes.
-* **Queued prompts send at command end.** When the command finishes, all the suffixed prompts are sent to the agent immediately, in queue order, even if you manually took over the command before it finished. Prompts queued in other ways (`/queue`, the auto-queue toggle, or the queue default mode) are untouched and still send under the normal end-of-response rules.
+* **Suffixed prompts send when the command finishes.** When the command finishes, Warp sends the suffixed prompts at the front of the queue, in order, even if you manually took over the command first. A suffixed prompt sends this way only while it stays at the front: if you reorder a prompt queued another way ahead of it, that suffixed prompt waits and sends later under the normal end-of-response rules. Prompts queued in other ways (`/queue`, the auto-queue toggle, or the queue default mode) always follow those normal rules.
 * **Shell commands queue as regular commands.** Shell commands you submit during a long-running command are queued without the suffix and run in the terminal as usual; they are not sent to the agent when the command ends.
 * **The UI reflects the queue state.** The auto-queue toggle in the warping indicator appears in its active, accent-colored state, and the empty input's ghost text shows the queue hint instead of the steer hint.
 * **All queue interactions still work.** You can reorder, edit, delete, use send now, or press `Enter` on an empty input to send the top row early.
 
 This queueing is per-conversation and derived from the running command rather than a sticky toggle: when the command ends or control transfers back to you, the conversation reverts to whatever queue state it had before the command (its own toggle state, or the app-wide default). It applies only while the agent is in control of the command, not while you are.
 
-To steer the agent mid-command instead, turn the auto-queue toggle off: click the clock-plus icon, or press `⌘+Shift+J` (macOS) or `Ctrl+Shift+J` (Windows/Linux). Prompts then send immediately for the remainder of that command only; the override doesn't change the conversation's persistent toggle state, and the next agent-controlled command auto-queues again. Toggling it back on re-enables queueing for the rest of the command.
+To steer the agent mid-command instead, turn the auto-queue toggle off: click the clock-plus icon, or press `⌘+Shift+J` (macOS) or `Ctrl+Shift+J` (Windows/Linux). Prompts then send immediately for the remainder of that command only; the override doesn't change the conversation's persistent toggle state, and the next command the agent starts auto-queues again. Toggling it back on re-enables queueing for the rest of the command.
 
 ### Change the long-running command submission mode
 
@@ -104,7 +104,7 @@ You can change this behavior app-wide:
 
 1. In the Warp app, go to **Settings** > **Agents** > **Warp Agent** > **Input**.
 2. For **Default long-running command submission mode**, choose one of:
-   * **Queue until command finishes** - Queue prompts submitted while an agent is driving a long-running command, and send them to the agent when the command finishes (the default).
+   * **Queue until command finishes** - Queue prompts submitted while an agent is driving a long-running command it started, and send them to the agent when the command finishes (the default).
    * **Send immediately** - Send the prompt to the agent right away, steering it mid-command.
 
 The dropdown appears directly below **Default prompt submission mode**, and only when that setting is **Interrupt response**. When the default prompt submission mode is **Queue until response finishes**, this setting is hidden and ignored, because prompts already queue until the entire response finishes.

--- a/src/content/docs/terminal/settings/all-settings.mdx
+++ b/src/content/docs/terminal/settings/all-settings.mdx
@@ -318,6 +318,8 @@ Settings for Warp's agents, including model behavior, permissions, knowledge, MC
 * `should_show_oz_updates_in_zero_state` — Whether the "What's new" section is shown in the agent view. Type: boolean. Default: `true`.
 * `should_render_use_agent_toolbar_for_user_commands` — Whether to show the "Use Agent" footer for terminal commands. Type: boolean. Default: `true`.
 * `cloud_agent_computer_use_enabled` — Whether computer use is enabled for cloud agent conversations. Type: boolean. Default: `false`.
+* `default_prompt_submission_mode` — What happens when you submit a prompt while the agent is responding: interrupt the current response or queue the prompt until the response finishes. Type: string. Default: `"interrupt"`. Options: `"interrupt"`, `"queue"`.
+* `long_running_command_submission_mode` — What happens when you submit a prompt while an agent is driving a long-running command: send it immediately or queue it until the command finishes. Applies only when `default_prompt_submission_mode` is `"interrupt"`. Type: string. Default: `"queue_until_command_completes"`. Options: `"send_immediately"`, `"queue_until_command_completes"`.
 
 ### Code review autogeneration
 


### PR DESCRIPTION
Documents two recently shipped Warp client features.

## Feature 1: Enter on an empty input sends the next queued prompt

`src/content/docs/agent-platform/local-agents/interacting-with-agents/prompt-queueing.mdx`:
- New "Send the next prompt with Enter" subsection under "Managing queued prompts": pressing `Enter` with an empty input sends the top queued row (same as its send now button), one row per press, for both prompt and shell-command rows; normal `Enter` behavior when the input has text or the CLI agent Rich Input composer is open.
- Documents the "⏎ to send" header hint and when it's hidden (inline editing, input has text, locked initial cloud-mode prompt at the head of the queue).
- Cross-references from the "Send now" bullet and a new "Key features" bullet.

## Feature 2: Auto-queue during agent-controlled long-running commands + new setting

- `prompt-queueing.mdx`: new "Queueing during long-running commands" section covering the default auto-queue behavior, the "(queued until the command finishes)" row suffix, at-command-end delivery in queue order, shell-command rows staying regular queued commands, the UI state (active auto-queue toggle, queue ghost text), the per-command toggle override (`⌘+Shift+J` / `Ctrl+Shift+J`), and the derived per-conversation state. Also documents the new **Default long-running command submission mode** setting ("Send immediately" / "Queue until command finishes", default queue), its visibility rule (only shown when **Default prompt submission mode** is **Interrupt response**), and the Command Palette entries.
- `src/content/docs/agent-platform/capabilities/full-terminal-use.mdx`: short "Prompts queue while the agent drives the command" subsection linking to the prompt-queueing section and the setting.
- `src/content/docs/terminal/settings/all-settings.mdx`: added `long_running_command_submission_mode` and the previously missing `default_prompt_submission_mode` under `[agents.warp_agent.other]`.

## Validation
- `npm run build` passes (338 pages built).

_Conversation: https://staging.warp.dev/conversation/e0d478b8-6dce-4363-b965-404b4132f6e1_
_Run: https://oz.staging.warp.dev/runs/019ebca6-bdb7-781d-bc7d-f06f24140f64_

_This PR was generated with [Oz](https://warp.dev/oz)._
