### PR TITLE
docs: use release docs profile secret

### DIFF
--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           skill: warpdotdev/docs:release_updates
           warp_api_key: ${{ secrets.WARP_API_KEY }}
-          profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
+          profile: ${{ secrets.WARP_AGENT_PROFILE || '' }}
           prompt: |
             Run the release docs update workflow from the `release_updates` skill.
 


### PR DESCRIPTION
## Summary
Fixes the release docs workflow so it uses the configured Docs Agent profile secret instead of looking for a missing repository variable.

## Changes
- Updates `.github/workflows/release-docs-update.yml` to pass `secrets.WARP_AGENT_PROFILE` into `oz-agent-action`.
- This should make the workflow run with the Docs Agent profile, which has `DOCS_AGENT_GRAFANA_TOKEN` configured for on-call reviewer assignment.

## Validation
- Synced with `origin/main`.
- Ran `git diff --check`.
- Confirmed the diff is a one-line workflow change.

## Follow-up
After this merges, rerun the release docs workflow with `assign_oncall_reviewers: true` to verify the Docs Agent profile exposes `DOCS_AGENT_GRAFANA_TOKEN` and can assign on-call reviewers.

Co-Authored-By: Oz <oz-agent@warp.dev>
