### PR TITLE
ci: default task_set to all for automated release dispatch

### DIFF
--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -68,7 +68,7 @@ jobs:
           if event_name == "repository_dispatch":
               raw = {
                   "channel_versions_ref": os.environ.get("DISPATCH_CHANNEL_VERSIONS_REF") or "main",
-                  "task_set": os.environ.get("DISPATCH_TASK_SET") or "changelog",
+                  "task_set": "all",  # always run all tasks for automated dispatch
                   "create_draft_pr": os.environ.get("DISPATCH_CREATE_DRAFT_PR") or "false",
                   "assign_oncall_reviewers": os.environ.get("DISPATCH_ASSIGN_ONCALL_REVIEWERS") or "false",
               }


### PR DESCRIPTION
## Summary

Changes the `repository_dispatch` default for `task_set` from `changelog` to `all`, so automated runs (triggered by channel-versions) run all four release tasks in order: warp_app_update, changelog, licenses, telemetry.

This keeps task set ownership in the docs workflow rather than the channel-versions dispatch payload.

## Related

- channel-versions PR #975 (removes task_set from payload)
- Follows #205, #197 (merged)

Co-Authored-By: Oz <oz-agent@warp.dev>