### PR TITLE
docs: use local release updates skill

### DIFF
--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Run release docs update with Oz
         uses: warpdotdev/oz-agent-action@v1
         with:
-          skill: warpdotdev/docs:release_updates
+          skill: release_updates
           warp_api_key: ${{ secrets.WARP_API_KEY }}
           profile: ${{ secrets.WARP_AGENT_PROFILE || '' }}
           prompt: |


### PR DESCRIPTION
## Summary
Updates the release docs workflow to use the checked-out repo's local `release_updates` skill instead of resolving `warpdotdev/docs:release_updates` through Oz repository access.

## Changes
- Changes `.github/workflows/release-docs-update.yml` from `skill: warpdotdev/docs:release_updates` to `skill: release_updates`.
- This should avoid the `Repository 'docs' not found` failure seen when running with the Docs Agent profile.

## Validation
- Synced with `origin/main`.
- Ran `git diff --check`.
- Confirmed the diff is a one-line workflow change.

## Follow-up
After this merges, rerun the release docs workflow with `task_set: all`, `create_draft_pr: true`, and `assign_oncall_reviewers: true` to verify the Docs Agent profile can run the local skill and access `DOCS_AGENT_GRAFANA_TOKEN`.

Co-Authored-By: Oz <oz-agent@warp.dev>