### PR TITLE
docs: add AEO cross-links for agents and orchestration

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/integrations/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/integrations/index.mdx
@@ -35,3 +35,4 @@ Use the setup walkthrough below for a quick look at how environments connect to 
 * [GitHub Actions](/agent-platform/cloud-agents/integrations/github-actions/) - Run agents from CI workflows and repository events.
 * [GitLab](/agent-platform/cloud-agents/integrations/gitlab/), [Bitbucket](/agent-platform/cloud-agents/integrations/bitbucket/), and [Azure DevOps](/agent-platform/cloud-agents/integrations/azure-devops/) - Connect non-GitHub repositories with tokens and Warp-managed secrets.
 * [AWS, GCP, and other cloud providers](/agent-platform/cloud-agents/integrations/cloud-providers/) - Give cloud agents short-lived access to cloud services.
+* [Managing cloud agents](/agent-platform/cloud-agents/managing-cloud-agents/) - Monitor and review integration-triggered runs across your team by source, status, or creator.

--- a/src/content/docs/agent-platform/cloud-agents/triggers/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/triggers/index.mdx
@@ -17,3 +17,5 @@ If you're choosing between schedules, Slack, Linear, GitHub Actions, the Oz CLI,
 * **[CLI](/reference/cli/)** - Trigger cloud agents directly from your terminal using the Oz CLI.
 * **[API & SDK](/reference/api-and-sdk/)** - Programmatically trigger agents via the Warp API or SDK.
 * **[Integrations](/agent-platform/cloud-agents/integrations/)** - Trigger agents from external services like Slack, Linear, or GitHub Actions.
+
+After a trigger fires, track and review the resulting runs across your team from the [Agent Management Panel and Oz web app Runs page](/agent-platform/cloud-agents/managing-cloud-agents/), where you can filter by source, status, day, or creator.

--- a/src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx
@@ -14,6 +14,8 @@ Warp's Scheduled Agents let you run cloud agents automatically on a **recurring 
 
 Scheduled Agents run in the background on Warp’s infrastructure. Each run starts from a clean session, executes a fixed prompt, and produces its own task and session history that can be inspected after the fact.
 
+For a guided, no-CLI walkthrough that creates a recurring agent from the Oz web app, see the [Scheduled Agents quickstart](/agent-platform/cloud-agents/triggers/scheduled-agents-quickstart/). This page is the full reference for managing schedules with the Oz CLI.
+
 If you're deciding whether to use a schedule, Slack or Linear trigger, GitHub Actions, the Oz CLI, or the API, see [Run agents unattended with schedules and triggers](/guides/agent-workflows/how-to-run-unattended-agents/).
 
 ---

--- a/src/content/docs/guides/agent-workflows/running-multiple-agents-at-once-with-warp.mdx
+++ b/src/content/docs/guides/agent-workflows/running-multiple-agents-at-once-with-warp.mdx
@@ -29,7 +29,7 @@ Each agent runs in its own thread, complete with:
 * Notifications when blocked or completed
 * Separate command histories
 
-Because Warp is a desktop app, it can send system notifications to alert you when an agent finishes or when it needs review.
+Because Warp is a desktop app, it can send system notifications to alert you when an agent finishes or when it needs review. To set up notifications for Claude Code, Codex, and OpenCode, see [Agent notifications](/agent-platform/capabilities/agent-notifications/).
 
 ---
 
@@ -94,6 +94,6 @@ Open the Agent Mode Dashboard to see:
 * Completed tasks
 * Logs and outputs
 
-You can refine or cancel tasks mid-run if needed, or switch back to manual commands.
+You can refine or cancel tasks mid-run if needed, or switch back to manual commands. To track these runs across your account and team, including cloud agent runs, open the [Agent Management Panel](/agent-platform/cloud-agents/managing-cloud-agents/) in the Warp app.
 
 For a workflow-oriented setup guide that covers task decomposition, worktrees, cloud orchestration, validation, and review handoff, see [How to run multiple AI coding agents](/guides/agent-workflows/how-to-run-multiple-ai-coding-agents/).


### PR DESCRIPTION
## AEO cross-link audit: agents and orchestration

Small, high-confidence internal cross-link additions for the agents, cloud agents, and orchestration topic area. Scope is limited to cross-linking existing pages — no new pages, no rewrites.

### Goal
Identify small internal cross-link improvements for agents, cloud agents, and orchestration docs that help readers continue a real workflow.

### Source signals
From the Peec snapshot at `buzz/aeo-snapshots/docs/agents-orchestration/latest.json` (window 2026-05-05 to 2026-06-04), high-volume docs-adjacent prompts include:
- "how do I set up AI coding agents to run on a schedule or in the background?" (high)
- "what's the best platform for scheduling and managing AI coding agents across a team?" (high)
- "how do development teams track and observe what their AI coding agents are doing in real time?" (high)
- "how do I trigger AI coding agents automatically from Slack, Linear, or GitHub?" (high)
- "what are the best tools for managing multiple AI coding agents?"

The snapshot's open questions also ask which page should be the canonical target for monitoring and reviewing cloud agent runs. `Managing cloud agents` (the Agent Management Panel + Oz web app Runs page) is that canonical target, and multiple pages were missing a link to it.

Google Search Console credentials were available in the environment, but no GSC query was run for this audit — the Peec prompts plus the repo-grounded gap on the hub pages were sufficient. No secret value was read, logged, or committed.

### Pages touched
- `src/content/docs/agent-platform/cloud-agents/triggers/scheduled-agents.mdx` — the CLI reference for Scheduled Agents did not link to the guided, no-CLI quickstart, despite scheduling being the strongest Peec signal cluster.
- `src/content/docs/agent-platform/cloud-agents/triggers/index.mdx` — Thin hub page that listed trigger types but never pointed readers to where triggered runs are monitored.
- `src/content/docs/agent-platform/cloud-agents/integrations/index.mdx` — Integrations hub that explained setup but never linked to the run-monitoring surface for integration-triggered runs.
- `src/content/docs/guides/agent-workflows/running-multiple-agents-at-once-with-warp.mdx` — An under-linked legacy guide (1 existing link) that mentions agent notifications and a run-review surface without linking either.

### Links added
1. `triggers/scheduled-agents.mdx` to `triggers/scheduled-agents-quickstart.mdx` — gives readers on the CLI reference a path to the guided web-app setup. The reverse link (quickstart to reference) already exists, confirming the relationship.
2. `triggers/index.mdx` to `managing-cloud-agents` — Added a sentence after the trigger types list: after a trigger fires, track and review the resulting runs from the Agent Management Panel and Oz web app Runs page. Backed by the "track and observe in real time" and "scheduling and managing across a team" prompts.
3. `integrations/index.mdx` to `managing-cloud-agents` — Added a "Managing cloud agents" item to the existing "Get started" list to monitor and review integration-triggered runs. Backed by the "track and observe in real time" and "trigger from Slack, Linear, or GitHub" prompts.
4. `guides/.../running-multiple-agents-at-once-with-warp.mdx` to `capabilities/agent-notifications.mdx` — the page lists "Notifications when blocked or completed" but never linked the notifications setup doc.
5. `guides/.../running-multiple-agents-at-once-with-warp.mdx` to `cloud-agents/managing-cloud-agents.mdx` — the "Reviewing all active agents" section describes monitoring active/completed runs; the Agent Management Panel is the canonical observability surface (matches the Peec "observe in real time" / "managing multiple" signals).

### Reader next step
- A reader on the Scheduled Agents CLI reference who wants the fastest setup can jump straight to the quickstart.
- A reader who just set up a trigger or integration next wants to know where the resulting runs appear and how to review them across the team. Both hub pages previously dead-ended without pointing to the canonical monitoring surface; these links complete that workflow.
- A reader running multiple agents who wants notifications can reach setup instructions; one who wants to track all runs across their account/team can reach the Agent Management Panel.

### Open questions for human review
- Confirm `Managing cloud agents` is the preferred canonical monitoring target over the standalone `Oz web app` page for these hub-page links (the snapshot raises this as an open question). `Managing cloud agents` was chosen because it documents both the Agent Management Panel and the Oz web app Runs page in one place.
- The "Run multiple agents at once" guide uses legacy terminology ("Agent Mode Dashboard", "Task List panel"). This PR only adds cross-links and does not rename these; a follow-up could align them with current terminology (Agent Management Panel, Task lists).
- GSC was available but not queried. A future run with a defined property/query path could confirm or expand these links with live search-query data.

### Follow-up recommendations (out of scope for this cross-link pilot)
- The Slack and Linear integration pages link "Environment Setup" to the integrations index rather than the dedicated `environments` page. That is an accuracy/link-target fix rather than a cross-link addition, so it was left out of this audit.
- Consider a reverse cross-link from `scheduled-agents.mdx` / integrations pages to `orchestration/` for the "managing multiple agents" cluster, if it reads as a natural next step rather than link stuffing.

---

_Conversation: https://app.warp.dev/conversation/59a539f1-3676-4526-aade-d7038c0f4ae1_
_Run: https://oz.warp.dev/runs/019eca82-5919-7e6d-9c89-b586eea9db27_

_This PR was generated with [Oz](https://warp.dev/oz)._
