### PR TITLE
removed/replaced discord community links within the docs

### DIFF
--- a/src/content/docs/getting-started/migrate-to-warp/index.mdx
+++ b/src/content/docs/getting-started/migrate-to-warp/index.mdx
@@ -21,4 +21,4 @@ Pick the tool you're switching from:
 
 ## Coming from something else?
 
-Warp works well for developers migrating from many other sources. If you're switching from a tool that isn't listed above - for example, Alacritty, WezTerm, Kitty, Hyper, or a Linux default like GNOME Terminal or Konsole - drop a note in our [Discord community](https://discord.gg/warpdotdev) so we can prioritize coverage.
+Warp works well for developers migrating from many other sources. If you're switching from a tool that isn't listed above - for example, Ghostty, Alacritty, WezTerm, Kitty, Hyper, or a Linux default like GNOME Terminal or Konsole - drop a note in our [Warp community Slack](https://go.warp.dev/join-preview) so we can prioritize coverage.

--- a/src/content/docs/support-and-community/community/contributing.mdx
+++ b/src/content/docs/support-and-community/community/contributing.mdx
@@ -15,7 +15,7 @@ Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/
 * **Share a workflow** - Add reusable command patterns to [`warpdotdev/workflows`](https://github.com/warpdotdev/workflows). Merged workflows ship to every Warp user.
 * **Publish Warp Drive objects** - Share Workflows, Notebooks, Rules, and Prompts publicly from [Warp Drive](/knowledge-and-collaboration/warp-drive/).
 * **Find an issue to pick up** - Browse [Warp's live agent dashboard](https://build.warp.dev), which shows the work Warp's agents are tackling across `warpdotdev/warp`. Use it to spot gaps, avoid duplicate work, and surface issues that haven't been claimed yet.
-* **Help others in the community** - Answer questions in the [Warp community Slack](https://go.warp.dev/join-preview) or [Discord](https://discord.com/invite/warpdotdev), and join conversations in [GitHub Discussions](https://github.com/warpdotdev/warp/discussions).
+* **Help others in the community** - Answer questions in the [Warp community Slack](https://go.warp.dev/join-preview), and join conversations in [GitHub Discussions](https://github.com/warpdotdev/warp/discussions).
 
 ## Send feedback and bug reports
 


### PR DESCRIPTION
Updated the community links to remove/replace discord. Directing folks to Slack community going forward for questions and feedback