### PR TITLE
docs: add AEO cross-links for agents and orchestration

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/integrations/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/integrations/index.mdx
@@ -35,3 +35,4 @@ Use the setup walkthrough below for a quick look at how environments connect to 
 * [GitHub Actions](/agent-platform/cloud-agents/integrations/github-actions/) - Run agents from CI workflows and repository events.
 * [GitLab](/agent-platform/cloud-agents/integrations/gitlab/), [Bitbucket](/agent-platform/cloud-agents/integrations/bitbucket/), and [Azure DevOps](/agent-platform/cloud-agents/integrations/azure-devops/) - Connect non-GitHub repositories with tokens and Warp-managed secrets.
 * [AWS, GCP, and other cloud providers](/agent-platform/cloud-agents/integrations/cloud-providers/) - Give cloud agents short-lived access to cloud services.
+* [Managing cloud agents](/agent-platform/cloud-agents/managing-cloud-agents/) - Monitor and review integration-triggered runs across your team by source, status, or creator.

--- a/src/content/docs/agent-platform/cloud-agents/triggers/index.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/triggers/index.mdx
@@ -17,3 +17,5 @@ If you're choosing between schedules, Slack, Linear, GitHub Actions, the Oz CLI,
 * **[CLI](/reference/cli/)** - Trigger cloud agents directly from your terminal using the Oz CLI.
 * **[API & SDK](/reference/api-and-sdk/)** - Programmatically trigger agents via the Warp API or SDK.
 * **[Integrations](/agent-platform/cloud-agents/integrations/)** - Trigger agents from external services like Slack, Linear, or GitHub Actions.
+
+After a trigger fires, track and review the resulting runs across your team from the [Agent Management Panel and Oz web app Runs page](/agent-platform/cloud-agents/managing-cloud-agents/), where you can filter by source, status, day, or creator.


### PR DESCRIPTION
## AEO cross-link audit: agents and orchestration

Small, high-confidence internal cross-link additions for the agents, cloud agents, and orchestration docs. Scope is limited to internal cross-linking; no new pages, rewrites, or broad SEO changes.

### Goal
Identify small internal cross-link improvements for agents, cloud agents, and orchestration docs, focused on helping readers continue a real workflow.

### Source signals
From the Peec snapshot at `buzz/aeo-snapshots/docs/agents-orchestration/latest.json` (window 2026-05-05 to 2026-06-04), high-volume docs-adjacent prompts include:
- "how do development teams track and observe what their AI coding agents are doing in real time?" (high)
- "what's the best platform for scheduling and managing AI coding agents across a team?" (high)
- "how do I trigger AI coding agents automatically from Slack, Linear, or GitHub?" (high)

The snapshot's open questions also ask which page should be the canonical target for monitoring and reviewing cloud agent runs. `Managing cloud agents` (the Agent Management Panel + Oz web app Runs page) is that canonical target, and both edited hub pages were missing a link to it.

Google Search Console credentials were available in the environment, but the audit did not need GSC query data to justify these two links — the Peec prompts plus the repo-grounded gap on the hub pages were sufficient. No secret value was read, logged, or committed.

### Pages touched
- `src/content/docs/agent-platform/cloud-agents/triggers/index.mdx` — Thin hub page that listed trigger types but never pointed readers to where triggered runs are monitored.
- `src/content/docs/agent-platform/cloud-agents/integrations/index.mdx` — Integrations hub that explained setup but never linked to the run-monitoring surface for integration-triggered runs.

### Links added
- `triggers/index.mdx` → `managing-cloud-agents` — Added a sentence after the trigger types list: after a trigger fires, track and review the resulting runs from the Agent Management Panel and Oz web app Runs page. Backed by the "track and observe in real time" and "scheduling and managing across a team" prompts.
- `integrations/index.mdx` → `managing-cloud-agents` — Added a "Managing cloud agents" item to the existing "Get started" list to monitor and review integration-triggered runs. Backed by the "track and observe in real time" and "trigger from Slack, Linear, or GitHub" prompts.

### Reader next step
A reader who just set up a trigger or an integration next wants to know where the resulting runs appear and how to review them across the team. Both pages previously dead-ended without pointing to the canonical monitoring surface; these links complete that workflow.

### Open questions for human review
- Confirm `Managing cloud agents` is the preferred canonical monitoring target over the standalone `Oz web app` page for these hub-page links (the snapshot raises this as an open question). `Managing cloud agents` was chosen because it documents both the Agent Management Panel and the Oz web app Runs page in one place.

### Follow-up (out of scope for this cross-link pilot)
- The Slack and Linear integration pages link "Environment Setup" to the integrations index rather than the dedicated `environments` page. That is an accuracy/link-target fix rather than a cross-link addition, so it was left out of this audit.

_Conversation: https://app.warp.dev/conversation/45f77819-80e6-4961-9d2f-a6ac896d8621_

_Run: https://oz.warp.dev/runs/019ecfa8-b500-75cc-bd31-0056b8abb22a_

_This PR was generated with [Oz](https://warp.dev/oz)._
