### PR TITLE
docs: clarify ChatGPT/Claude subscriptions aren't supported

### DIFF
--- a/src/content/docs/agent-platform/getting-started/faqs.mdx
+++ b/src/content/docs/agent-platform/getting-started/faqs.mdx
@@ -33,7 +33,7 @@ Warp supports [Bring Your Own Key (BYOK)](/agent-platform/inference/bring-your-o
 
 ### Can I use my ChatGPT or Claude subscription with Warp?
 
-No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. This may change in the future.
+No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. Warp is open to supporting them, has raised this with both providers, and will revisit it if that changes.
 
 Note that a ChatGPT or Claude subscription is different from API access. To use your own OpenAI or Anthropic account in Warp, you have two options:
 

--- a/src/content/docs/agent-platform/getting-started/faqs.mdx
+++ b/src/content/docs/agent-platform/getting-started/faqs.mdx
@@ -33,7 +33,7 @@ Warp supports [Bring Your Own Key (BYOK)](/agent-platform/inference/bring-your-o
 
 ### Can I use my ChatGPT or Claude subscription with Warp?
 
-No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. These plans are intended for use in the providers' own apps, so they aren't available for third-party clients like Warp.
+No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. Warp is open to supporting them and will revisit this if that changes.
 
 Note that a ChatGPT or Claude subscription is different from API access. To use your own OpenAI or Anthropic account in Warp, you have two options:
 

--- a/src/content/docs/agent-platform/getting-started/faqs.mdx
+++ b/src/content/docs/agent-platform/getting-started/faqs.mdx
@@ -33,7 +33,7 @@ Warp supports [Bring Your Own Key (BYOK)](/agent-platform/inference/bring-your-o
 
 ### Can I use my ChatGPT or Claude subscription with Warp?
 
-No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. Warp is open to supporting them and will revisit this if that changes.
+No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. This may change in the future.
 
 Note that a ChatGPT or Claude subscription is different from API access. To use your own OpenAI or Anthropic account in Warp, you have two options:
 

--- a/src/content/docs/agent-platform/getting-started/faqs.mdx
+++ b/src/content/docs/agent-platform/getting-started/faqs.mdx
@@ -33,7 +33,7 @@ Warp supports [Bring Your Own Key (BYOK)](/agent-platform/inference/bring-your-o
 
 ### Can I use my ChatGPT or Claude subscription with Warp?
 
-No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp.
+No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. These plans are intended for use in the providers' own apps, so they aren't available for third-party clients like Warp.
 
 Note that a ChatGPT or Claude subscription is different from API access. To use your own OpenAI or Anthropic account in Warp, you have two options:
 

--- a/src/content/docs/agent-platform/getting-started/faqs.mdx
+++ b/src/content/docs/agent-platform/getting-started/faqs.mdx
@@ -33,7 +33,7 @@ Warp supports [Bring Your Own Key (BYOK)](/agent-platform/inference/bring-your-o
 
 ### Can I use my ChatGPT or Claude subscription with Warp?
 
-No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. Warp would love to support this and has raised it with both providers, but it isn't permitted today.
+No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp.
 
 Note that a ChatGPT or Claude subscription is different from API access. To use your own OpenAI or Anthropic account in Warp, you have two options:
 

--- a/src/content/docs/agent-platform/getting-started/faqs.mdx
+++ b/src/content/docs/agent-platform/getting-started/faqs.mdx
@@ -31,6 +31,17 @@ Warp supports a curated list of LLMs from providers like OpenAI, Anthropic, and 
 
 Warp supports [Bring Your Own Key (BYOK)](/agent-platform/inference/bring-your-own-api-key/) for users on paid plans (starting with Build). You can connect your own Anthropic, OpenAI, or Google API keys to route requests directly through your account. Organizations on the Enterprise plan can additionally enable managed "Bring Your Own LLM" configurations to meet strict security or compliance requirements.
 
+### Can I use my ChatGPT or Claude subscription with Warp?
+
+No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. Warp would love to support this and has raised it with both providers, but it isn't permitted today.
+
+Note that a ChatGPT or Claude subscription is different from API access. To use your own OpenAI or Anthropic account in Warp, you have two options:
+
+* **[Bring Your Own API Key (BYOK)](/agent-platform/inference/bring-your-own-api-key/)** — Add your own OpenAI, Anthropic, or Google API key and pay your provider directly instead of using Warp credits.
+* **[Custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/)** — Route Warp through any OpenAI-compatible endpoint, such as OpenRouter or LiteLLM.
+
+For xAI's Grok models, you can connect a [SuperGrok subscription](/agent-platform/inference/grok-subscription/) directly through your xAI account.
+
 ## Billing
 
 Every Warp plan includes a set number of credits per user per month. See [pricing](https://www.warp.dev/pricing) to compare plans.

--- a/src/content/docs/agent-platform/getting-started/faqs.mdx
+++ b/src/content/docs/agent-platform/getting-started/faqs.mdx
@@ -33,7 +33,7 @@ Warp supports [Bring Your Own Key (BYOK)](/agent-platform/inference/bring-your-o
 
 ### Can I use my ChatGPT or Claude subscription with Warp?
 
-No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. Warp is open to supporting them, has raised this with both providers, and will revisit it if that changes.
+No. Warp doesn't support signing in with a ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription to power its agents. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. Warp has raised this with both providers and is open to supporting these subscriptions if that changes.
 
 Note that a ChatGPT or Claude subscription is different from API access. To use your own OpenAI or Anthropic account in Warp, you have two options:
 

--- a/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
+++ b/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
@@ -31,7 +31,7 @@ See [Warp pricing](https://www.warp.dev/pricing) for current plan availability.
 Platform credits apply to every cloud agent run on any plan, and to local agent runs on Business and Enterprise when using BYOK, a custom inference endpoint, or BYOLLM. See [platform credits](/support-and-community/plans-and-billing/platform-credits/) for the full breakdown.
 
 :::note
-**Can I sign in with a ChatGPT or Claude subscription?** No. A ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription can't be connected to Warp the way a [SuperGrok subscription](/agent-platform/inference/grok-subscription/) can. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. To use your own OpenAI or Anthropic account, add an API key with BYOK and pay your provider directly. A subscription and API access are billed separately by the provider.
+**Can I sign in with a ChatGPT or Claude subscription?** No. A ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription can't be connected to Warp the way a [SuperGrok subscription](/agent-platform/inference/grok-subscription/) can. These plans are intended for use in the providers' own apps, so they aren't available for third-party clients like Warp. To use your own OpenAI or Anthropic account, add an API key with BYOK and pay your provider directly. A subscription and API access are billed separately by the provider.
 :::
 
 ## How BYOK works

--- a/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
+++ b/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
@@ -31,7 +31,7 @@ See [Warp pricing](https://www.warp.dev/pricing) for current plan availability.
 Platform credits apply to every cloud agent run on any plan, and to local agent runs on Business and Enterprise when using BYOK, a custom inference endpoint, or BYOLLM. See [platform credits](/support-and-community/plans-and-billing/platform-credits/) for the full breakdown.
 
 :::note
-**Can I sign in with a ChatGPT or Claude subscription?** No. A ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription can't be connected to Warp the way a [SuperGrok subscription](/agent-platform/inference/grok-subscription/) can. These plans are intended for use in the providers' own apps, so they aren't available for third-party clients like Warp. To use your own OpenAI or Anthropic account, add an API key with BYOK and pay your provider directly. A subscription and API access are billed separately by the provider.
+**Can I sign in with a ChatGPT or Claude subscription?** No. A ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription can't be connected to Warp the way a [SuperGrok subscription](/agent-platform/inference/grok-subscription/) can. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. To use your own OpenAI or Anthropic account, add an API key with BYOK and pay your provider directly. A subscription and API access are billed separately by the provider.
 :::
 
 ## How BYOK works

--- a/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
+++ b/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
@@ -30,6 +30,10 @@ See [Warp pricing](https://www.warp.dev/pricing) for current plan availability.
 
 Platform credits apply to every cloud agent run on any plan, and to local agent runs on Business and Enterprise when using BYOK, a custom inference endpoint, or BYOLLM. See [platform credits](/support-and-community/plans-and-billing/platform-credits/) for the full breakdown.
 
+:::note
+**Can I sign in with a ChatGPT or Claude subscription?** No. A ChatGPT (OpenAI) or Claude (Anthropic) consumer subscription can't be connected to Warp the way a [SuperGrok subscription](/agent-platform/inference/grok-subscription/) can. OpenAI and Anthropic don't currently allow their subscription plans to be used in third-party clients like Warp. To use your own OpenAI or Anthropic account, add an API key with BYOK and pay your provider directly. A subscription and API access are billed separately by the provider.
+:::
+
 ## How BYOK works
 
 When you add your own model API keys in Warp, those keys are stored **only on your device** (in your OS keychain or equivalent secure storage), never on Warp's servers. They're used to make requests to your chosen model provider.


### PR DESCRIPTION
## Summary
Adds documentation making clear that **ChatGPT (OpenAI) and Claude (Anthropic) consumer subscriptions can't be used in Warp**, in response to recurring user questions. Contrasts this with the supported [SuperGrok subscription](https://docs.warp.dev/agent-platform/inference/grok-subscription) and points users to BYOK / custom inference endpoints to use their own OpenAI/Anthropic accounts.

## Changes
- **Agent platform FAQs** (`agent-platform/getting-started/faqs.mdx`): New user-voice Q&A "Can I use my ChatGPT or Claude subscription with Warp?" — leads with a direct "No," explains the providers don't currently allow it in third-party clients, and clarifies a subscription is different from API access.
- **Bring Your Own API Key** (`agent-platform/inference/bring-your-own-api-key.mdx`): Added a `:::note` after the comparison table clarifying you can't sign in with a ChatGPT/Claude subscription (unlike SuperGrok), and to use BYOK API keys instead.

## Notes
- Tone is kept neutral and factual: states that OpenAI and Anthropic don't currently allow subscription plans in third-party clients like Warp, and that this may change in the future.
- Validated with `npm run build` (339 pages built successfully).
- No new pages, so no `astro.config.mjs` sidebar or `vercel.json` redirect changes needed.

### Suggested stock answer for socials
> We'd like to support ChatGPT and Claude subscriptions in Warp, but they aren't currently allowed in third-party clients like Warp. In the meantime you can bring your own OpenAI, Anthropic, or Google API key (BYOK), or connect a SuperGrok subscription for Grok.

_Conversation: https://staging.warp.dev/conversation/6e32e81e-c0ab-4991-ba0e-d46cd5670ec8_
_Run: https://oz.staging.warp.dev/runs/019ed12b-bc16-72a7-9d9a-a02bb4befa67_

_This PR was generated with [Oz](https://warp.dev/oz)._
