### PR TITLE
fix: update vite to 7.3.5 to resolve CVE-2026-53571

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9732,9 +9732,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "overrides": {
     "path-to-regexp": "^6.3.0",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "vite": "7.3.5"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",


### PR DESCRIPTION
Pins `vite` to `>=7.3.5` via npm `overrides` to resolve a high-severity vulnerability.

**Vulnerability:** CVE-2026-53571 — `vite`: `server.fs.deny` bypass on Windows alternate paths
**Severity:** High
**Advisory:** https://github.com/vitejs/vite/security/advisories/GHSA-fx2h-pf6j-xcff
**Dependabot alert:** https://github.com/warpdotdev/docs/security/dependabot/23

**What changed:**
- Added `"vite": "7.3.5"` to the `overrides` section in `package.json`
- Updated `package-lock.json` to reflect the pinned version (7.3.2 → 7.3.5)

**Verification:**
- `npm audit` confirms CVE-2026-53571 no longer appears after the update
