### PR TITLE
Fix broken GitHub LICENSE links (master -> main)

### DIFF
--- a/src/content/docs/agent-platform/index.mdx
+++ b/src/content/docs/agent-platform/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 Warp includes **Oz**, the orchestration platform that powers all of Warp's agents. Oz runs interactive agents locally inside Warp for real-time coding assistance and deploys autonomous agents in the cloud for background automation, event-driven workflows, and parallel execution across repos and teams.
 
-Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL), so the editor and terminal that host your agents are fully auditable. See [Contributing to Warp](/support-and-community/community/contributing/) for the source and contribution flow.
+Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL), so the editor and terminal that host your agents are fully auditable. See [Contributing to Warp](/support-and-community/community/contributing/) for the source and contribution flow.
 
 With Oz, you can:
 

--- a/src/content/docs/agent-platform/local-agents/overview.mdx
+++ b/src/content/docs/agent-platform/local-agents/overview.mdx
@@ -18,7 +18,7 @@ Warp's AI features can be globally disabled in **Settings** > **Agents** > **War
 These features send input data to various LLM providers through their API. Warp is **SOC 2 compliant** and has **Zero Data Retention** policies with all contracted LLM providers — no customer AI data is retained, stored, or used for training. Read more about data privacy for Warp features [on our privacy page](https://www.warp.dev/privacy).
 :::
 
-Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp). The agent surface you're reading about is built in the open — see [Contributing to Warp](/support-and-community/community/contributing/) to read the code, file issues, or shape the roadmap.
+Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp). The agent surface you're reading about is built in the open — see [Contributing to Warp](/support-and-community/community/contributing/) to read the code, file issues, or shape the roadmap.
 
 ## What you can do with agents
 

--- a/src/content/docs/enterprise/index.mdx
+++ b/src/content/docs/enterprise/index.mdx
@@ -31,7 +31,7 @@ Warp Enterprise serves three primary audiences:
 ### Security and compliance
 * **SOC 2 Type II certified** - Meets enterprise security and compliance requirements
 * **Zero Data Retention (ZDR)** - No customer data is retained, stored, or used for training by contracted LLM providers
-* **Open source client** - Warp's client code is published under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp) for security review and audit
+* **Open source client** - Warp's client code is published under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp) for security review and audit
 * **Bring Your Own LLM (BYOLLM)** - Route inference through your own cloud infrastructure (AWS Bedrock)
 * **Flexible deployment** - Choose Warp-hosted or hybrid deployment models
 * **Telemetry controls** - Configure what data is collected at the team level

--- a/src/content/docs/enterprise/security-and-compliance/security-overview.mdx
+++ b/src/content/docs/enterprise/security-and-compliance/security-overview.mdx
@@ -16,7 +16,7 @@ Warp's security philosophy centers on **transparency and developer control**:
 * **Real-time monitoring** - Use Warp's [Network Log](/support-and-community/privacy-and-security/network-log/) to monitor all network requests in real time
 * **Opt-out controls** - Disable telemetry and crash reporting at any time while retaining full functionality
 * **Team-level enforcement** - Admins can configure telemetry and data collection policies for the entire organization
-* **Open source client** - Warp's client code is published under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), so security teams can audit the codebase directly. See [Contributing to Warp](/support-and-community/community/contributing/) for the source repository and the security reporting process.
+* **Open source client** - Warp's client code is published under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), so security teams can audit the codebase directly. See [Contributing to Warp](/support-and-community/community/contributing/) for the source repository and the security reporting process.
 
 ## What telemetry does Warp collect and why?
 

--- a/src/content/docs/getting-started/quickstart/customizing-warp.mdx
+++ b/src/content/docs/getting-started/quickstart/customizing-warp.mdx
@@ -7,7 +7,7 @@ description: >-
 
 Warp is deeply customizable. Whether you use Warp primarily as a modern terminal or as an AI-powered development environment, you can tailor the experience to fit how you work. Configure the terminal side (themes, keybindings, vertical tabs, tab configs) and the AI side (model choice, agent autonomy, default mode) independently.
 
-Use the quick-reference table to find what you need, or browse the sections below for more details. If you want to go further than configuration, Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL) — see [Contributing to Warp](/support-and-community/community/contributing/) to build a custom variant or contribute changes upstream.
+Use the quick-reference table to find what you need, or browse the sections below for more details. If you want to go further than configuration, Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL) — see [Contributing to Warp](/support-and-community/community/contributing/) to build a custom variant or contribute changes upstream.
 
 ## Quick reference
 

--- a/src/content/docs/getting-started/quickstart/installation-and-setup.mdx
+++ b/src/content/docs/getting-started/quickstart/installation-and-setup.mdx
@@ -174,7 +174,7 @@ Want to try our newest features? [Warp Preview](/support-and-community/community
 
 ## Build from source
 
-Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL), so you can build it yourself from [`warpdotdev/warp`](https://github.com/warpdotdev/warp).
+Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL), so you can build it yourself from [`warpdotdev/warp`](https://github.com/warpdotdev/warp).
 
 Clone the repo, bootstrap toolchain dependencies, and start a development build:
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -85,7 +85,7 @@ Oz is multi-model by design. You can [choose your preferred LLM](/agent-platform
 
 ## Open source
 
-Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL). The source lives at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), where you can read the code, file issues, and contribute alongside the Warp team. Development happens in the open with an agent-first workflow managed by Oz.
+Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL). The source lives at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), where you can read the code, file issues, and contribute alongside the Warp team. Development happens in the open with an agent-first workflow managed by Oz.
 
 → [Contributing to Warp](/support-and-community/community/contributing/) explains how to file issues, claim work, and ship code or themes.
 

--- a/src/content/docs/support-and-community/community/contributing.mdx
+++ b/src/content/docs/support-and-community/community/contributing.mdx
@@ -10,7 +10,7 @@ Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/
 ## Ways you can contribute
 
 * **Report a bug or request a feature** - [File an issue](https://github.com/warpdotdev/warp/issues/new/choose) in [`warpdotdev/warp`](https://github.com/warpdotdev/warp), or [explore existing issues](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) to comment on or upvote ones that matter to you. Clear reproductions and upvotes help Warp prioritize.
-* **Contribute code** - Claim any issue labeled `ready-to-spec` or `ready-to-implement`, then open a spec or code PR. [`CONTRIBUTING.md`](https://github.com/warpdotdev/warp/blob/master/CONTRIBUTING.md) covers the spec format, tests, `./script/presubmit`, and the PR template.
+* **Contribute code** - Claim any issue labeled `ready-to-spec` or `ready-to-implement`, then open a spec or code PR. [`CONTRIBUTING.md`](https://github.com/warpdotdev/warp/blob/main/CONTRIBUTING.md) covers the spec format, tests, `./script/presubmit`, and the PR template.
 * **Build a theme** - Submit a new color scheme or improve an existing one at [`warpdotdev/themes`](https://github.com/warpdotdev/themes).
 * **Share a workflow** - Add reusable command patterns to [`warpdotdev/workflows`](https://github.com/warpdotdev/workflows). Merged workflows ship to every Warp user.
 * **Publish Warp Drive objects** - Share Workflows, Notebooks, Rules, and Prompts publicly from [Warp Drive](/knowledge-and-collaboration/warp-drive/).
@@ -35,8 +35,8 @@ For logs, crash reports, CPU samples, and AI conversation IDs, see [Sending feed
 Do not file public issues for security vulnerabilities.
 :::
 
-Email [security@warp.dev](mailto:security@warp.dev) with reproduction steps, impact, and any proof of concept. We'll acknowledge receipt and coordinate a fix and disclosure. Full guidance is in [`CONTRIBUTING.md`](https://github.com/warpdotdev/warp/blob/master/CONTRIBUTING.md#reporting-security-issues).
+Email [security@warp.dev](mailto:security@warp.dev) with reproduction steps, impact, and any proof of concept. We'll acknowledge receipt and coordinate a fix and disclosure. Full guidance is in [`CONTRIBUTING.md`](https://github.com/warpdotdev/warp/blob/main/CONTRIBUTING.md#reporting-security-issues).
 
 ## Code of conduct
 
-Warp's open source repositories follow the [Contributor Covenant](https://www.contributor-covenant.org/) v2.1. Read the [full text](https://github.com/warpdotdev/warp/blob/master/CODE_OF_CONDUCT.md), or report violations to [warp-coc@warp.dev](mailto:warp-coc@warp.dev).
+Warp's open source repositories follow the [Contributor Covenant](https://www.contributor-covenant.org/) v2.1. Read the [full text](https://github.com/warpdotdev/warp/blob/main/CODE_OF_CONDUCT.md), or report violations to [warp-coc@warp.dev](mailto:warp-coc@warp.dev).

--- a/src/content/docs/support-and-community/community/contributing.mdx
+++ b/src/content/docs/support-and-community/community/contributing.mdx
@@ -5,7 +5,7 @@ description: >-
   requests, building themes, and sharing workflows.
 ---
 
-Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), and there's room for every kind of contribution — from a one-line bug report to a full feature PR, a new theme, or a workflow that ships to every Warp user. For the full code contribution flow, see [`CONTRIBUTING.md`](https://github.com/warpdotdev/warp/blob/master/CONTRIBUTING.md).
+Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), and there's room for every kind of contribution — from a one-line bug report to a full feature PR, a new theme, or a workflow that ships to every Warp user. For the full code contribution flow, see [`CONTRIBUTING.md`](https://github.com/warpdotdev/warp/blob/main/CONTRIBUTING.md).
 
 ## Ways you can contribute
 

--- a/src/content/docs/support-and-community/community/contributing.mdx
+++ b/src/content/docs/support-and-community/community/contributing.mdx
@@ -5,7 +5,7 @@ description: >-
   requests, building themes, and sharing workflows.
 ---
 
-Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), and there's room for every kind of contribution — from a one-line bug report to a full feature PR, a new theme, or a workflow that ships to every Warp user. For the full code contribution flow, see [`CONTRIBUTING.md`](https://github.com/warpdotdev/warp/blob/master/CONTRIBUTING.md).
+Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), and there's room for every kind of contribution — from a one-line bug report to a full feature PR, a new theme, or a workflow that ships to every Warp user. For the full code contribution flow, see [`CONTRIBUTING.md`](https://github.com/warpdotdev/warp/blob/master/CONTRIBUTING.md).
 
 ## Ways you can contribute
 

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -230,7 +230,7 @@ Warp doesn’t currently offer discounts for students or non-profits. We recomme
 For open source teams, two paths are available:
 
 * The [Oz Open Source Partnership](/support-and-community/community/open-source-partnership/) program offers free agent credits to high-impact open source projects.
-* Warp's client itself is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL), so you can build, run, and contribute to it directly. See [Contributing to Warp](/support-and-community/community/contributing/) for the flow.
+* Warp's client itself is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL), so you can build, run, and contribute to it directly. See [Contributing to Warp](/support-and-community/community/contributing/) for the flow.
 
 ### Where is Warp Drive data for my team stored?
 

--- a/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
+++ b/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
@@ -17,7 +17,7 @@ Our philosophy is complete transparency and control over any data leaving your m
 * Read a complete list of [all the telemetry events](/support-and-community/privacy-and-security/privacy/#exhaustive-telemetry-table) that get sent for app analytics
 * Monitor telemetry in real-time with Warp's native [Network Log](/support-and-community/privacy-and-security/network-log/)
 * [Opt out](/support-and-community/privacy-and-security/privacy/#how-to-disable-telemetry-and-crash-reporting) of telemetry at any time
-* Read and audit Warp's client source code at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL)
+* Read and audit Warp's client source code at [`warpdotdev/warp`](https://github.com/warpdotdev/warp), open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/main/LICENSE-AGPL)
 
 ## What telemetry data does Warp collect and why?
 


### PR DESCRIPTION
## Summary
Fixes broken GitHub LICENSE links found by the broken-link checker. The `warpdotdev/warp` repo's default branch is `main`, not `master`, so links to `https://github.com/warpdotdev/warp/blob/master/LICENSE` returned **HTTP 404**.

Updated all 10 occurrences to use the `main` branch.

## Verification
- `https://github.com/warpdotdev/warp/blob/master/LICENSE` → HTTP 404
- `https://github.com/warpdotdev/warp/blob/main/LICENSE` → HTTP 200

## Files changed (10)
- `src/content/docs/index.mdx`
- `src/content/docs/agent-platform/index.mdx`
- `src/content/docs/agent-platform/local-agents/overview.mdx`
- `src/content/docs/enterprise/index.mdx`
- `src/content/docs/enterprise/security-and-compliance/security-overview.mdx`
- `src/content/docs/getting-started/quickstart/customizing-warp.mdx`
- `src/content/docs/getting-started/quickstart/installation-and-setup.mdx`
- `src/content/docs/support-and-community/community/contributing.mdx`
- `src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx`
- `src/content/docs/support-and-community/privacy-and-security/privacy.mdx`

## Notes
Other checker hits were false positives: docs.warp.dev links returned HTTP 429 (rate limiting from running many requests), and `help.openai.com` (403) / `tiktok.com/@warp.dev` (403) are bot-blocking — the TikTok link returns 200 with a browser user-agent.

_Conversation: https://app.warp.dev/conversation/f4e02269-22d2-4e0b-b0d9-c9683702d4e6_
_Run: https://oz.warp.dev/runs/019eeb20-018c-7ac8-8afe-b4e70c5980b8_

_This PR was generated with [Oz](https://warp.dev/oz)._
