### PR TITLE
docs: add AEO cross-links for agents and orchestration

### DIFF
--- a/src/content/docs/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-analyze-pr-modify-ui.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-analyze-pr-modify-ui.mdx
@@ -67,7 +67,7 @@ In the demo, we run three parallel workflows:
 2. #### Monitor all agents
 
    The **task pane** in Warp shows all running agents.\
-   You can view plans, progress, and results live without interrupting other tasks.
+   You can view plans, progress, and results live without interrupting other tasks. To track these runs across your account and team in real time, including cloud agent runs, open the [Agent Management Panel](/agent-platform/cloud-agents/managing-cloud-agents/) in the Warp app.
 
 3. #### Review results
 
@@ -88,3 +88,8 @@ In the demo, we run three parallel workflows:
    :::
 
 </Steps>
+
+### Next steps
+
+* [How to run multiple AI coding agents](/guides/agent-workflows/how-to-run-multiple-ai-coding-agents/) - Decompose tasks, assign Git worktrees, validate output, and hand off branches or PRs for review.
+* [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/) - Fan parallel work out to cloud child agents when a task is too large or slow to run locally.


### PR DESCRIPTION
## AEO cross-link audit

Small, high-confidence internal cross-linking improvements for the agents, cloud agents, and orchestration docs, scoped to the AEO cross-link audit pilot.

### Goal
Identify small internal cross-link improvements for agents, cloud agents, and orchestration docs — no new pages, no rewrites, no keyword stuffing.

### Source signals
- **Peec snapshot** (`buzz/aeo-snapshots/docs/agents-orchestration`, generated 2026-06-04, 18 days old — older than the 14-day freshness window, noted here for reviewers). High-volume prompts driving these links:
  - "how do development teams track and observe what their AI coding agents are doing in real time?" (real-time monitoring/observability)
  - "what are the best tools for managing multiple AI coding agents?" (orchestration / managing multiple agents)
- Snapshot open question: "Which docs page should be the canonical target for monitoring and reviewing cloud agent runs?" → `managing-cloud-agents`.
- **Google Search Console**: unavailable in this environment (no credentials), so links are Peec- and repo-grounded only.
- **Existing-docs signal**: the sibling guide `running-multiple-agents-at-once-with-warp.mdx` already links its monitoring step to the Agent Management Panel and points to the canonical multi-agent guide; this PR brings the same reader journey to a guide that was missing it.

### Pages touched
- `src/content/docs/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-analyze-pr-modify-ui.mdx` — this guide previously had **zero** internal links despite being entirely about running and monitoring multiple agents in parallel. It was the clearest cross-link gap in the topic area; the rest of the agents/cloud-agents/orchestration set is already densely and well cross-linked.

### Links added
- **Monitoring step → [Managing cloud agents](/agent-platform/cloud-agents/managing-cloud-agents/)**: the "Monitor all agents" step describes watching running agents but pointed nowhere. Backed by the real-time monitoring Peec signal and the snapshot's canonical-monitoring-page open question.
- **Next steps → [How to run multiple AI coding agents](/guides/agent-workflows/how-to-run-multiple-ai-coding-agents/)**: the canonical workflow guide (task decomposition, worktrees, validation, handoff) is the natural deepening step after this demo-style page. Backed by the "best tools for managing multiple AI coding agents" Peec signal.
- **Next steps → [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/)**: distinct next step for scaling parallel work to cloud child agents when a task is too large or slow to run locally. Same Peec signal.

### Reader next step
A reader on this demo page is learning to run several agents at once. After it, they most likely want to (1) monitor those runs in one place, (2) learn a repeatable multi-agent workflow with worktrees and review handoff, and (3) scale to cloud orchestration. Each link maps to one of those journeys. The page had no links before, so the three additions stay within link-density limits and each supports a distinct next step.

### Open questions for human review
- The "Next steps" section is new, but it matches the established pattern used by every other guide in `guides/agent-workflows/`. Confirm placement after `</Steps>` reads well.
- Follow-up (out of scope for this cross-link pilot): the Slack and Linear integration pages link the phrase "Environment Setup" to the integrations index (`/agent-platform/cloud-agents/integrations/`) rather than the dedicated `environments` page — worth revisiting as a link-correction pass.

### Quality gates
- `style_lint --changed`: 1 file scanned, 0 issues.
- `check_for_broken_links --internal-only`: 0 broken links (2966 internal links checked).
- `git diff --check`: clean.

_Conversation: https://app.warp.dev/conversation/f0a67a9e-e5d0-40e5-8c44-4d8d7c4fb73f_
_Run: https://oz.warp.dev/runs/019eefd8-728f-7628-943f-fabc2f71804c_

_This PR was generated with [Oz](https://warp.dev/oz)._
