### PR TITLE
docs: add GLM 5.2 to model-choice page

### DIFF
--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -106,6 +106,7 @@ Warp also supports leading open source models hosted via Fireworks AI, so you ca
 
 | Model | `model_id` |
 | --- | --- |
+| GLM 5.2 | `glm-5.2-fireworks` |
 | GLM 5.1 | `glm-5.1-fireworks` |
 | Kimi K2.5 | `kimi-k25-fireworks` |
 | Kimi K2.6 | `kimi-k26-fireworks` |


### PR DESCRIPTION
## Summary
Audited whether GLM 5.2 is documented. It is **supported and live in production** (`fireworks_glm_52` is `true` in both prod and staging; public `model_id` `glm-5.2-fireworks`, display name "GLM 5.2", present in `ConfigurableLlmIds`/`FireworksModelIds`), but the public **Agent model choice** page (`agent-platform/inference/model-choice.mdx`) only listed GLM 5.1. This closes that gap.

## What changed
- Added a **GLM 5.2** row (`glm-5.2-fireworks`) to the "Hosted models (via Fireworks AI)" table, above the existing GLM 5.1 row.

## Validation
- `npm run build` completes successfully (339 pages built).
- Confirmed GLM 5.2 renders in the built page and in the generated `model-choice.md`, `llms-full.txt`, and `llms-small.txt` outputs.

## Scope
Docs repo only — no changes to `warp-server` or the client. Stacked on top of #246 (both edit `model-choice.mdx`); base will retarget to `main` once #246 merges.

_Conversation: https://staging.warp.dev/conversation/57949194-2610-4cc3-967c-e90056a75c5b_
_Run: https://oz.staging.warp.dev/runs/019ef30f-374e-776a-a3bb-09222fddc119_

_This PR was generated with [Oz](https://warp.dev/oz)._
