### PR TITLE
feat: serve public OpenAPI JSON and add SSR endpoint content to /api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ dist/
 .vercel/
 # generated types
 .astro/
+# generated from developers/agent-api-openapi.yaml via scripts/generate-openapi-json.mjs
+public/openapi.json
 
 # dependencies
 node_modules/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",
+    "predev": "node scripts/generate-openapi-json.mjs",
     "build": "astro build",
+    "prebuild": "node scripts/generate-openapi-json.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "typecheck": "astro check",

--- a/scripts/generate-openapi-json.mjs
+++ b/scripts/generate-openapi-json.mjs
@@ -1,0 +1,23 @@
+/**
+ * Generates public/openapi.json from developers/agent-api-openapi.yaml.
+ *
+ * Run automatically via the `prebuild` / `predev` npm scripts.
+ * Also runnable directly: node scripts/generate-openapi-json.mjs
+ *
+ * The JSON copy in public/ is what gets served at docs.warp.dev/openapi.json.
+ * The YAML source is the source of truth — update that file when the API changes
+ * and this script picks it up at the next build.
+ */
+
+import fs from 'node:fs';
+import { parse } from 'yaml';
+
+const src = 'developers/agent-api-openapi.yaml';
+const dst = 'public/openapi.json';
+
+const yaml = fs.readFileSync(src, 'utf-8');
+const obj = parse(yaml);
+fs.writeFileSync(dst, JSON.stringify(obj, null, 2));
+
+const bytes = fs.statSync(dst).size;
+console.log(`Generated ${dst} (${(bytes / 1024).toFixed(1)} KB) from ${src}`);

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -16,6 +16,18 @@ import WarpTopbar from '../components/WarpTopbar.astro';
 const yamlContent = fs.readFileSync('developers/agent-api-openapi.yaml', 'utf-8');
 const specObject = parse(yamlContent);
 const specJson = JSON.stringify(specObject);
+
+// Pre-typed data for the server-rendered endpoint index.
+// Typed here in the frontmatter so the JSX below stays clean.
+type OpInfo = {
+  summary?: string;
+  description?: string;
+  parameters?: Array<{ name: string; in: string; description?: string; required?: boolean }>;
+};
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace']);
+const specPaths = (specObject.paths ?? {}) as Record<string, Record<string, OpInfo>>;
+const specInfo = specObject.info as { title?: string; description?: string } | undefined;
+const specBaseUrl = (specObject.servers as Array<{ url?: string }> | undefined)?.[0]?.url;
 ---
 
 <!doctype html>
@@ -185,6 +197,37 @@ const specJson = JSON.stringify(specObject);
     </script>
     <WarpTopbar crumb="API Reference" />
     <h1 class="api-visually-hidden">Warp & Oz HTTP API reference</h1>
+    <!--
+      Server-rendered API index for crawlers and agents that don't execute JS.
+      Scalar (below) provides the interactive experience for browser users.
+      This section is visually hidden but fully in the DOM and accessible to
+      any HTTP client that reads HTML — including AI crawlers, scanners and agents.
+    -->
+    <section aria-label="Oz Agent API endpoint index" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;">
+      <h1>{specInfo?.title}</h1>
+      <p>{specInfo?.description}</p>
+      <p>Base URL: {specBaseUrl}</p>
+      <p>Authentication: Bearer token (Warp API key). Obtain from account settings. Pass as Authorization: Bearer YOUR_API_KEY.</p>
+      <p>Full machine-readable spec: <a href="/openapi.json">openapi.json</a></p>
+      {Object.entries(specPaths).map(([endpointPath, methods]) => (
+        <article>
+          {Object.entries(methods).filter(([method]) => HTTP_METHODS.has(method)).map(([method, op]) => (
+            <section>
+              <h2>{method.toUpperCase()} {endpointPath}</h2>
+              {op.summary && <p>{op.summary}</p>}
+              {op.description && <p>{op.description}</p>}
+              {op.parameters && op.parameters.length > 0 && (
+                <ul>
+                  {op.parameters.map((p) => (
+                    <li><strong>{p.name}</strong> ({p.in}{p.required ? ', required' : ''}){p.description ? ': ' + p.description : ''}</li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          ))}
+        </article>
+      ))}
+    </section>
     <script
       is:inline
       id="api-reference"


### PR DESCRIPTION
## What

Improves agent discoverability of the Oz Agent API as part of AEO work. Part of a broader effort to improve warp.dev's ora.ai agent-readiness score.

## Changes

- `scripts/generate-openapi-json.mjs` — new script converting `developers/agent-api-openapi.yaml` → `public/openapi.json` at build time
- `package.json` — adds `prebuild` and `predev` lifecycle scripts so the JSON is always regenerated before any build or dev run
- `.gitignore` — adds `public/openapi.json` as a gitignored generated artifact
- `src/pages/api.astro` — adds a visually-hidden server-rendered section listing all API endpoints with summaries, descriptions, and parameters. Scalar stays for browser users; this makes the API readable to crawlers and AI agents that don't execute JS.

## Why

The ora.ai scanner (`openapi-spec` and `public-api` checks, 7 pts each) couldn't find the spec because the `/api` page is fully JS-rendered and no raw spec was at a standard path. After this PR, `docs.warp.dev/openapi.json` serves the machine-readable spec and `/api` has server-rendered HTML content.

A companion PR on the marketing site will redirect `warp.dev/openapi.json` → `docs.warp.dev/openapi.json`.

## Spec sync

The YAML source is managed by the `sync-openapi-spec` Oz skill (warp-server → docs). The JSON is regenerated from the YAML via `prebuild` automatically on every deploy.

Co-Authored-By: Oz <oz-agent@warp.dev>