### PR TITLE
docs: document Rudderstack env vars in .env.example and fix misleading 404.astro comment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,16 @@
 # If unset, the Ask AI button is hidden and the site still runs normally.
 # Get yours at: https://app.kapa.ai/admin
 PUBLIC_KAPA_INTEGRATION_ID=
+
+# RudderStack analytics — required for docs_404 event tracking and page analytics.
+# Without these, no analytics events are sent and the weekly 404 monitor will
+# report zero data. Set both in the Vercel project environment (all environments).
+#
+# PUBLIC_RUDDERSTACK_WRITE_KEY: Source write key from the RudderStack dashboard
+#   (Sources → your docs source → Write Key).
+# PUBLIC_RUDDERSTACK_DATA_PLANE_URL: Data plane endpoint. Currently proxied
+#   through https://app.warp.dev — do NOT change to a direct
+#   *.dataplane.rudderstack.com URL without also updating the connect-src
+#   directive in vercel.json (a mismatch silently blocks all events in the browser).
+PUBLIC_RUDDERSTACK_WRITE_KEY=
+PUBLIC_RUDDERSTACK_DATA_PLANE_URL=

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -47,10 +47,13 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		var brokenUrl = window.location.origin + window.location.pathname;
 		var referrer = document.referrer ? new URL(document.referrer).origin : '';
 
-		// rudderanalytics is guaranteed to be a queue array at this point
-		// (the stub in RudderStackAnalytics.astro sets it up before this runs).
-		// Calling .track() on the queue simply pushes the call; once the real
-		// SDK loads it replays the queue automatically.
+		// If PUBLIC_RUDDERSTACK_WRITE_KEY and PUBLIC_RUDDERSTACK_DATA_PLANE_URL are
+		// set, RudderStackAnalytics.astro (loaded via CustomHead.astro in <head>)
+		// stubs window.rudderanalytics as a queue array before this script runs.
+		// Calling .track() on the queue pushes the call; once the real SDK loads it
+		// replays the queue automatically. If either env var is missing, the stub is
+		// not emitted and window.rudderanalytics is undefined — the guard below
+		// prevents a runtime error in that case.
 		if (window.rudderanalytics) {
 			window.rudderanalytics.track('docs_404', {
 				broken_url: brokenUrl,


### PR DESCRIPTION
## What

Documents the two RudderStack env vars in `.env.example` and fixes a misleading comment in `src/pages/404.astro`.

## Why

**Note: the original PR description incorrectly claimed these missing env vars caused zero `docs_404` data. They are in fact set in Vercel. The actual root cause was the dbt `stg_website_events` model not ingesting track events from the docs site's RudderStack source — fixed separately in [warpdotdev/dbt#1087](https://github.com/warpdotdev/dbt/pull/1087).**

That said, the changes here are still worth merging:

- `PUBLIC_RUDDERSTACK_WRITE_KEY` and `PUBLIC_RUDDERSTACK_DATA_PLANE_URL` were genuinely absent from `.env.example`, so anyone setting up or re-deploying the project from scratch has no documentation that these vars exist or what they're for.
- The `404.astro` comment that called `window.rudderanalytics` "guaranteed" to be a queue array was genuinely misleading — it's only present when both env vars are configured.

## Changes

- **`.env.example`** — adds both Rudderstack vars with inline documentation: what they are, where to get the write key, and the CSP constraint (do not swap to a direct `*.dataplane.rudderstack.com` URL without updating `vercel.json`).
- **`src/pages/404.astro`** — corrects the misleading comment.

_Conversation: https://staging.warp.dev/conversation/d0dc60f6-6efe-42a2-9743-991705736302_
_Run: https://oz.staging.warp.dev/runs/019ef046-6ad3-71a1-b7f9-003f6badf967_

_This PR was generated with [Oz](https://warp.dev/oz)._
