### PR TITLE
fix: update tar to 7.5.16 to resolve CVE-2026-53655

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9079,9 +9079,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "overrides": {
     "path-to-regexp": "^6.3.0",
     "esbuild": "^0.28.1",
-    "vite": "7.3.5"
+    "vite": "7.3.5",
+    "tar": "^7.5.16"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",


### PR DESCRIPTION
Pins `tar` to `>=7.5.16` via an npm override to resolve CVE-2026-53655.

## Advisory
- **CVE**: CVE-2026-53655
- **Advisory**: https://github.com/advisories/GHSA-vmf3-w455-68vh
- **Dependabot alert**: https://github.com/warpdotdev/docs/security/dependabot/25

## What changed
Added `"tar": "^7.5.16"` to the `overrides` field in `package.json`. This forces npm to resolve all transitive `tar` dependencies to >=7.5.16, which contains the fix for the PAX size override file-smuggling vulnerability.

The `tar` package (7.5.11 → 7.5.16) is a transitive dependency pulled in by `@mapbox/node-pre-gyp` (via `sharp`).

## Verification
`npm audit` no longer flags `tar` after applying the override and running `npm install`.
