### PR TITLE
afdocs: fix llms.txt directive on /api and document known exceptions

### DIFF
--- a/.agents/skills/afdocs-audit/references/known-exceptions.md
+++ b/.agents/skills/afdocs-audit/references/known-exceptions.md
@@ -34,11 +34,22 @@ This file lists checks from the afdocs-audit skill that may flag as warnings or 
 - `/guides/getting-started/10-coding-features-you-should-know/` — numbered feature headings
 **Action**: No fix needed. Content is intact.
 
+## llms-txt-links-markdown
+
+**Expected status**: fail
+**Reason**: False positive. The llms.txt file links to `openapi.yaml` and `openapi.json` (the Oz Agent API OpenAPI spec) in its Optional section. The `afdocs` checker classifies YAML/JSON files as "non-markdown" (the same bucket as HTML pages) and looks for `.md` variants that don't exist and shouldn't. Machine-readable spec files have no markdown equivalent by design.
+**Affected links** (2 of 14 in llms.txt):
+- `https://docs.warp.dev/openapi.yaml`
+- `https://docs.warp.dev/openapi.json`
+**Action**: No fix needed. The OpenAPI specs are intentionally YAML/JSON and don't need markdown variants.
+
 ## page-size-markdown / page-size-html
 
 **Expected status**: pass (after changelog split)
-**Reason**: The changelog was split into yearly pages in May 2026, resolving the page-size issue. No pages should flag this check now.
-**Action**: If any page is flagged, treat it as a genuine issue that may need splitting.
+**Reason**: The changelog was split into yearly pages in May 2026, resolving the page-size issue. The one page that may appear in this check is `all-settings.mdx` (50,088 markdown chars — 88 chars over the 50K warn threshold). This is the comprehensive settings reference page; splitting it would harm usability for a trivial overage.
+**Affected pages** (as of 2026-06-24):
+- `/terminal/settings/all-settings/` — settings reference (50,088 md chars, borderline warn)
+**Action**: Monitor. If it grows substantially past 50K, consider splitting by TOML section. For now, accept as a platform limitation of having a comprehensive reference page.
 
 ## section-header-quality
 

--- a/.agents/skills/afdocs-audit/references/known-exceptions.md
+++ b/.agents/skills/afdocs-audit/references/known-exceptions.md
@@ -45,11 +45,11 @@ This file lists checks from the afdocs-audit skill that may flag as warnings or 
 
 ## page-size-markdown / page-size-html
 
-**Expected status**: pass (after changelog split)
-**Reason**: The changelog was split into yearly pages in May 2026, resolving the page-size issue. The one page that may appear in this check is `all-settings.mdx` (50,088 markdown chars — 88 chars over the 50K warn threshold). This is the comprehensive settings reference page; splitting it would harm usability for a trivial overage.
+**Expected status**: pass for page-size-markdown; warn for page-size-html (`all-settings.mdx` only)
+**Reason**: The changelog was split into yearly pages in May 2026, resolving the markdown page-size issue. `all-settings.mdx` may still appear in `page-size-html` at 50,088 markdown chars — 88 chars over the 50K warn threshold. This is the comprehensive settings reference page; splitting it would harm usability for a trivial overage.
 **Affected pages** (as of 2026-06-24):
 - `/terminal/settings/all-settings/` — settings reference (50,088 md chars, borderline warn)
-**Action**: Monitor. If it grows substantially past 50K, consider splitting by TOML section. For now, accept as a platform limitation of having a comprehensive reference page.
+**Action**: Monitor. If it grows substantially past 50K, consider splitting by TOML section. For now, accept as a known exception for the borderline HTML page-size warning.
 
 ## section-header-quality
 

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -197,7 +197,7 @@ const specBaseUrl = (specObject.servers as Array<{ url?: string }> | undefined)?
     </script>
     <WarpTopbar crumb="API Reference" />
     <!-- llms.txt directive: machine-readable signal for agents and AI tools. -->
-    <span class="api-visually-hidden">For the complete documentation in markdown, see <a href="/llms.txt">llms.txt</a>.</span>
+    <span class="api-visually-hidden" aria-hidden="true">For the complete documentation in markdown, see <a href="/llms.txt" tabindex="-1">llms.txt</a>.</span>
     <h1 class="api-visually-hidden">Warp & Oz HTTP API reference</h1>
     <!--
       Server-rendered API index for crawlers and agents that don't execute JS.

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -196,6 +196,8 @@ const specBaseUrl = (specObject.servers as Array<{ url?: string }> | undefined)?
       })();
     </script>
     <WarpTopbar crumb="API Reference" />
+    <!-- llms.txt directive: machine-readable signal for agents and AI tools. -->
+    <span class="api-visually-hidden">For the complete documentation in markdown, see <a href="/llms.txt">llms.txt</a>.</span>
     <h1 class="api-visually-hidden">Warp & Oz HTTP API reference</h1>
     <!--
       Server-rendered API index for crawlers and agents that don't execute JS.


### PR DESCRIPTION
## Summary

Follow-up to the June 2026 AFDocs audit work. Now that `docs.warp.dev` is accessible to the afdocs crawler (Bot Protection switched to Log mode), we ran the first valid audit and got **79/100 (C+)**. This PR addresses the actionable findings.

## Changes

### `src/pages/api.astro`
- Added a visually-hidden `llms.txt` directive link. The `/api` page (Scalar API reference) uses a custom layout that doesn't include Starlight's `CustomHeader.astro`, so it was missing the in-page llms.txt signal that the AFDocs audit checks for.

### `.agents/skills/afdocs-audit/references/known-exceptions.md`
- Added `llms-txt-links-markdown` as an allowlisted false positive: the afdocs checker misclassifies `openapi.yaml` and `openapi.json` as "HTML links" that need `.md` variants. They're machine-readable spec files — no markdown equivalent needed.
- Updated `page-size-html`: `all-settings.mdx` renders to 50,088 markdown chars, just 88 chars over the 50K warn threshold. Too small an overage to justify splitting a comprehensive reference page.

## Audit results (before → after)

| Check | Before | After |
|---|---|---|
| `llms-txt-directive-html` | WARN (1/50 pages missing) | Fixed (directive added to `/api`) |
| `llms-txt-links-markdown` | FAIL | Allowlisted (false positive) |
| `page-size-html` | WARN | Allowlisted (88 chars over threshold) |
| `content-negotiation` | FAIL | Existing known exception (Vercel static hosting limitation) |

Overall score remains 79/100 — the remaining 3 failures are all documented platform limitations.

Co-Authored-By: Oz <oz-agent@warp.dev>
