### PR TITLE
fix(redirects): add missing redirects for top broken URLs (BYOK, /help/updating-warp, /help/licenses)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9839,6 +9839,31 @@
       "source": "/guides/developer-workflows/devops/:slug*",
       "destination": "/guides/devops/:slug*/",
       "statusCode": 308
+    },
+    {
+      "source": "/support-and-community/plans-and-billing/bring-your-own-api-key/",
+      "destination": "/agent-platform/inference/bring-your-own-api-key/",
+      "statusCode": 308
+    },
+    {
+      "source": "/help/updating-warp",
+      "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
+      "statusCode": 308
+    },
+    {
+      "source": "/help/updating-warp/",
+      "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
+      "statusCode": 308
+    },
+    {
+      "source": "/help/licenses",
+      "destination": "/support-and-community/community/open-source-licenses/",
+      "statusCode": 308
+    },
+    {
+      "source": "/help/licenses/",
+      "destination": "/support-and-community/community/open-source-licenses/",
+      "statusCode": 308
     }
   ]
 }


### PR DESCRIPTION
## What

Adds 5 missing redirect entries to `vercel.json` for the top broken URLs surfaced by the weekly 404 monitor.

## Why

These paths have been generating 404s for real visitors. The weekly 404 monitor (warpdotdev/docs `.agents/skills/weekly-404-monitor`) confirmed 130 hits across these three broken URL patterns in the past week.

| Broken URL | Hits/week | Root cause |
|---|---|---|
| `/support-and-community/plans-and-billing/bring-your-own-api-key/` | 104 | Trailing-slash case not covered by existing `:path*` wildcard entry |
| `/help/updating-warp` and `/help/updating-warp/` | 21 | `/help/*` short paths covered for other pages (known-issues, licenses, etc.) but not this one |
| `/help/licenses` and `/help/licenses/` | 5 | Same `/help/*` gap pattern |

## Redirects added

- `/support-and-community/plans-and-billing/bring-your-own-api-key/` → `/agent-platform/inference/bring-your-own-api-key/`
- `/help/updating-warp` → `/support-and-community/troubleshooting-and-support/updating-warp/`
- `/help/updating-warp/` → `/support-and-community/troubleshooting-and-support/updating-warp/`
- `/help/licenses` → `/support-and-community/community/open-source-licenses/`
- `/help/licenses/` → `/support-and-community/community/open-source-licenses/`

All destinations are confirmed live pages in the current docs.

_Conversation: https://staging.warp.dev/conversation/d0dc60f6-6efe-42a2-9743-991705736302_
_Run: https://oz.staging.warp.dev/runs/019ef046-6ad3-71a1-b7f9-003f6badf967_

_This PR was generated with [Oz](https://warp.dev/oz)._
