### PR TITLE
Add missing public models to Model choice

### DIFF
--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -88,6 +88,7 @@ Anthropic requires data retention for Claude Fable 5 for safety, abuse monitorin
 | Model | `model_id` |
 | --- | --- |
 | Gemini 3.1 Pro | `gemini-3.1-pro` |
+| Gemini 3.5 Flash | `gemini-3.5-flash` |
 
 #### xAI
 
@@ -108,10 +109,13 @@ Warp also supports leading open source models hosted via Fireworks AI, so you ca
 | --- | --- |
 | GLM 5.2 | `glm-5.2-fireworks` |
 | GLM 5.1 | `glm-5.1-fireworks` |
-| Kimi K2.5 | `kimi-k25-fireworks` |
+| Kimi K2.7 Code | `kimi-k27-code-fireworks` |
 | Kimi K2.6 | `kimi-k26-fireworks` |
+| Minimax 3 | `minimax-3-fireworks` |
 | Minimax 2.7 | `minimax-2.7-fireworks` |
+| Qwen 3.7 Plus | `qwen-3.7-plus-fireworks` |
 | Qwen 3.6 Plus | `qwen-3.6-plus-fireworks` |
+| DeepSeek V4 Pro | `deepseek-v4-pro-fireworks` |
 
 ### How to change models
 


### PR DESCRIPTION
## Summary
Adds publicly available models that were missing from the [Available models](https://docs.warp.dev/agent-platform/inference/model-choice/#available-models) list, and removes a deprecated entry. Follows up on the review note in #256 that the page was missing some entries.

## Changes
- **Google** - added Gemini 3.5 Flash (`gemini-3.5-flash`).
- **Fireworks-hosted** - added Kimi K2.7 Code (`kimi-k27-code-fireworks`), Minimax 3 (`minimax-3-fireworks`), Qwen 3.7 Plus (`qwen-3.7-plus-fireworks`), and DeepSeek V4 Pro (`deepseek-v4-pro-fireworks`).
- Removed the deprecated **Kimi K2.5** entry (`kimi-k25-fireworks`), which is no longer offered in the model picker.

Each addition was verified as enabled in production. Models that aren't generally available were intentionally left out.

## Notes
- Separate from #256 (custom routers); this PR only updates the Available models list.
- Claude Opus 4.8 is added in #256 and is intentionally not duplicated here.

---
_Conversation: https://staging.warp.dev/conversation/2a9a2183-616a-474c-bad3-36ea7a1a813b_
_Run: https://oz.staging.warp.dev/runs/019f0024-3ae2-7680-bebe-e15a191fee16_

_This PR was generated with [Oz](https://warp.dev/oz)._
