### PR TITLE
docs: add AEO cross-links for agents and orchestration

### DIFF
--- a/src/content/docs/agent-platform/cloud-agents/deployment-patterns.mdx
+++ b/src/content/docs/agent-platform/cloud-agents/deployment-patterns.mdx
@@ -80,7 +80,7 @@ Use this when you want Oz to run agent workloads on Warp-managed infrastructure,
 
 #### Common ways to trigger
 
-* **First-party integrations (Slack, Linear, etc.)** that create tasks automatically from external events.
+* **First-party integrations** (Slack, Linear, etc.) that create tasks automatically from external events. See the [Integrations overview](/agent-platform/cloud-agents/integrations/).
 * **Scheduled agents** for recurring work (cron-like automation).
 * **Custom triggers** from your own systems using Warp’s API/SDK.
 * **On-demand cloud jobs** using CLI commands like `oz agent run-cloud`.

--- a/src/content/docs/agent-platform/getting-started/agents-in-warp.mdx
+++ b/src/content/docs/agent-platform/getting-started/agents-in-warp.mdx
@@ -101,8 +101,8 @@ In addition to Warp's built-in agent, Warp provides first-class support for thir
 The same agent capabilities that power interactive conversations in Warp also run in the cloud. Cloud agents can:
 
 * React to events from Slack, Linear, or GitHub
-* Run on schedules for recurring tasks like dependency updates
-* Execute in parallel across repos or tasks
+* Run on [schedules](/agent-platform/cloud-agents/triggers/scheduled-agents/) for recurring tasks like dependency updates
+* Execute [in parallel across repos or tasks](/agent-platform/cloud-agents/orchestration/)
 * Produce tracked, auditable, shareable runs
 
 Cloud agents are ideal for work that doesn't need your immediate attention—PR reviews, issue triage, routine maintenance, and integration-driven workflows.


### PR DESCRIPTION
## AEO cross-link audit

Small, high-confidence internal cross-links for agents, cloud agents, and orchestration docs, sourced from the Peec AEO snapshot (`buzz/aeo-snapshots/docs/agents-orchestration/latest.json`, generated 2026-06-24).

### Goal
Identify small internal cross-link improvements for agents, cloud agents, and orchestration docs so readers can jump from an overview/concept page to the canonical page for the workflow they're researching.

### Source signals
Top Peec prompt clusters this period (all high or medium volume):
- "how do I set up AI coding agents to run on a schedule or in the background?" (scheduling, high volume)
- "how do I run multiple AI coding agents in parallel?" / "best tools for managing multiple AI coding agents" (parallel/multi-agent, high/medium volume)
- "how do I trigger AI coding agents automatically from Slack, Linear, or GitHub?" (integration triggers, high volume)

### Pages touched
- `src/content/docs/agent-platform/getting-started/agents-in-warp.mdx` — the "From local to cloud" section names scheduling and parallel execution but only linked to the cloud agents overview.
- `src/content/docs/agent-platform/cloud-agents/deployment-patterns.mdx` — the "Common ways to trigger" list named first-party integrations (Slack, Linear) without linking to the integrations docs.

### Links added
- `agents-in-warp.mdx` → [Scheduled Agents](/agent-platform/cloud-agents/triggers/scheduled-agents/) — anchored on "schedules" in the "Run on schedules for recurring tasks" bullet. Backed by the high-volume scheduling prompt cluster.
- `agents-in-warp.mdx` → [Multi-agent orchestration](/agent-platform/cloud-agents/orchestration/) — anchored on "in parallel across repos or tasks". Backed by the parallel/multi-agent prompt clusters.
- `deployment-patterns.mdx` → [Integrations overview](/agent-platform/cloud-agents/integrations/) — appended to the "First-party integrations (Slack, Linear, etc.)" trigger bullet. Backed by the Slack/Linear/GitHub trigger prompt cluster.

### Reader next step
- A reader on the getting-started agents hub who is interested in running agents on a recurring cadence or fanning work out in parallel can go straight to the scheduling and orchestration docs instead of routing through the cloud agents overview.
- A reader comparing deployment patterns who wants event-driven triggers can jump to the integrations setup docs from the pattern that mentions them.

### Open questions for human review
- The "From local to cloud" section also lists "React to events from Slack, Linear, or GitHub". I linked integrations from `deployment-patterns.mdx` instead to keep `agents-in-warp.mdx` to two new links; reviewers may prefer also linking integrations directly on that bullet.
- Newer signals this period (SSH-based remote agent access, self-hosted/on-prem) had no clear high-confidence existing-docs target and were left as follow-ups.

### Follow-up recommendations (out of scope for this cross-link pilot)
- Consider whether an SSH/remote-terminal-with-agents page is warranted given the new SSH signal.
- Evaluate whether self-hosted/on-prem queries should cross-link to environment isolation / self-hosting docs more prominently.

_Conversation: https://app.warp.dev/conversation/1605300e-6a83-496f-9ccd-32d244d6df5d_
_Run: https://oz.warp.dev/runs/019f13e4-fb3c-7d09-843f-46e4742674de_

_This PR was generated with [Oz](https://warp.dev/oz)._
