### PR TITLE
fix: render GFM markdown tables by registering remark-gfm

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { defineConfig, envField } from 'astro/config';
+import remarkGfm from 'remark-gfm';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import starlight from '@astrojs/starlight';
@@ -13,6 +14,12 @@ import docsMarkdownIntegration from './src/integrations/docs-markdown-integratio
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://docs.warp.dev',
+	// Explicitly register remark-gfm so GitHub-Flavored Markdown (notably
+	// pipe tables) is reliably applied to .mdx content. Astro enables gfm by
+	// default, but the @astrojs/mdx 5.x + @astrojs/markdown-remark 7.2.0
+	// version pairing stopped auto-applying it, which made markdown tables
+	// render as raw `| ... |` text. Registering the plugin here restores it.
+	markdown: { remarkPlugins: [remarkGfm] },
 	env: {
 		schema: {
 			PUBLIC_KAPA_INTEGRATION_ID: envField.string({

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-dom": "^19.2.4",
         "react-icons": "^5.6.0",
         "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "sharp": "^0.34.2",
         "starlight-llms-txt": "^0.8.1",
         "starlight-sidebar-topics": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^19.2.4",
     "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "sharp": "^0.34.2",
     "starlight-llms-txt": "^0.8.1",
     "starlight-sidebar-topics": "^0.7.1",


### PR DESCRIPTION
## Summary

Markdown pipe tables were rendering as raw `| ... |` text instead of HTML tables across the docs site — for example, the BYOLLM FAQ comparison table on `enterprise/enterprise-features/bring-your-own-llm`. Everything else (headings, bold, lists, asides) rendered fine.

## Root cause

GFM (`remark-gfm`) was not being applied to `.mdx` content in the build, so GFM pipe tables fell back to raw paragraph text. Astro enables GFM by default, but the current `@astrojs/mdx` 5.x + `@astrojs/markdown-remark` 7.2.0 pairing (the markdown-remark override was added on 2026-06-26 alongside the `astro@^6.4.6` bump) stopped auto-applying `remark-gfm` to `.mdx`. Confirmed by building locally: the installed libraries parse tables correctly in isolation, but the real build produced `0` `<table>` elements on affected pages.

## Fix

- Explicitly register `remark-gfm` in `astro.config.mjs` via `markdown: { remarkPlugins: [remarkGfm] }` (imported function, not a string — `@astrojs/mdx` drops string-named inherited plugins).
- Add `remark-gfm` (`^4.0.1`, already the resolved transitive version) as a direct dependency so the config doesn't rely on a hoisted transitive package.

This repairs **all** affected pages, not just BYOLLM (e.g. `model-choice`, `bring-your-own-api-key`, the `migrate-to-warp-from-*` pages, `teams`).

## Validation

- `npm run build` succeeds.
- Built pages containing `<table>` rise from **11 → 56**.
- BYOLLM page: `0 → 1` `<table>`; `model-choice`: `0 → 6` `<table>`.

## Alternatives considered

- Removing the `@astrojs/markdown-remark` override: risks reintroducing the CVE it was added to mitigate.
- Bumping `@astrojs/mdx`: constrained by `@astrojs/starlight@0.38.4` (`@astrojs/mdx@^5.0.0`).

The explicit `remark-gfm` registration is minimal, low-risk, and leaves CVE mitigations intact.

_Conversation: https://staging.warp.dev/conversation/3ddd7da8-3fc6-4462-ac42-34a265ca2870_
_Run: https://oz.staging.warp.dev/runs/019f1553-cacc-7375-ae63-a8c5cebf7f1f_
_Plans_:
- _[Fix broken markdown tables in docs (BYOLLM + site-wide)](https://staging.warp.dev/drive/notebook/NUphcWNTKlrEJXf5PNuB19)_

_This PR was generated with [Oz](https://warp.dev/oz)._
