### PR TITLE
docs: remove Do Things entry point from Warp Drive prompts

### DIFF
--- a/src/content/docs/knowledge-and-collaboration/warp-drive/prompts.mdx
+++ b/src/content/docs/knowledge-and-collaboration/warp-drive/prompts.mdx
@@ -26,7 +26,7 @@ Here's an example from [Warp Guides](/guides/), where Zach walks through what pr
 
 <VideoEmbed url="https://www.youtube.com/watch?ab_channel=Warp&v=pE15zjJmB4E" title="Using Warp Drive prompts video" />
 
-There are other great examples of prompts on [Do Things](https://dothings.warp.dev/) and [Warp Guides](/guides/).
+There are other great examples of prompts on [Warp Guides](/guides/).
 
 ## How to save and edit prompts
 


### PR DESCRIPTION
## Summary
Audits the docs for entry points into the Do Things site (`dothings.warp.dev`) and removes the one that exists.

## Audit findings
A repo-wide search (`.mdx`, `.md`, `.json`, `.mjs`, `.ts`, `.txt`, `.astro`, plus `vercel.json` redirects and `astro.config.mjs`) found a single real entry point:

- `src/content/docs/knowledge-and-collaboration/warp-drive/prompts.mdx` — a `[Do Things](https://dothings.warp.dev/)` link.

The only other match (`guides/getting-started/welcome-to-warp.mdx`) is a natural-language false positive ("prompt an agent to **do things** like debugging") and was left untouched.

No `vercel.json` redirects, sidebar entries, or other references point to the site.

## Change
Removes the Do Things link from the prompts doc while preserving the adjacent Warp Guides reference:

> Before: There are other great examples of prompts on [Do Things](https://dothings.warp.dev/) and [Warp Guides](/guides/).
> After: There are other great examples of prompts on [Warp Guides](/guides/).

_Conversation: https://staging.warp.dev/conversation/29b0c7f5-02d6-46c6-ad52-b745c52ec421_

_Run: https://oz.staging.warp.dev/runs/019f15c3-6dda-73c4-832f-15d9308b7d48_

_This PR was generated with [Oz](https://warp.dev/oz)._
