### PR TITLE
docs: use cheaper open-source models in custom router examples

### DIFF
--- a/src/content/docs/agent-platform/inference/custom-routers.mdx
+++ b/src/content/docs/agent-platform/inference/custom-routers.mdx
@@ -79,7 +79,7 @@ A rule-based router uses `type: prompt`. `default` is the required catch-all use
 ```yaml title="~/.warp/custom_model_routers/by-task.yaml"
 name: By task
 type: prompt
-default: gemini-3.5-flash
+default: claude-4-6-sonnet-high
 routing:
   - description: writing or reviewing database migrations for the acme-payments service
     model: glm-5.2-fireworks

--- a/src/content/docs/agent-platform/inference/custom-routers.mdx
+++ b/src/content/docs/agent-platform/inference/custom-routers.mdx
@@ -71,7 +71,7 @@ default: glm-5.2-fireworks
 routing:
   easy: minimax-3-fireworks
   medium: glm-5.2-fireworks
-  hard: claude-4-6-sonnet-high
+  hard: claude-4-8-opus-high
 ```
 
 A rule-based router uses `type: prompt`. `default` is the required catch-all used when no rule matches, and `routing` is the ordered list of rules. Rules can describe your team's specific workflows, so you can send routine work to cheaper models and reserve a frontier model for the tasks that need it:
@@ -79,7 +79,7 @@ A rule-based router uses `type: prompt`. `default` is the required catch-all use
 ```yaml title="~/.warp/custom_model_routers/by-task.yaml"
 name: By task
 type: prompt
-default: claude-4-6-sonnet-high
+default: gpt-5-5-medium
 routing:
   - description: writing or reviewing database migrations for the acme-payments service
     model: glm-5.2-fireworks

--- a/src/content/docs/agent-platform/inference/custom-routers.mdx
+++ b/src/content/docs/agent-platform/inference/custom-routers.mdx
@@ -71,7 +71,7 @@ default: glm-5.2-fireworks
 routing:
   easy: minimax-3-fireworks
   medium: glm-5.2-fireworks
-  hard: claude-4-8-opus-high
+  hard: deepseek-v4-pro-fireworks
 ```
 
 A rule-based router uses `type: prompt`. `default` is the required catch-all used when no rule matches, and `routing` is the ordered list of rules. Rules can describe your team's specific workflows, so you can send routine work to cheaper models and reserve a frontier model for the tasks that need it:
@@ -79,7 +79,7 @@ A rule-based router uses `type: prompt`. `default` is the required catch-all use
 ```yaml title="~/.warp/custom_model_routers/by-task.yaml"
 name: By task
 type: prompt
-default: gpt-5-5-medium
+default: gemini-3.5-flash
 routing:
   - description: writing or reviewing database migrations for the acme-payments service
     model: glm-5.2-fireworks

--- a/src/content/docs/agent-platform/inference/custom-routers.mdx
+++ b/src/content/docs/agent-platform/inference/custom-routers.mdx
@@ -62,7 +62,7 @@ Custom routers are stored as YAML files in `~/.warp/custom_model_routers/`, with
 
 Routing targets use the same `model_id` values listed on the [Model choice](/agent-platform/inference/model-choice/#available-models) page. Every target must be a concrete, Warp-supported model. You can't route to an Auto model, another router, or a model from a [custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/).
 
-A complexity router uses `type: complexity`. `default` is required and is used for any bucket you omit. This example keeps every task on lower-cost open-source models, stepping up in capability as complexity increases:
+A complexity router uses `type: complexity`. `default` is required and is used for any bucket you omit:
 
 ```yaml title="~/.warp/custom_model_routers/cost-saver.yaml"
 name: Cost saver
@@ -71,7 +71,7 @@ default: glm-5.2-fireworks
 routing:
   easy: minimax-3-fireworks
   medium: glm-5.2-fireworks
-  hard: deepseek-v4-pro-fireworks
+  hard: claude-4-6-sonnet-high
 ```
 
 A rule-based router uses `type: prompt`. `default` is the required catch-all used when no rule matches, and `routing` is the ordered list of rules. Rules can describe your team's specific workflows, so you can send routine work to cheaper models and reserve a frontier model for the tasks that need it:

--- a/src/content/docs/agent-platform/inference/custom-routers.mdx
+++ b/src/content/docs/agent-platform/inference/custom-routers.mdx
@@ -62,31 +62,33 @@ Custom routers are stored as YAML files in `~/.warp/custom_model_routers/`, with
 
 Routing targets use the same `model_id` values listed on the [Model choice](/agent-platform/inference/model-choice/#available-models) page. Every target must be a concrete, Warp-supported model. You can't route to an Auto model, another router, or a model from a [custom inference endpoint](/agent-platform/inference/custom-inference-endpoint/).
 
-A complexity router uses `type: complexity`. `default` is required and is used for any bucket you omit:
+A complexity router uses `type: complexity`. `default` is required and is used for any bucket you omit. This example keeps every task on lower-cost open-source models, stepping up in capability as complexity increases:
 
 ```yaml title="~/.warp/custom_model_routers/cost-saver.yaml"
 name: Cost saver
 type: complexity
-default: claude-4-6-sonnet-high
+default: glm-5.2-fireworks
 routing:
-  easy: claude-4-5-haiku
-  medium: claude-4-6-sonnet-high
-  hard: claude-4-8-opus-high
+  easy: minimax-3-fireworks
+  medium: glm-5.2-fireworks
+  hard: deepseek-v4-pro-fireworks
 ```
 
-A rule-based router uses `type: prompt`. `default` is the required catch-all used when no rule matches, and `routing` is the ordered list of rules:
+A rule-based router uses `type: prompt`. `default` is the required catch-all used when no rule matches, and `routing` is the ordered list of rules. Rules can describe your team's specific workflows, so you can send routine work to cheaper models and reserve a frontier model for the tasks that need it:
 
 ```yaml title="~/.warp/custom_model_routers/by-task.yaml"
 name: By task
 type: prompt
 default: claude-4-6-sonnet-high
 routing:
-  - description: debugging or fixing failing tests
+  - description: writing or reviewing database migrations for the acme-payments service
+    model: glm-5.2-fireworks
+  - description: debugging production incidents or fixing failing CI tests
     model: claude-4-8-opus-high
-  - description: writing documentation or comments
-    model: gpt-5-5-low
-  - description: simple one-line edits or renames
-    model: claude-4-5-haiku
+  - description: scaffolding new services or boilerplate from our internal templates
+    model: kimi-k27-code-fireworks
+  - description: drafting release notes, runbooks, or API documentation
+    model: qwen-3.7-plus-fireworks
 ```
 
 If a file can't be parsed, Warp shows a non-blocking error identifying the file and skips it; your other routers keep working.


### PR DESCRIPTION
## What

Updates the two custom router examples in `custom-routers.mdx` to demonstrate cost-conscious, real-world routing.

### `cost-saver.yaml` (complexity router)
Routes entirely to low-cost open-source models (hosted via Fireworks AI), ramping up capability with complexity:
- `easy` → `minimax-3-fireworks` (cheapest, fast)
- `medium`/`default` → `glm-5.2-fireworks` (strong, low-cost workhorse)
- `hard` → `deepseek-v4-pro-fireworks` (strongest open-source reasoning in the documented set)

### `by-task.yaml` (prompt router)
Replaces generic rules with concrete, company-style workflows so the example reads like something a real team would author:
- database migrations for the `acme-payments` service → `glm-5.2-fireworks`
- debugging production incidents / failing CI → `claude-4-8-opus-high`
- scaffolding new services / boilerplate → `kimi-k27-code-fireworks`
- release notes / runbooks / API docs → `qwen-3.7-plus-fireworks`

## Why

The previous examples routed almost everything to Claude tiers, which doesn't showcase the cost savings or the open-source models Warp supports. GLM 5.2 and other open-weights models (Minimax 3, DeepSeek V4 Pro, Kimi K2.7 Code, Qwen 3.7 Plus) are strong, low-cost options that are a natural fit for routine work, with a frontier model reserved for genuinely hard tasks.

## Notes
- All target `model_id` values are documented on the [Model choice](https://docs.warp.dev/agent-platform/inference/model-choice) page.
- Content-only change (YAML inside existing code fences + two short framing sentences); no new components or imports.

_Conversation: https://staging.warp.dev/conversation/721bc915-0528-4870-ad2b-e6c3b9ad9d05_
_Run: https://oz.staging.warp.dev/runs/019f15ce-c417-7214-8ce0-6cf5194f3fa8_

_This PR was generated with [Oz](https://warp.dev/oz)._
