### PR TITLE
docs: add Claude Sonnet 5 to model choice

### DIFF
--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -57,6 +57,9 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 
 | Model | `model_id` | Variant |
 | --- | --- | --- |
+| Claude Sonnet 5 | `claude-5-sonnet-xhigh` | Default effort |
+| Claude Sonnet 5 | `claude-5-sonnet-high` | High effort |
+| Claude Sonnet 5 | `claude-5-sonnet-max` | Max effort |
 | Claude Opus 4.8 | `claude-4-8-opus-xhigh` | Default effort |
 | Claude Opus 4.8 | `claude-4-8-opus-high` | High effort |
 | Claude Opus 4.8 | `claude-4-8-opus-max` | Max effort |
@@ -129,7 +132,7 @@ You can use the model picker in your prompt input to quickly switch between mode
 <figcaption>Model selector in Warp's input.</figcaption>
 </figure>
 
-To change models, click the displayed model name (for example, _Claude Sonnet 4.6_) to open a dropdown with all supported options. Your selection will automatically persist for future prompts.
+To change models, click the displayed model name (for example, _Claude Sonnet 5_) to open a dropdown with all supported options. Your selection will automatically persist for future prompts.
 
 ### Custom routers
 


### PR DESCRIPTION
## Summary
Claude Sonnet 5 is releasing today. This PR documents it in the agent model choice docs so the public model list reflects what's live in production (`claude_5_sonnet: true` in `warp-server`).

## Changes

### src/content/docs/agent-platform/inference/model-choice.mdx
- Added Claude Sonnet 5 to the **Anthropic** model table with all three effort variants, matching the server's model IDs and picker grouping (`LLMDisplayNameParts` in `warp-server/logic/ai/llm/model_choice.go`):
  - `claude-5-sonnet-xhigh` — Default effort
  - `claude-5-sonnet-high` — High effort
  - `claude-5-sonnet-max` — Max effort
- Placed it at the top of the Anthropic table as the newest, headline release (consistent with the existing newest-first ordering and the Opus 4.7/4.8 variant convention).
- Refreshed the model picker example to reference _Claude Sonnet 5_ as the displayed model.

## Notes for reviewers
- Variant labeling follows the same pattern already used for Claude Opus 4.7/4.8 (`-xhigh` = default, `-high` = high, `-max` = max), which is the authoritative grouping from `model_choice.go`.
- Internal link check passes (0 broken links).

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/1ede5134-4372-4009-b657-1e9a0184aa81_
_Run: https://oz.staging.warp.dev/runs/019f19db-6ac4-76e0-b352-7cf56b4fdf68_

_This PR was generated with [Oz](https://warp.dev/oz)._
