### PR TITLE
fix: disable Starlight's built-in 404 rout

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -60,6 +60,10 @@ export default defineConfig({
 				baseUrl: 'https://github.com/warpdotdev/docs/edit/main/',
 			},
 			lastUpdated: true,
+			// Disables Starlight's generated 404 route so it doesn't collide with
+			// the custom src/pages/404.astro, which fires a docs_404 analytics event
+			// with the real broken URL.
+			disable404Route: true,
 			// Soft-wrap long lines by default. Expressive Code defaults to
 			// `overflow-x: auto` for `<pre>`, which combined with macOS's
 			// auto-hidden scrollbars made wide lines silently truncate.


### PR DESCRIPTION
## Summary

Follow-up to #264.

Starlight injects its own 404 route on top of our custom `src/pages/404.astro`. Setting `disable404Route: true` turns that off so only our page is served.

Right now it's just a router warning, but Astro will turn the collision into a hard error soon.

## Validation

`npm run build` and `npm run typecheck` both pass.
