### PR TITLE
[demo] missing_docs drift-watch: CLI backlog burn-down sample

### DIFF
--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -204,6 +204,22 @@ oz provider -> src/content/docs/reference/cli/index.mdx
 oz federate -> src/content/docs/reference/cli/federate.mdx
 oz artifact -> src/content/docs/reference/cli/artifacts.mdx
 oz api-key -> src/content/docs/reference/cli/api-keys.mdx
+
+# Scheduled-agent CLI subcommands are fully documented in the scheduled-agents feature page.
+oz schedule create -> src/content/docs/platform/triggers/scheduled-agents.mdx
+oz schedule list -> src/content/docs/platform/triggers/scheduled-agents.mdx
+oz schedule get -> src/content/docs/platform/triggers/scheduled-agents.mdx
+oz schedule update -> src/content/docs/platform/triggers/scheduled-agents.mdx
+oz schedule pause -> src/content/docs/platform/triggers/scheduled-agents.mdx
+oz schedule unpause -> src/content/docs/platform/triggers/scheduled-agents.mdx
+oz schedule delete -> src/content/docs/platform/triggers/scheduled-agents.mdx
+
+# Warp-managed secret CLI subcommands are documented in the secrets feature page.
+oz secret create -> src/content/docs/platform/secrets.mdx
+oz secret list -> src/content/docs/platform/secrets.mdx
+oz secret update -> src/content/docs/platform/secrets.mdx
+oz secret delete -> src/content/docs/platform/secrets.mdx
+
 # Internal/hidden command — not a user-facing surface, so no public docs.
 oz harness-support -> internal
 

--- a/src/content/docs/reference/cli/api-keys.mdx
+++ b/src/content/docs/reference/cli/api-keys.mdx
@@ -104,6 +104,50 @@ To delete an API key, find it in either the Oz web app or the Warp app's API Key
 
 Deleted keys are immediately invalidated and cannot be recovered. Any services or scripts using the deleted key will lose access and may return an [`authentication_required` error](/reference/api-and-sdk/troubleshooting/errors/authentication-required/).
 
+## Manage API keys from the CLI
+
+In addition to the web and Warp app surfaces, you can manage API keys directly with the [Oz CLI](/reference/cli/). These commands are useful for scripting key rotation and for headless environments.
+
+### List keys
+
+`oz api-key list` prints your active API keys.
+
+* `--sort-by <FIELD>` — Sort by `name`, `created-at`, `last-used-at`, `expires-at`, or `scope`.
+* `--sort-order <DIR>` — Sort direction: `asc` or `desc`.
+* `--jq <FILTER>` — Filter the JSON output with a jq expression (for example, `--jq '.[].name'`).
+
+```bash
+oz api-key list --sort-by last-used-at --sort-order desc
+```
+
+### Create a key
+
+`oz api-key create <NAME>` creates a key and prints the raw secret once. Store it securely — you can't retrieve it again.
+
+* `<NAME>` — A name to identify the key (required).
+* `--agent <UID>` — Create an agent key that runs as the given cloud agent, instead of a personal key.
+* One expiration choice is required: `--expires-in <DURATION>` (for example, `30d`, `12h`, or `90m`), `--expires-at <RFC3339>` (an exact timestamp), or `--no-expiration`.
+* `--jq <FILTER>` — Filter the JSON output with a jq expression.
+
+```bash
+# A personal key that expires in 30 days
+oz api-key create "ci-pipeline" --expires-in 30d
+
+# An agent key scoped to a cloud agent, with no expiration
+oz api-key create "nightly-triage" --agent AGENT_UID --no-expiration
+```
+
+### Expire a key
+
+`oz api-key expire <NAME_OR_UID>` immediately invalidates a key (also available as `oz api-key delete`). Expired keys can't be recovered.
+
+* `<NAME_OR_UID>` — The name or UID of the key to expire (required).
+* `--force` — Skip the confirmation prompt.
+
+```bash
+oz api-key expire "ci-pipeline" --force
+```
+
 ## Best practices
 
 * **Use personal keys for runs that should act as you.** When code changes should be attributed to your GitHub account, a personal key is the right choice. Use agent keys for automation that isn't tied to a specific user.


### PR DESCRIPTION
## What this is

A **sample PR generated by running the `missing_docs` drift-watch skill** over the standing CLI backlog, so we can evaluate the skill's efficacy. Not intended to merge as-is — it's stacked on #201 (the skill itself) and meant for inspection.

## What one pass produced

Triaging the 31 undocumented `oz` CLI commands, the skill split them into two resolution types:

**Draft (genuinely undocumented):**
- Documented `oz api-key list`, `oz api-key create`, and `oz api-key expire` in `reference/cli/api-keys.mdx` — command syntax, every flag, and examples, all extracted from `crates/warp_cli/src/api_key.rs` (`--sort-by`, `--sort-order`, `--jq`, `--agent`, the required expiration group, `--force`).

**Map, don't duplicate (already documented elsewhere):**
- `oz schedule *` (7 subcommands) → `platform/triggers/scheduled-agents.mdx`
- `oz secret *` (4 subcommands) → `platform/secrets.mdx`

These are fully documented in their feature pages, so the skill adds surface-map entries pointing there instead of re-drafting (avoids junk-drawer duplication).

## Reviewer routing

`suggest_reviewers.py` resolved the owning engineers from `crates/warp_cli` ownership: **@bnavetta, @ianhodge**. (Not actually requested here since this is a throwaway demo PR.)

## Result

- Undocumented CLI commands: **31 → 17** in one pass.
- Audit exits 0, `unaccounted: none`, drafted doc passes `style_lint`.

## What it does NOT cover (good signal on limits)

- The remaining 17 are newer/uncertain-rollout groups (`oz run message/conversation`, `oz agent` CRUD, `oz memory*` [research preview], `oz provider*` [dogfood]) — these need a human rollout/readiness call before documenting, which is exactly the kind of judgment the skill defers rather than guesses.

_Conversation: https://staging.warp.dev/conversation/c5ce6a1a-81a4-4a04-92d9-8d587693be12_
_Run: https://oz.staging.warp.dev/runs/019f19e2-f981-725b-b383-bc7ea01adb6a_

_This PR was generated with [Oz](https://warp.dev/oz)._
