### PR TITLE
[demo] missing_docs drift-watch: resolve oz CLI drift (GA docs + gated deferral)

### DIFF
--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -203,7 +203,6 @@ oz whoami -> src/content/docs/reference/cli/index.mdx
 oz integration -> src/content/docs/reference/cli/integration-setup.mdx
 oz schedule -> src/content/docs/reference/cli/index.mdx
 oz secret -> src/content/docs/reference/cli/index.mdx
-oz provider -> src/content/docs/reference/cli/index.mdx
 oz federate -> src/content/docs/reference/cli/federate.mdx
 oz artifact -> src/content/docs/reference/cli/artifacts.mdx
 oz api-key -> src/content/docs/reference/cli/api-keys.mdx
@@ -237,6 +236,14 @@ oz memory-store get -> gated:AIMemories
 oz memory-store list -> gated:AIMemories
 oz memory-store list-store-agents -> gated:AIMemories
 oz memory-store update -> gated:AIMemories
+
+# `oz provider` (link third-party services like Slack and Linear) is gated by
+# ProviderCommand, which is non-GA (dogfood), so the whole command group is
+# deferred via `gated:` — it auto-surfaces for docs when ProviderCommand goes
+# GA. See "Public vs. private surfaces" in SKILL.md.
+oz provider -> gated:ProviderCommand
+oz provider setup -> gated:ProviderCommand
+oz provider list -> gated:ProviderCommand
 
 # Internal/hidden command — not a user-facing surface, so no public docs.
 oz harness-support -> internal

--- a/src/content/docs/reference/cli/index.mdx
+++ b/src/content/docs/reference/cli/index.mdx
@@ -365,13 +365,68 @@ The `--share` flag can be repeated, and uses the following syntax:
 
 The following commands are available for managing and inspecting Oz resources.
 
-### `oz agent list`
+### Managing named agents
 
-List all available skills discovered from your environments. Optionally filter by repository:
+[Named agents](/platform/agents/) are reusable agent configurations — a name, description, skills, secrets, base model, and default environment — that you can run with `oz agent run-cloud --agent <UID>` and scope API keys to.
+
+List the named agents on your team, optionally sorting by name or creation time:
 
 ```sh
 oz agent list
-oz agent list --repo owner/repo
+oz agent list --sort-by created-at --sort-order desc
+```
+
+Show the full configuration for a single agent by its UID:
+
+```sh
+oz agent get <UID>
+```
+
+Create a named agent. Only `--name` is required; attach skills and secrets by repeating the flags:
+
+```sh
+oz agent create \
+  --name "release-notes" \
+  --description "Drafts release notes from merged PRs" \
+  --skill "myorg/repo:release-notes" \
+  --secret GITHUB_TOKEN \
+  --base-model <MODEL_ID> \
+  --environment <ENVIRONMENT_ID>
+```
+
+Update an existing agent. Each attribute has an explicit add/remove flag so changes are unambiguous:
+
+```sh
+# Rename the agent and swap one of its skills
+oz agent update <UID> --name "weekly-release-notes" \
+  --remove-skill "myorg/repo:old" --add-skill "myorg/repo:release-notes"
+
+# Clear attributes entirely
+oz agent update <UID> --remove-description --remove-all-secrets
+```
+
+Common `oz agent update` flags:
+
+* `--name <NAME>` (`-n`) — rename the agent.
+* `--description <TEXT>` / `--remove-description` — set or clear the description.
+* `--add-secret <NAME>` / `--remove-secret <NAME>` / `--remove-all-secrets` — manage attached secrets.
+* `--add-skill <SKILL>` / `--remove-skill <SKILL>` / `--remove-all-skills` — manage attached skills.
+* `--base-model <MODEL_ID>` / `--remove-base-model` — set or clear the base model.
+* `--environment <ENVIRONMENT_ID>` (`-e`) / `--remove-environment` — set or clear the default cloud environment.
+
+Delete a named agent by its UID:
+
+```sh
+oz agent delete <UID>
+```
+
+### `oz agent skills`
+
+List the agent skills discovered across your environments. Pass `--repo` (`-r`) to list skills from a specific GitHub repository instead:
+
+```sh
+oz agent skills
+oz agent skills --repo owner/repo
 ```
 
 ### `oz run list` / `oz run get`
@@ -386,6 +441,45 @@ oz run list --limit 20
 # Get details for a specific run
 oz run get <RUN_ID>
 ```
+
+### Run conversations and messages
+
+Read an agent run's transcript and exchange messages between runs — for example, between a parent orchestrator and its [child agents](/platform/orchestration/multi-agent-runs/).
+
+Retrieve a conversation transcript by its ID:
+
+```sh
+oz run conversation get <CONVERSATION_ID>
+```
+
+List and read the messages in a run's inbox:
+
+```sh
+# List inbox message headers
+oz run message list <RUN_ID>
+oz run message list <RUN_ID> --unread --since 2026-01-01T00:00:00Z --limit 100
+
+# Read one message body
+oz run message read <MESSAGE_ID>
+
+# Stream new messages as they arrive (resume reconnects with --since-sequence)
+oz run message watch <RUN_ID>
+oz run message watch <RUN_ID> --since-sequence 42
+```
+
+Send a message from one run to one or more recipient runs, then mark it delivered once handled:
+
+```sh
+oz run message send \
+  --sender-run-id <RUN_ID> \
+  --to <RECIPIENT_RUN_ID> \
+  --subject "build status" \
+  --body "tests are green"
+
+oz run message mark-delivered <MESSAGE_ID>
+```
+
+Repeat `--to` to fan a message out to multiple recipient runs.
 
 ### `oz model list`
 


### PR DESCRIPTION
## What this is

A **live drift-detection demo** for the `missing_docs` skill (stacked on #201). It runs the skill's drift-watch loop on real, current drift in the `oz` CLI and resolves every finding according to each command's GA rollout status — including the new `gated:<Flag>` deferral mechanism from #201.

This is the "actual drift-detection test" requested: the audit found 15 undocumented CLI subcommands, and this PR closes all of them.

## The drift the audit detected

`python3 .agents/skills/missing_docs/scripts/audit_docs.py --category cli` flagged **15** undocumented `oz` subcommands across three command groups:

- `oz agent get` / `create` / `update` / `delete` / `skills`
- `oz run conversation` / `conversation get` / `message` (+ `watch` / `send` / `list` / `read` / `mark-delivered`)
- `oz provider setup` / `list`

## How each group was resolved (by rollout status)

The skill defers non-GA surfaces and documents GA ones. Statuses were confirmed via the audit's own `compute_flag_statuses` against `crates/warp_features`:

- **`NamedAgents` = ga** → documented the `oz agent` named-agent management group in the CLI reference, drafted flag-by-flag from `crates/warp_cli/src/agent.rs`. Also **fixed an existing bug**: the old `oz agent list` entry incorrectly described listing *skills* with `--repo` (that behavior is actually `oz agent skills`).
- **`ConversationApi` = ga** → documented `oz run conversation get` and the `oz run message` inbox commands, drafted from `crates/warp_cli/src/task.rs`.
- **`ProviderCommand` = dogfood (non-GA)** → deferred the whole `oz provider` group via `gated:ProviderCommand` in the surface map. It is intentionally undocumented while non-GA and will **auto-surface as a finding** once `ProviderCommand` goes GA. This is the core demonstration of the gated mechanism on real drift.

## Validation

- `audit_docs.py --category cli` → **0 gaps** (was 15).
- Full audit `accounting`: `cli_commands.finding: 0`, `gated_non_ga: 14` (11 Agent Memory + 3 `oz provider`), `map_hygiene: 0`, `unaccounted: {}`.
- Skill test suite: **27 passed**.
- Reviewer routing (`suggest_reviewers.py`) for the documented sources (`crates/warp_cli/*`) → **@bnavetta, @ianhodge**.

The remaining gaps in the full audit (18 API spec gaps, 29 LOW terminology) are pre-existing and unrelated to this change.

## Files changed

- `src/content/docs/reference/cli/index.mdx` — GA command docs + `oz agent list` bug fix.
- `.agents/skills/missing_docs/references/feature_surface_map.md` — `oz provider` group deferred via `gated:ProviderCommand`.

_Conversation: https://staging.warp.dev/conversation/c5ce6a1a-81a4-4a04-92d9-8d587693be12_
_Run: https://oz.staging.warp.dev/runs/019f19e2-f981-725b-b383-bc7ea01adb6a_
_Plans_:
- _[missing_docs skill overhaul (#201)](https://github.com/warpdotdev/docs/pull/201)_

_This PR was generated with [Oz](https://warp.dev/oz)._
