### PR TITLE
docs: reconcile Model choice page with prod-enabled models (restore Fable 5, add Opus fast-mode)

### DIFF
--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -57,8 +57,8 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 
 | Model | `model_id` | Variant |
 | --- | --- | --- |
-| Claude Fable 5 | `claude-5-fable-xhigh` | Default effort |
-| Claude Fable 5 | `claude-5-fable-high` | High effort |
+| Claude Fable 5 | `claude-5-fable-high` | Default effort |
+| Claude Fable 5 | `claude-5-fable-xhigh` | Extra high effort |
 | Claude Fable 5 | `claude-5-fable-max` | Max effort |
 | Claude Sonnet 5 | `claude-5-sonnet-xhigh` | Default effort |
 | Claude Sonnet 5 | `claude-5-sonnet-high` | High effort |

--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -57,6 +57,9 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 
 | Model | `model_id` | Variant |
 | --- | --- | --- |
+| Claude Fable 5 | `claude-5-fable-xhigh` | Default effort |
+| Claude Fable 5 | `claude-5-fable-high` | High effort |
+| Claude Fable 5 | `claude-5-fable-max` | Max effort |
 | Claude Sonnet 5 | `claude-5-sonnet-xhigh` | Default effort |
 | Claude Sonnet 5 | `claude-5-sonnet-high` | High effort |
 | Claude Sonnet 5 | `claude-5-sonnet-max` | Max effort |
@@ -76,18 +79,9 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 | Claude Sonnet 4.5 | `claude-4-5-sonnet-thinking` | Thinking on |
 | Claude Haiku 4.5 | `claude-4-5-haiku` | — |
 
-{/* Claude Fable 5 was removed from the product and may return in a future release.
-    To restore it, re-add the three Claude Fable 5 rows to the Anthropic table above
-    and uncomment the caution below. */}
-{/*
-| Claude Fable 5 | `claude-5-fable-xhigh` | Default effort |
-| Claude Fable 5 | `claude-5-fable-high` | High effort |
-| Claude Fable 5 | `claude-5-fable-max` | Max effort |
-
 :::caution
 Anthropic requires data retention for Claude Fable 5 for safety, abuse monitoring, and compliance reasons, so it is **not available under Zero Data Retention (ZDR)**. This requirement is specific to Claude Fable 5 and doesn't change the ZDR behavior of any other supported model. For Enterprise teams, the model is off by default and a workspace admin must enable it — see the [Admin Panel](/enterprise/team-management/admin-panel/#models-settings) and the [Security overview](/enterprise/security-and-compliance/security-overview/#zero-data-retention-zdr).
 :::
-*/}
 
 #### Google
 

--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -66,9 +66,11 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 | Claude Opus 4.8 | `claude-4-8-opus-xhigh` | Default effort |
 | Claude Opus 4.8 | `claude-4-8-opus-high` | High effort |
 | Claude Opus 4.8 | `claude-4-8-opus-max` | Max effort |
+| Claude Opus 4.8 | `claude-4-8-opus-xhigh-fast` | Fast mode |
 | Claude Opus 4.7 | `claude-4-7-opus-xhigh` | Default effort |
 | Claude Opus 4.7 | `claude-4-7-opus-high` | High effort |
 | Claude Opus 4.7 | `claude-4-7-opus-max` | Max effort |
+| Claude Opus 4.7 | `claude-4-7-opus-xhigh-fast` | Fast mode |
 | Claude Opus 4.6 | `claude-4-6-opus-high` | Default effort |
 | Claude Opus 4.6 | `claude-4-6-opus-max` | Max effort |
 | Claude Sonnet 4.6 | `claude-4-6-sonnet-high` | Default effort |


### PR DESCRIPTION
## Summary

Reconciles the **Model choice** page (`agent-platform/inference/model-choice.mdx`) with the models actually enabled in production, based on a full audit of warp-server's `GetModelChoices` against `config/prod.yaml` feature flags.

Three changes:

1. **Restore Claude Fable 5.** Fable was re-enabled in prod (warp-server PR #12305 set `claude_5_fable: true`). Restored the three Fable rows to the Anthropic table (top, its original position) and re-enabled the data-retention `:::caution` block that had been commented out.
2. **Add the Opus fast-mode variants.** `claude-4-7-opus-xhigh-fast` and `claude-4-8-opus-xhigh-fast` are added unconditionally in `GetModelChoices` (always on in prod), are in `ConfigurableLlmIds`, and have prod specs — but were missing from the docs. Added both to the Anthropic table.
3. **Update Fable 5 default effort to high.** Reflects warp-server PR #12322 (Anthropic recommends high as the default; xhigh/max are too token-hungry for most tasks): `claude-5-fable-high` → **Default effort** (was High), `claude-5-fable-xhigh` → **Extra high effort** (was Default), `claude-5-fable-max` unchanged.

## ⚠️ Release timing

- Changes 1 and 2 reflect behavior **already in prod** (Fable reenabled, fast-mode variants always-on).
- Change 3 (default effort) is a code change on warp-server `develop` (PR #12322) that **deploys to prod with the next release, targeted next Tuesday** — it is not live yet. Merge/publish this doc change around that release so the docs don't lead prod. If you'd rather not lead prod at all, hold this PR (or split out change 3) until Tuesday.

## Full audit (every model reconciled against prod)

Verified against `warp-server/logic/ai/llm/model_choice.go` (`GetModelChoices`) and `config/prod.yaml`. `base.yaml` has no `features:` block, so prod flags are authoritative.

**Correctly documented / present in prod:** all Auto models (`auto`, `auto-efficient`, `auto-genius`, `auto-open`); OpenAI GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.2 Codex, GPT-5.2; Anthropic Fable 5, Sonnet 5, Opus 4.8/4.7/4.6, Sonnet 4.6, Opus/Sonnet 4.5, Haiku 4.5; Google Gemini 3.1 Pro, 3.5 Flash; xAI Grok 4.3, Grok Build 0.1; Fireworks GLM 5.2/5.1, Kimi K2.7 Code/K2.6, Minimax 3/2.7, Qwen 3.7/3.6 Plus, DeepSeek V4 Pro.

**Correctly excluded (flag is `false`/absent in prod):** Gemini 2.5 Flash (`gemini_2_5_flash: false`), Grok 4 (`grok_4: false`), GPT-OSS 120B (`fireworks_gpt_oss_120b` absent), Grape (`grape` absent), Kiwi (`kiwi` absent), GPT-5 Mini (`gpt_5_mini` absent), GLM 4.6/4.7 (deprecated, not added to the picker).

## Notes for reviewers

- Fable 5 details verified against the server: model_ids/effort labels match `LLMDisplayNameParts`; `requiresDataRetentionWorkspace()` returns true only for the three Fable models (so it's not available under ZDR); `defaultDisabledForEnterpriseLlmIds` contains exactly the three Fable models.
- The fast-mode rows are surfaced in the picker as separate entries named "Claude Opus 4.x (fast mode)"; here they're grouped under the family with a **Fast mode** variant label for readability. If they were intentionally omitted from the docs, drop those two rows.
- No other docs pages needed changes: `admin-panel.mdx` and `security-overview.mdx` already use generic "some models require data retention" language.

_Conversation: https://staging.warp.dev/conversation/5a818da7-1ef0-4e94-b969-d3bdd185d101_
_Run: https://oz.staging.warp.dev/runs/019f23c2-e174-7386-8213-e655d5d2b971_

_This PR was generated with [Oz](https://warp.dev/oz)._
