### PR TITLE
docs: remove GLM 5.1 from hosted models

### DIFF
--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -110,7 +110,6 @@ Warp also supports leading open source models hosted via Fireworks AI, so you ca
 | Model | `model_id` |
 | --- | --- |
 | GLM 5.2 | `glm-5.2-fireworks` |
-| GLM 5.1 | `glm-5.1-fireworks` |
 | Kimi K2.7 Code | `kimi-k27-code-fireworks` |
 | Kimi K2.6 | `kimi-k26-fireworks` |
 | Minimax 3 | `minimax-3-fireworks` |


### PR DESCRIPTION
## What
Removes GLM 5.1 from the docs. GLM 5.1 is being decommissioned as a serverless model by Fireworks on July 27th, and GLM 5.2 is already available, so the model is being deprecated (see warpdotdev/warp-server#12378).

## Changes
- Removed the `GLM 5.1` (`glm-5.1-fireworks`) row from the Fireworks-hosted models table on the Model choice page (`agent-platform/inference/model-choice.mdx`).

## Deep-pass notes
Did a thorough sweep of the entire docs repo for GLM references. The only actual GLM 5.1 model reference was the table row on the Model choice page. Other GLM mentions are unaffected:
- `custom-routers.mdx` only uses `glm-5.2-fireworks` in examples (correct, stays).
- GLM 5.2 remains listed in the hosted models table.
- Changelog entries are historical records and were not modified.

Verified with a full `npm run build` (346 pages built successfully).

_Conversation: https://staging.warp.dev/conversation/d5959718-d3e5-486a-ae10-3cd8a99da774_
_Run: https://oz.staging.warp.dev/runs/019f3d75-b688-7bcc-90be-0afdd9fea500_

_This PR was generated with [Oz](https://warp.dev/oz)._
