### PR TITLE
docs(skills): fix cloud-agent run links and route Slack to #growth-docs

### DIFF
--- a/.agents/skills/aeo_crosslink_audit/SKILL.md
+++ b/.agents/skills/aeo_crosslink_audit/SKILL.md
@@ -29,7 +29,7 @@ Do not:
 The following environment secrets should be set in the Oz cloud agent environment:
 
 - `SLACK_BOT_TOKEN` — Slack bot token for posting to `#growth-docs`. If unavailable, write the notification body to the run output instead and skip Slack posting.
-- `SLACK_CHANNEL_ID` — Slack channel ID for `#growth-docs`. Find it in Slack by right-clicking the channel → Copy link (the ID begins with `C`). If unavailable, skip Slack posting.
+- `GROWTH_DOCS_SLACK_CHANNEL_ID` — Slack channel ID for `#growth-docs`. Find it in Slack by right-clicking the channel → Copy link (the ID begins with `C`). If unavailable, skip Slack posting.
 
 Do NOT print, log, commit, or include secret values in reports or Slack messages.
 
@@ -85,9 +85,9 @@ If Google Search Console data is unavailable, say what could not be verified and
    import os, json, urllib.request, sys
 
    token = os.environ.get("SLACK_BOT_TOKEN", "")
-   channel = os.environ.get("SLACK_CHANNEL_ID", "")
+   channel = os.environ.get("GROWTH_DOCS_SLACK_CHANNEL_ID", "")
    if not token or not channel:
-       print("SLACK_BOT_TOKEN or SLACK_CHANNEL_ID not set — skipping Slack notification", file=sys.stderr)
+       print("SLACK_BOT_TOKEN or GROWTH_DOCS_SLACK_CHANNEL_ID not set — skipping Slack notification", file=sys.stderr)
        sys.exit(0)
 
    # Replace the triple-quoted string with the message from the Slack notification format section.
@@ -113,7 +113,7 @@ If Google Search Console data is unavailable, say what could not be verified and
    SLACK_EOF
    ```
 
-   Replace `<message text here>` with the message from the appropriate format in the "Slack notification format" section. Do not print `SLACK_BOT_TOKEN` or `SLACK_CHANNEL_ID` values in the run output or in any file.
+   Replace `<message text here>` with the message from the appropriate format in the "Slack notification format" section. Do not print `SLACK_BOT_TOKEN` or `GROWTH_DOCS_SLACK_CHANNEL_ID` values in the run output or in any file.
 
 ## Link quality rules
 
@@ -309,6 +309,7 @@ Oz run: [run URL]
 Rules:
 - Post on every run, including no-change runs.
 - Never include raw secret values, personal access tokens, or credential file paths in the Slack message.
+- Build the `Oz run` link at runtime — never hard-code the Oz host (for example `app.warp.dev` or `oz.warp.dev`). This agent may run on staging or production, and a hard-coded host resolves to the wrong environment (or a generic Runs page). Resolve the environment-correct link from your current run with `oz-dev run get "<your run ID>" --output-format json | jq -r '.session_link'`, substituting the run ID this agent is executing as.
 - If the Oz run URL is unavailable, omit that line rather than posting a broken link.
 
 ## Future expansion boundaries

--- a/.agents/skills/check_for_broken_links/SKILL.md
+++ b/.agents/skills/check_for_broken_links/SKILL.md
@@ -21,7 +21,7 @@ python3 .warp/skills/check_for_broken_links/check_links.py
 - `--external-only`: Only check external links
 - `--timeout N`: HTTP timeout in seconds (default: 10)
 - `--output FILE`: Save results to JSON file
-- `--slack-notify`: Send results to Slack (requires `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` env vars)
+- `--slack-notify`: Send results to Slack (requires `SLACK_BOT_TOKEN` and `GROWTH_DOCS_SLACK_CHANNEL_ID` env vars)
 - `--slack-channel ID`: Override the default Slack channel
 
 ### Quick internal-only check:

--- a/.agents/skills/check_for_broken_links/check_links.py
+++ b/.agents/skills/check_for_broken_links/check_links.py
@@ -17,7 +17,7 @@ import time
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
-DEFAULT_SLACK_CHANNEL = os.environ.get("SLACK_CHANNEL_ID", "")
+DEFAULT_SLACK_CHANNEL = os.environ.get("GROWTH_DOCS_SLACK_CHANNEL_ID", "")
 
 try:
     import requests
@@ -496,8 +496,8 @@ def main():
     parser.add_argument('--external-only', action='store_true', help='Only check external links')
     parser.add_argument('--timeout', type=int, default=10, help='HTTP timeout (default: 10)')
     parser.add_argument('--output', help='Output JSON file')
-    parser.add_argument('--slack-notify', action='store_true', 
-                        help='Send results to Slack (requires SLACK_BOT_TOKEN and SLACK_CHANNEL_ID env vars)')
+    parser.add_argument('--slack-notify', action='store_true',
+                        help='Send results to Slack (requires SLACK_BOT_TOKEN and GROWTH_DOCS_SLACK_CHANNEL_ID env vars)')
     parser.add_argument('--slack-channel', default=DEFAULT_SLACK_CHANNEL,
                         help=f'Slack channel ID (default: {DEFAULT_SLACK_CHANNEL})')
     

--- a/.agents/skills/improve-aeo-crosslink-skill/SKILL.md
+++ b/.agents/skills/improve-aeo-crosslink-skill/SKILL.md
@@ -21,7 +21,7 @@ Suggested cron: `0 17 1-7 * 1` (UTC) = first Monday of each month at 9am PT.
 - The standing log PR (`chore: aeo crosslink audit run log`) merged into `main` so the entries are present there. If it is unmerged, merge it first (or read the log from the `chore/aeo-crosslink-audit-log` branch) before analyzing.
 - `gh` CLI authenticated with write access to `warpdotdev/docs`
 - `SLACK_BOT_TOKEN` — for posting summary to `#growth-docs`
-- `SLACK_CHANNEL_ID` — channel ID for `#growth-docs`
+- `GROWTH_DOCS_SLACK_CHANNEL_ID` — channel ID for `#growth-docs`
 
 ## Signal
 
@@ -123,6 +123,11 @@ Entries analyzed: N
 No actionable patterns found: [brief reason]
 Oz run: [run URL]
 ```
+In both messages, build the `Oz run` link at runtime — never hard-code the Oz host (for example `app.warp.dev` or `oz.warp.dev`). This agent may run on staging or production, and a hard-coded host resolves to the wrong environment (or a generic Runs page). Resolve the environment-correct link from your current run, substituting the run ID this agent is executing as:
+```bash
+oz-dev run get "<your run ID>" --output-format json | jq -r '.session_link'
+```
+If the command fails or returns an empty value, omit the `Oz run` line rather than posting a hard-coded or broken URL.
 
 ## Deployment
 
@@ -130,8 +135,8 @@ This skill is designed for a monthly Oz scheduled agent. Start it on month 3 aft
 
 To deploy:
 1. Push this skill to `main` in the docs repo.
-2. Verify the Oz environment has `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` set.
-3. In the Oz web app (oz.warp.dev), create a new scheduled agent:
+2. Verify the Oz environment has `SLACK_BOT_TOKEN` and `GROWTH_DOCS_SLACK_CHANNEL_ID` set.
+3. In the Oz web app, create a new scheduled agent:
    - **Skill**: `improve-aeo-crosslink-skill` from `warpdotdev/docs`
    - **Schedule**: `0 17 1-7 * 1` (UTC) = first Monday of each month at 9am PT
    - **Environment**: the same environment used for `aeo_crosslink_audit` (has `warpdotdev/docs` and buzz workspace checked out)

--- a/.agents/skills/improve-drafting-skills/SKILL.md
+++ b/.agents/skills/improve-drafting-skills/SKILL.md
@@ -20,7 +20,7 @@ The following must be available in the cloud agent environment:
 - Docs repo checked out at `main`
 - `gh` CLI authenticated with write access to `warpdotdev/docs`
 - `SLACK_BOT_TOKEN` — for posting a summary to `#growth-docs`
-- `SLACK_CHANNEL_ID` — channel ID for `#growth-docs`
+- `GROWTH_DOCS_SLACK_CHANNEL_ID` — channel ID for `#growth-docs`
 
 ## Signal sources
 
@@ -180,6 +180,11 @@ Patterns addressed: N (human feedback: N, agent review: N, style lint: N)
 Top patterns: [pattern 1], [pattern 2], [pattern 3]
 Oz run: [run URL]
 ```
+Build the `Oz run` link at runtime — never hard-code the Oz host (for example `app.warp.dev` or `oz.warp.dev`). This agent may run on staging or production, and a hard-coded host resolves to the wrong environment (or a generic Runs page). Resolve the environment-correct link from your current run, substituting the run ID this agent is executing as:
+```bash
+oz-dev run get "<your run ID>" --output-format json | jq -r '.session_link'
+```
+If the command fails or returns an empty value, omit the `Oz run` line rather than posting a hard-coded or broken URL.
 
 If fewer than 2 actionable patterns are found, do not open a PR. Write a no-change report to the run output instead:
 
@@ -205,8 +210,8 @@ This skill is designed for a monthly Oz scheduled agent.
 
 To deploy:
 1. Push this skill to `main` in the docs repo.
-2. Verify the Oz environment has `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` set.
-3. In the Oz web app (oz.warp.dev), create a new scheduled agent:
+2. Verify the Oz environment has `SLACK_BOT_TOKEN` and `GROWTH_DOCS_SLACK_CHANNEL_ID` set.
+3. In the Oz web app, create a new scheduled agent:
    - **Skill**: `improve-drafting-skills` from `warpdotdev/docs`
    - **Schedule**: `0 17 1-7 * 1` (UTC) = first Monday of each month at 9am PT
    - **Environment**: the same environment used for `weekly-404-monitor` (already has `warpdotdev/docs` checked out)

--- a/.agents/skills/style_lint/SKILL.md
+++ b/.agents/skills/style_lint/SKILL.md
@@ -22,7 +22,7 @@ python3 .agents/skills/style_lint/style_lint.py
 - `--fix`: Auto-fix high-confidence issues (optional, off by default)
 - `--create-pr`: Create a branch and PR with auto-fixes (requires `gh` CLI, implies `--fix`)
 - `--output FILE`: Save results to JSON file
-- `--slack-notify`: Send results to Slack (only sends when issues are found; requires `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` env vars)
+- `--slack-notify`: Send results to Slack (only sends when issues are found; requires `SLACK_BOT_TOKEN` and `GROWTH_DOCS_SLACK_CHANNEL_ID` env vars)
 - `--slack-channel ID`: Override the default Slack channel
 
 ### Quick check on changed files:

--- a/.agents/skills/style_lint/style_lint.py
+++ b/.agents/skills/style_lint/style_lint.py
@@ -90,7 +90,7 @@ OZ_TERMS_TO_AVOID = [
 # Action verbs that precede UI elements (should be bold, not backtick)
 UI_ACTION_VERBS = r"(?:click|select|toggle|enable|disable|choose|check|uncheck|expand|collapse|open|close|tap)"
 
-DEFAULT_SLACK_CHANNEL = os.environ.get("SLACK_CHANNEL_ID", "")
+DEFAULT_SLACK_CHANNEL = os.environ.get("GROWTH_DOCS_SLACK_CHANNEL_ID", "")
 
 TERMINOLOGY_FILE = Path(".warp/references/terminology.md")
 

--- a/.agents/skills/validate_ui_refs/SKILL.md
+++ b/.agents/skills/validate_ui_refs/SKILL.md
@@ -23,7 +23,7 @@ python3 .warp/skills/validate_ui_refs/validate_ui_refs.py --all
 - `--all`: Run all checks (default)
 - `--fix`: Auto-fix high-confidence issues (e.g. case mismatches)
 - `--create-pr`: Create a branch and PR with auto-fixes (requires `gh` CLI)
-- `--slack-notify`: Post results to Slack (only sends when issues are found; requires `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` env vars)
+- `--slack-notify`: Post results to Slack (only sends when issues are found; requires `SLACK_BOT_TOKEN` and `GROWTH_DOCS_SLACK_CHANNEL_ID` env vars)
 - `--slack-channel ID`: Override default Slack channel
 - `--include-changelog`: Include `changelog/` in the scan (excluded by default since it's a historical record)
 - `--refresh-valid-paths`: Re-extract valid paths from `warp-internal` and update `valid_paths.json`

--- a/.agents/skills/validate_ui_refs/validate_ui_refs.py
+++ b/.agents/skills/validate_ui_refs/validate_ui_refs.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List, Optional, Tuple
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_VALID_PATHS_FILE = SCRIPT_DIR / "valid_paths.json"
 DEFAULT_DOCS_DIR = SCRIPT_DIR.parents[2] / "docs"
-DEFAULT_SLACK_CHANNEL = os.environ.get("SLACK_CHANNEL_ID", "")
+DEFAULT_SLACK_CHANNEL = os.environ.get("GROWTH_DOCS_SLACK_CHANNEL_ID", "")
 
 # Known Warp UI roots — paths starting with these are Warp UI paths
 WARP_UI_ROOTS = {"Settings", "File", "View", "Warp", "Warp Drive", "Personal"}

--- a/.agents/skills/weekly-404-monitor/SKILL.md
+++ b/.agents/skills/weekly-404-monitor/SKILL.md
@@ -13,7 +13,7 @@ The following environment secrets must be set in the Oz cloud agent environment:
 
 - `METABASE_API_KEY` — Metabase API key for BigQuery queries. If unavailable, the run must fail fast with a clear error.
 - `SLACK_BOT_TOKEN` — Slack bot token for posting to the docs channel. If unavailable, write a no-post report to the run output instead.
-- `SLACK_CHANNEL_ID` — Slack channel ID for **`#growth-docs`**. Find it in Slack by right-clicking the channel → Copy link (the ID begins with `C`). There is no fallback — the run will skip Slack posting if this is unset.
+- `GROWTH_DOCS_SLACK_CHANNEL_ID` — Slack channel ID for **`#growth-docs`**. Find it in Slack by right-clicking the channel → Copy link (the ID begins with `C`). There is no fallback — the run will skip Slack posting if this is unset.
 
 Do NOT print, log, or include secret values in reports, commits, or Slack messages.
 
@@ -94,6 +94,12 @@ _+{long_tail_count} other uncovered URLs under {report_min_hits} hits each (most
 → Add redirects for the gaps above: `vercel.json` › `redirects` array (PR against `main`)
 → Full breakdown: {oz_run_url}
 ```
+
+Build `{oz_run_url}` at runtime — never hard-code the Oz host (for example `app.warp.dev` or `oz.warp.dev`). This agent may run on staging or production, and a hard-coded host resolves to the wrong environment (or a generic Runs page). Resolve the environment-correct link from your current run, substituting the run ID this agent is executing as:
+```bash
+oz-dev run get "<your run ID>" --output-format json | jq -r '.session_link'
+```
+If the command fails or returns an empty value, omit the `→ Full breakdown` line rather than posting a hard-coded or broken URL.
 
 Rules:
 - **Lead with volume trend, not distinct-URL counts.** The first line is always `trend_summary` — the pre-formatted total-404 trend, which reflects real user impact. It already includes the direction arrow (▼ fewer 404s, ▲ more, → no change) and falls back to a "no prior-week baseline yet" message when last week had no data, so the percentage is never rendered as null.
@@ -199,11 +205,11 @@ This skill is designed for an Oz scheduled agent with a weekly cron trigger: eve
 
 To deploy:
 1. Push this skill to `main` in the docs repo.
-2. Verify the **`buzz`** Oz environment (oz.warp.dev → Environments) has these secrets set:
+2. Verify the **`buzz`** Oz environment (in the Oz web app → Environments) has these secrets set:
    - `METABASE_API_KEY` — Metabase API key for BigQuery
    - `SLACK_BOT_TOKEN` — Slack bot token
-   - `SLACK_CHANNEL_ID` — ID for `#growth-docs` (right-click channel in Slack → Copy link; the ID starts with `C`)
-3. In the Oz web app (oz.warp.dev), create a new scheduled agent:
+   - `GROWTH_DOCS_SLACK_CHANNEL_ID` — ID for `#growth-docs` (right-click channel in Slack → Copy link; the ID starts with `C`)
+3. In the Oz web app, create a new scheduled agent:
    - **Skill**: `weekly-404-monitor` from `warpdotdev/docs`
    - **Schedule**: `0 17 * * 1` (UTC) = 9am PT (Mondays)
    - **Environment**: `buzz` (already has `warpdotdev/docs` checked out)


### PR DESCRIPTION
## Summary
Fixes two issues in the docs cloud-agent skills. 

### 1. Broken Oz run links in Slack
`weekly-404-monitor` and related cloud-agent skills posted a hard-coded run URL using the production host (`app.warp.dev`) even though these scheduled agents run on staging, so the run link in `#growth-docs` resolved to the generic Runs page instead of the actual run. These skills now resolve the environment-correct link at runtime, and omit it if it can't be resolved:

```bash
oz-dev run get "<your run ID>" --output-format json | jq -r '.session_link'
```

Affected: `weekly-404-monitor`, `improve-drafting-skills`, `improve-aeo-crosslink-skill`, `aeo_crosslink_audit`.

### 2. Shared Slack channel secret
Docs skills that post to `#growth-docs` read the shared team `SLACK_CHANNEL_ID` secret, which many other bots also use. They now read a dedicated `GROWTH_DOCS_SLACK_CHANNEL_ID` secret so #growth-docs routing can't be affected by (or affect) other bots.

Repointed: the four skills above plus `validate_ui_refs`, `check_for_broken_links`, `style_lint` (SKILL.md docs + Python `--slack-notify` defaults).

Also made deploy-note Oz hosts environment-neutral (removed `oz.warp.dev`).

## Validation
- No bare `SLACK_CHANNEL_ID` remains in `.agents/skills/`.
- `python3 -m py_compile` passes for the three edited scripts.
- `git diff --check` is clean.

## Notes
- Requires the `GROWTH_DOCS_SLACK_CHANNEL_ID` team secret (already created via `oz-dev secret create`).
- The shared `SLACK_CHANNEL_ID` secret was intentionally left untouched.

Conversation: https://staging.warp.dev/conversation/54f65368-3438-4737-b195-39e2acb14a6a

Co-Authored-By: Oz <oz-agent@warp.dev>
