### PR TITLE
Docs: Tab groups, drag-to-window, warp://settings, and more CLI agents

### DIFF
--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -134,6 +134,13 @@ ShellSelector -> src/content/docs/getting-started/supported-shells.mdx
 WorkflowAliases -> src/content/docs/terminal/entry/yaml-workflows.mdx
 KittyImages -> src/content/docs/terminal/more-features/full-screen-apps.mdx
 UndoClosedPanes -> src/content/docs/terminal/windows/tabs.mdx
+# Tab groups (organize tabs into named, collapsible groups) — GA (in the default
+# feature set). Pinning tab groups is still Preview (PinnedTabs), so it stays out
+# of the docs for now.
+GroupedTabs -> src/content/docs/terminal/windows/tabs.mdx
+# Drag a tab out to its own window or between windows. GA on macOS and Windows
+# (RELEASE_FLAGS, cfg-gated), documented with that platform caveat.
+DragTabsToWindows -> src/content/docs/terminal/windows/tabs.mdx
 RevertDiffHunk -> src/content/docs/code/code-review.mdx
 SshRemoteServer -> src/content/docs/terminal/warpify/ssh.mdx
 
@@ -313,6 +320,7 @@ DELETE /memory_stores/{uid} -> gated:AIMemories
 GET /memory_stores/{uid}/agents -> gated:AIMemories
 GET /memory_stores/{uid}/memories -> gated:AIMemories
 POST /memory_stores/{uid}/memories -> gated:AIMemories
+GET /memory_stores/{uid}/memories/{memoryUid} -> gated:AIMemories
 DELETE /memory_stores/{uid}/memories/{memoryUid} -> gated:AIMemories
 PUT /memory_stores/{uid}/memories/{memoryUid} -> gated:AIMemories
 GET /memory_stores/{uid}/memories/{memoryUid}/versions -> gated:AIMemories
@@ -334,6 +342,11 @@ GET /memory_stores/{uid}/memories/{memoryUid}/versions -> gated:AIMemories
 # One-time internal state for the deprecated tmux SSH wrapper migration banner;
 # not a user-configurable setting.
 warpify.ssh.ssh_tmux_deprecation_notice_pending -> internal
+
+# TUI-only (warp-tui) background auto-updater toggle (surface: TUI). It isn't
+# present in the GUI settings UI, so it isn't documented in the all-settings
+# reference.
+general.autoupdate_enabled -> internal
 
 ## Unlisted docs pages to ignore
 
@@ -449,10 +462,6 @@ OwnerOrchestrationAncestorStreamer
 # rollout status (the audit computes that from code); entries here are ignored
 # because the toggle itself isn't a documentable surface, or because the
 # feature isn't user-facing yet — the snapshot diff flags promotions.
-# Grouped Tabs is a macOS-only Preview feature (organize tabs into named,
-# collapsible groups); public docs are pending GA promotion, which the snapshot
-# diff will flag.
-GroupedTabs
 # Pinned Tabs is a Preview feature (pin individual tabs and whole tab groups to
 # the front of the tab list); public docs are pending GA promotion, which the
 # snapshot diff will flag.
@@ -476,7 +485,6 @@ CodeModeChip
 # Internal agent file-search tool plumbing (read tools are not individually documented).
 GrepTool
 NativeShellCompletions
-DragTabsToWindows
 SshDragAndDrop
 ITermImages
 AIGeneratedOnboardingSuggestions

--- a/.agents/skills/missing_docs/references/surface_snapshot.json
+++ b/.agents/skills/missing_docs/references/surface_snapshot.json
@@ -101,7 +101,7 @@
     "DiffSetAsContext": "ga",
     "DirectoryTabColors": "ga",
     "DiscardPerFileAndAllChanges": "ga",
-    "DragTabsToWindows": "preview",
+    "DragTabsToWindows": "ga",
     "DriveObjectsAsContext": "ga",
     "DynamicWorkflowEnums": "ga",
     "EditableMarkdownMermaid": "dogfood",
@@ -154,6 +154,7 @@
     "IntegratedGPU": "other",
     "IntegrationCommand": "ga",
     "InteractiveConversationManagementView": "ga",
+    "JupyterNotebookRendering": "dogfood",
     "KittyImages": "ga",
     "KittyKeyboardProtocol": "ga",
     "KnowledgeSidebar": "other",
@@ -269,6 +270,7 @@
     "ValidateAutosuggestions": "ga",
     "VerticalTabs": "ga",
     "VerticalTabsSummaryMode": "ga",
+    "VideoRecording": "dogfood",
     "ViewingSharedSessions": "ga",
     "VimCodeEditor": "ga",
     "WaitForEventsParentRegistration": "dogfood",
@@ -1019,6 +1021,7 @@
     "code.indexing.agent_mode_codebase_context": "always_on",
     "code.indexing.agent_mode_codebase_context_auto_indexing": "always_on",
     "experimental.async_find_enabled": "always_on",
+    "general.autoupdate_enabled": "always_on",
     "general.default_session_mode": "always_on",
     "general.default_tab_config_path": "always_on",
     "general.link_tooltip": "always_on",
@@ -1214,5 +1217,5 @@
     "verify-ui-change-in-cloud": "dogfood",
     "warpctrl": "bundled"
   },
-  "changelog_last_version": "2026.06.24"
+  "changelog_last_version": "2026.07.03"
 }

--- a/src/content/docs/agent-platform/cli-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cli-agents/overview.mdx
@@ -29,6 +29,10 @@ Warp currently supports the following CLI coding agents:
 * **Gemini CLI** — Google's CLI coding agent
 * **Droid** — Factory's CLI coding agent
 * **Pi** — Open-source CLI coding agent
+* **Goose** — Block's CLI coding agent
+* **Antigravity** — the Antigravity CLI coding agent (invoked with `agy`)
+* **Hermes** — Nous Research's CLI coding agent
+* **Mistral Vibe** — Mistral's CLI coding agent
 
 When you launch a supported agent inside Warp, the **agent toolbelt** appears automatically, giving you quick access to Warp's enhanced features.
 
@@ -51,8 +55,10 @@ Not every feature is available for every agent. The table below shows current su
 | Tab Configs | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Remote Control | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
+**Goose**, **Antigravity** (`agy`), **Hermes**, and **Mistral Vibe** are also recognized. They get the same enhanced features as the agents above — rich input editor, code review comments, attach code as context, vertical tabs and metadata, Tab Configs, and Remote Control — but don't support agent notifications yet.
+
 :::note
-Agent notifications require a one-time setup. Claude Code and OpenCode use a Warp notification plugin. Codex uses a native config change. See the individual agent pages for setup instructions. Amp, Auggie, Copilot CLI, Cursor, Gemini CLI, Droid, and Pi don't support notifications yet.
+Agent notifications require a one-time setup. Claude Code and OpenCode use a Warp notification plugin. Codex uses a native config change. See the individual agent pages for setup instructions. Amp, Auggie, Copilot CLI, Cursor, Gemini CLI, Droid, Pi, Goose, Antigravity, Hermes, and Mistral Vibe don't support notifications yet.
 :::
 
 ## Customizing the toolbelt

--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -131,9 +131,9 @@ To change models, click the displayed model name (for example, _Claude Sonnet 5_
 
 ### Custom routers
 
-Beyond the built-in Auto models, you can define your own custom routers that automatically pick a concrete model for each task, based on task complexity or rules you write. Custom routers appear in the model picker alongside Auto and individual models.
+Beyond the built-in Auto models, you can define your own custom routers that automatically route each task to a concrete model based on task complexity or rules you write. Custom routers appear in the model picker alongside Auto and individual models.
 
-See [Custom routers](/agent-platform/inference/custom-routers/) to create one.
+Add and manage custom routers in **Settings** > **AI** > **Custom Routers**. See [Custom routers](/agent-platform/inference/custom-routers/) for details on creating one.
 
 ### Model fallback
 
@@ -150,12 +150,6 @@ Warp uses a model fallback system to ensure uninterrupted service if your select
 You can configure the base model for each [Agent Profile](/agent-platform/capabilities/agent-profiles-permissions/), alongside the Agent's autonomy, tool access, and other permissions. The base model is also used for [Planning](/agent-platform/capabilities/planning/).
 
 Edit your default profile or any other profile directly in **Settings** > **Agents** > **Profiles**.
-
-### Custom routers
-
-Custom model routers automatically route each task to a specific model based on task complexity or rules you define, instead of using a single fixed model for every prompt. Your custom routers appear in the [model selector](#how-to-change-models) alongside Warp's built-in models.
-
-Add and manage custom routers in **Settings** > **AI** > **Custom Routers**.
 
 ### Zero data retention policies
 

--- a/src/content/docs/terminal/more-features/uri-scheme.mdx
+++ b/src/content/docs/terminal/more-features/uri-scheme.mdx
@@ -16,10 +16,26 @@ There are several ways to use the URI scheme:
 * Open new tab `warp://action/new_tab?path=<path_to_folder>`
 * Open Launch Configuration `warp://launch/<launch_configuration_path>`
 * Open Tab Config `warp://tab_config/<name>` — opens the saved [Tab Config](/terminal/windows/tab-configs/) as a new tab in the active window. Append `?new_window=true` to open it in a new window instead. `<name>` is matched case-insensitively against the file stem of the `.toml`, so both `warp://tab_config/my_tab` and `warp://tab_config/my_tab.toml` resolve to `my_tab.toml`.
+* Open Settings `warp://settings` — opens the Settings window. See [Settings deep links](#settings-deep-links) for search, widget, and sub-page options.
 
 :::note
 [Warp Preview](/support-and-community/community/warp-preview-and-alpha-program/) URI scheme begins with `warppreview://`
 :::
+
+## Settings deep links
+
+Open the Settings window directly, optionally jumping to a specific page, widget, or search:
+
+* `warp://settings` — open Settings on the default page.
+* `warp://settings?q=<query>` — open Settings with the search bar pre-filled.
+* `warp://settings?widget=<widget_id>` — open Settings scrolled to a specific setting.
+* `warp://settings/appearance` — open the Appearance page (themes, fonts, and more).
+* `warp://settings/mcp` — open the MCP servers page. Append `?autoinstall=<name>` to install a gallery MCP server by name.
+* `warp://settings/warp_agent` — open the Warp Agent page (inference and API keys).
+* `warp://settings/environments` — open the Cloud environments page.
+* `warp://settings/platform` — open the Platform page.
+* `warp://settings/billing_and_usage` — open the Billing & usage page.
+* `warp://settings/teams` — open Team settings. Append `?invite=<email>` to open the invite dialog with the email pre-filled.
 
 ## How it works
 

--- a/src/content/docs/terminal/windows/tabs.mdx
+++ b/src/content/docs/terminal/windows/tabs.mdx
@@ -87,3 +87,53 @@ Please see our [Appearance > Tabs Behavior](/terminal/appearance/tabs-behavior/)
 ### How Tabs work
 
 <VideoEmbed url="https://www.loom.com/share/84d15cc7eb5a4a668bb86be9e827f261?hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true" title="Tabs Demo" />
+
+## Tab groups
+
+Organize related tabs into named, collapsible groups. A tab group keeps its member tabs together in the tab bar, can be given a name and a color, and can be collapsed to hide its members until you need them. Tab groups work in both the horizontal tab bar and the [vertical tabs](/terminal/windows/vertical-tabs/) panel.
+
+### Create a group
+
+* Right-click a tab and choose **New group with tab** to start a group from that tab.
+* Select multiple tabs first (see [Select multiple tabs](#select-multiple-tabs)), then right-click the selection to group them together.
+* Click the **+** new-tab button and choose **New tab group** to create an empty group.
+
+### Select multiple tabs
+
+* `Cmd`-click (macOS) or `Ctrl`-click (Windows/Linux) a tab to add it to or remove it from the selection.
+* `Shift`-click a tab to select every tab between it and the active tab.
+
+With multiple tabs selected, right-click to group them, move them into an existing group, or remove them from their group in one step.
+
+### Manage a group
+
+Right-click a group's header to:
+
+* **Rename** the group.
+* Set a **color** for the group.
+* Add a **New tab in group**.
+* **Ungroup tabs** to dissolve the group while keeping its tabs.
+* Close the tabs in the group.
+
+Right-click an individual tab for **New group with tab**, **Move to group** (to move it into another group), and **Remove from group**.
+
+### Collapse a group
+
+Click a group's header to collapse or expand it. Collapsed groups hide their member tabs to save space in the tab bar; click the header again to expand.
+
+:::note
+You can assign keyboard shortcuts for creating a group from the active or selected tabs and for removing tabs from a group in **Settings** > **Keyboard shortcuts**.
+:::
+
+## Move a tab to another window
+
+You can pull a tab out of the tab bar to reorganize your windows, similar to a web browser:
+
+* **Detach a tab into its own window** — drag a tab out of the tab bar and drop it in empty space to open it in a new window.
+* **Move a tab between windows** — drag a tab onto another window's tab bar to move it there.
+
+The tab keeps its running session, panes, and state as it moves. This works from both the horizontal tab bar and the [vertical tabs](/terminal/windows/vertical-tabs/) panel.
+
+:::note
+Dragging tabs between windows is available on macOS and Windows.
+:::


### PR DESCRIPTION
## Summary

Fills documentation gaps surfaced by the `missing_docs` audit, run **against the public `warpdotdev/warp`** repo (plus `warp-server`). Each item was verified GA in source before documenting (feature flags checked against `RELEASE_FLAGS`/`PREVIEW_FLAGS` and the `app/Cargo.toml` default feature set).

### New / updated docs
- **CLI agents** (`agent-platform/cli-agents/overview.mdx`) — added **Goose**, **Antigravity** (`agy`), **Hermes**, and **Mistral Vibe** to the supported agents list and notifications note. All four are recognized unconditionally in the OSS client (`app/src/terminal/cli_agent.rs`).
- **Tab groups + drag-to-window** (`terminal/windows/tabs.mdx`) — documented Tab groups (create/select/manage/collapse) and dragging a tab into its own window or between windows. `GroupedTabs` is GA (in the default feature set); `DragTabsToWindows` is GA on **macOS and Windows only** (`RELEASE_FLAGS`, cfg-gated). Tab/group **pinning is intentionally omitted** — `PinnedTabs` is still Preview.
- **`warp://settings` deep link** (`terminal/more-features/uri-scheme.mdx`) — documented the settings URI scheme (`?q=`, `?widget=`, and the `teams`/`environments`/`mcp`/`billing_and_usage`/`platform`/`appearance`/`warp_agent` sub-pages) from `app/src/uri/mod.rs`.

### Corrections
- **Duplicate heading** — merged two identical `### Custom routers` sections in `agent-platform/inference/model-choice.mdx` into one.

### Audit bookkeeping (`missing_docs` references)
- Mapped `GroupedTabs` and `DragTabsToWindows` to `tabs.mdx` and removed them from the ignore list — both had gone GA but were stale-ignored as "Preview," which is why the coverage audit never flagged them.
- Deferred the new `GET /memory_stores/{uid}/memories/{memoryUid}` endpoint as `gated:AIMemories` (Agent Memory is research preview).
- Marked the TUI-only `general.autoupdate_enabled` setting `internal` (not present in the GUI settings UI).
- Refreshed `surface_snapshot.json`.

## Validation
- `npm run build` passes (346 pages built).
- `audit_docs.py` re-run is clean (exit 0, no unaccounted surfaces); addressed findings cleared.

## Deferred (not in this PR)
- **18 warp-server public API endpoints** missing from the OpenAPI spec (schedules, messaging/events, artifacts, factory). warp-server is private, so these are **not** hand-documented here — released ones should be brought in via the `sync-openapi-spec` skill after confirming public-release status. Owners: `@captainsafia` (schedules, factory), `@harryalbert` / Matthew Albright (messaging/events/artifacts).
- **~31 low-severity terminology hits** ("ai credits", "warp terminal", etc.) — these belong to the `style_lint` skill.
- **Note for reviewers:** the CLI agents feature-support matrix in `overview.mdx` has a pre-existing column-count inconsistency (some rows have more cells than the header). I left the matrix as-is and documented the four new agents in prose beneath it; worth a follow-up cleanup. Also please confirm **Hermes** and **Mistral Vibe** are intended to be publicly listed (they're recognized in code but ship without brand icons).

## Suggested reviewers
- `@zachbai` / `@harryalbert` — CLI agent recognition (`cli_agent.rs`)
- `@peicodes` — Tab groups + cross-window tab drag
- `@seemeroland` — `warp://settings` URI handling

_Conversation: https://staging.warp.dev/conversation/242a5572-723f-4523-bae2-5d1afffac657_
_Run: https://oz.staging.warp.dev/runs/019f3e82-58b3-7bf1-8117-5d26b83d7fd7_

_This PR was generated with [Oz](https://warp.dev/oz)._
