### PR TITLE
Docs: add Goose, Antigravity, Hermes, and Mistral Vibe to CLI agents overview

### DIFF
--- a/src/content/docs/agent-platform/cli-agents/overview.mdx
+++ b/src/content/docs/agent-platform/cli-agents/overview.mdx
@@ -29,6 +29,10 @@ Warp currently supports the following CLI coding agents:
 * **Gemini CLI** — Google's CLI coding agent
 * **Droid** — Factory's CLI coding agent
 * **Pi** — Open-source CLI coding agent
+* **Goose** — Block's CLI coding agent
+* **Antigravity** — the Antigravity CLI coding agent (invoked with `agy`)
+* **Hermes** — Nous Research's CLI coding agent
+* **Mistral Vibe** — Mistral's CLI coding agent
 
 When you launch a supported agent inside Warp, the **agent toolbelt** appears automatically, giving you quick access to Warp's enhanced features.
 
@@ -51,8 +55,10 @@ Not every feature is available for every agent. The table below shows current su
 | Tab Configs | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Remote Control | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
+**Goose**, **Antigravity** (`agy`), **Hermes**, and **Mistral Vibe** are also recognized. They get the same enhanced features as the agents above — rich input editor, code review comments, attach code as context, vertical tabs and metadata, Tab Configs, and Remote Control — but don't support agent notifications yet.
+
 :::note
-Agent notifications require a one-time setup. Claude Code and OpenCode use a Warp notification plugin. Codex uses a native config change. See the individual agent pages for setup instructions. Amp, Auggie, Copilot CLI, Cursor, Gemini CLI, Droid, and Pi don't support notifications yet.
+Agent notifications require a one-time setup. Claude Code and OpenCode use a Warp notification plugin. Codex uses a native config change. See the individual agent pages for setup instructions. Amp, Auggie, Copilot CLI, Cursor, Gemini CLI, Droid, Pi, Goose, Antigravity, Hermes, and Mistral Vibe don't support notifications yet.
 :::
 
 ## Customizing the toolbelt


### PR DESCRIPTION
## Summary

Adds four CLI coding agents that Warp's OSS client already recognizes but that were missing from the supported agents list in `agent-platform/cli-agents/overview.mdx`:

- **Goose** — Block's CLI coding agent
- **Antigravity** — the Antigravity CLI coding agent (invoked with `agy`)
- **Hermes** — Nous Research's CLI coding agent
- **Mistral Vibe** — Mistral's CLI coding agent

All four are defined and recognized unconditionally in `app/src/terminal/cli_agent.rs` (command prefix, display name, brand color). They get the same enhanced features as the other recognized agents (rich input editor, code review comments, attach code as context, vertical tabs + metadata, Tab Configs, Remote Control) and don't support agent notifications yet.

Source of finding: `missing_docs` audit against the public `warpdotdev/warp` repo.

## Notes for reviewers
- Suggested owners: `@zachbai` / `@harryalbert` (CLI agent recognition).
- Please confirm **Hermes** and **Mistral Vibe** are intended to be publicly listed — they're recognized in code but ship without brand icons.
- The feature-support matrix on this page has a pre-existing column-count inconsistency (some rows have more cells than the header). I left it as-is and described the new agents in prose beneath it; a follow-up cleanup would be worthwhile.

_Conversation: https://staging.warp.dev/conversation/242a5572-723f-4523-bae2-5d1afffac657_
_Run: https://oz.staging.warp.dev/runs/019f3e82-58b3-7bf1-8117-5d26b83d7fd7_

_This PR was generated with [Oz](https://warp.dev/oz)._
