### PR TITLE
Docs: document Tab groups and moving a tab to another window

### DIFF
--- a/src/content/docs/terminal/windows/tabs.mdx
+++ b/src/content/docs/terminal/windows/tabs.mdx
@@ -104,7 +104,9 @@ Organize related tabs into named, collapsible groups. A tab group keeps its memb
 * `Shift`-click a tab to select every tab between it and the active tab.
 
 With multiple tabs selected, right-click to group them, move them into an existing group, or remove them from their group in one step.
-
+:::note
+The active tab is always included in a selection.
+:::
 ### Manage a group
 
 Right-click a group's header to:

--- a/src/content/docs/terminal/windows/tabs.mdx
+++ b/src/content/docs/terminal/windows/tabs.mdx
@@ -96,7 +96,7 @@ Organize related tabs into named, collapsible groups. A tab group keeps its memb
 
 * Right-click a tab and choose **New group with tab** to start a group from that tab.
 * Select multiple tabs first (see [Select multiple tabs](#select-multiple-tabs)), then right-click the selection to group them together.
-* Click the **+** new-tab button and choose **New tab group** to create an empty group.
+* Click the **+** new-tab button and choose **New tab group** to create a new group with a new tab.
 
 ### Select multiple tabs
 

--- a/src/content/docs/terminal/windows/tabs.mdx
+++ b/src/content/docs/terminal/windows/tabs.mdx
@@ -87,3 +87,53 @@ Please see our [Appearance > Tabs Behavior](/terminal/appearance/tabs-behavior/)
 ### How Tabs work
 
 <VideoEmbed url="https://www.loom.com/share/84d15cc7eb5a4a668bb86be9e827f261?hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true" title="Tabs Demo" />
+
+## Tab groups
+
+Organize related tabs into named, collapsible groups. A tab group keeps its member tabs together in the tab bar, can be given a name and a color, and can be collapsed to hide its members until you need them. Tab groups work in both the horizontal tab bar and the [vertical tabs](/terminal/windows/vertical-tabs/) panel.
+
+### Create a group
+
+* Right-click a tab and choose **New group with tab** to start a group from that tab.
+* Select multiple tabs first (see [Select multiple tabs](#select-multiple-tabs)), then right-click the selection to group them together.
+* Click the **+** new-tab button and choose **New tab group** to create an empty group.
+
+### Select multiple tabs
+
+* `Cmd`-click (macOS) or `Ctrl`-click (Windows/Linux) a tab to add it to or remove it from the selection.
+* `Shift`-click a tab to select every tab between it and the active tab.
+
+With multiple tabs selected, right-click to group them, move them into an existing group, or remove them from their group in one step.
+
+### Manage a group
+
+Right-click a group's header to:
+
+* **Rename** the group.
+* Set a **color** for the group.
+* Add a **New tab in group**.
+* **Ungroup tabs** to dissolve the group while keeping its tabs.
+* Close the tabs in the group.
+
+Right-click an individual tab for **New group with tab**, **Move to group** (to move it into another group), and **Remove from group**.
+
+### Collapse a group
+
+Click a group's header to collapse or expand it. Collapsed groups hide their member tabs to save space in the tab bar; click the header again to expand.
+
+:::note
+You can assign keyboard shortcuts for creating a group from the active or selected tabs and for removing tabs from a group in **Settings** > **Keyboard shortcuts**.
+:::
+
+## Move a tab to another window
+
+You can pull a tab out of the tab bar to reorganize your windows, similar to a web browser:
+
+* **Detach a tab into its own window** — drag a tab out of the tab bar and drop it in empty space to open it in a new window.
+* **Move a tab between windows** — drag a tab onto another window's tab bar to move it there.
+
+The tab keeps its running session, panes, and state as it moves. This works from both the horizontal tab bar and the [vertical tabs](/terminal/windows/vertical-tabs/) panel.
+
+:::note
+Dragging tabs between windows is available on macOS and Windows.
+:::


### PR DESCRIPTION
## Summary

Documents two GA tab-management features in `terminal/windows/tabs.mdx` that were missing from the docs. Both live in the same file and are owned by the same person, so they're grouped into one PR.

### Tab groups
Organize related tabs into named, collapsible, color-coded groups (create, multi-select, manage, collapse). `GroupedTabs` is GA (in the `app/Cargo.toml` default feature set). **Tab/group pinning is intentionally omitted** — `PinnedTabs` is still Preview.

### Move a tab to another window
Drag a tab out of the tab bar into its own window, or onto another window's tab bar to move it there. `DragTabsToWindows` is GA on **macOS and Windows only** (`RELEASE_FLAGS`, cfg-gated), documented with that platform caveat.

Source of finding: `missing_docs` audit against the public `warpdotdev/warp` repo. The surface-map mappings that reflect these features going GA are in a separate audit-bookkeeping PR.

## Notes for reviewers
- Suggested owner: `@peicodes` (tab groups + cross-window tab drag).
- I combined tab groups and drag-to-window because they edit the same file and share an owner; happy to split into two stacked PRs if you'd prefer.

_Conversation: https://staging.warp.dev/conversation/242a5572-723f-4523-bae2-5d1afffac657_
_Run: https://oz.staging.warp.dev/runs/019f3e82-58b3-7bf1-8117-5d26b83d7fd7_

_This PR was generated with [Oz](https://warp.dev/oz)._
