### PR TITLE
Docs: document the warp://settings deep link

### DIFF
--- a/src/content/docs/terminal/more-features/uri-scheme.mdx
+++ b/src/content/docs/terminal/more-features/uri-scheme.mdx
@@ -16,10 +16,26 @@ There are several ways to use the URI scheme:
 * Open new tab `warp://action/new_tab?path=<path_to_folder>`
 * Open Launch Configuration `warp://launch/<launch_configuration_path>`
 * Open Tab Config `warp://tab_config/<name>` — opens the saved [Tab Config](/terminal/windows/tab-configs/) as a new tab in the active window. Append `?new_window=true` to open it in a new window instead. `<name>` is matched case-insensitively against the file stem of the `.toml`, so both `warp://tab_config/my_tab` and `warp://tab_config/my_tab.toml` resolve to `my_tab.toml`.
+* Open Settings `warp://settings` — opens the Settings window. See [Settings deep links](#settings-deep-links) for search, widget, and sub-page options.
 
 :::note
 [Warp Preview](/support-and-community/community/warp-preview-and-alpha-program/) URI scheme begins with `warppreview://`
 :::
+
+## Settings deep links
+
+Open the Settings window directly, optionally jumping to a specific page, widget, or search:
+
+* `warp://settings` — open Settings on the default page.
+* `warp://settings?q=<query>` — open Settings with the search bar pre-filled.
+* `warp://settings?widget=<widget_id>` — open Settings scrolled to a specific setting.
+* `warp://settings/appearance` — open the Appearance page (themes, fonts, and more).
+* `warp://settings/mcp` — open the MCP servers page. Append `?autoinstall=<name>` to install a gallery MCP server by name.
+* `warp://settings/warp_agent` — open the Warp Agent page (inference and API keys).
+* `warp://settings/environments` — open the Cloud environments page.
+* `warp://settings/platform` — open the Platform page.
+* `warp://settings/billing_and_usage` — open the Billing & usage page.
+* `warp://settings/teams` — open Team settings. Append `?invite=<email>` to open the invite dialog with the email pre-filled.
 
 ## How it works
 


### PR DESCRIPTION
## Summary

Documents the `warp://settings` deep link in `terminal/more-features/uri-scheme.mdx`. The URI is live (handled in `app/src/uri/mod.rs`) and already referenced elsewhere in the docs (e.g. `warp://settings/mcp`), but the URI scheme reference didn't cover it.

Adds:
- `warp://settings` — open Settings on the default page.
- `warp://settings?q=<query>` — open with the search bar pre-filled.
- `warp://settings?widget=<widget_id>` — open scrolled to a specific setting.
- Sub-pages: `appearance`, `mcp` (with `?autoinstall=<name>`), `warp_agent`, `environments`, `platform`, `billing_and_usage`, and `teams` (with `?invite=<email>`).

Source of finding: `missing_docs` audit against the public `warpdotdev/warp` repo.

## Notes for reviewers
- Suggested owner: `@seemeroland` (`app/src/uri/` handling).

_Conversation: https://staging.warp.dev/conversation/242a5572-723f-4523-bae2-5d1afffac657_
_Run: https://oz.staging.warp.dev/runs/019f3e82-58b3-7bf1-8117-5d26b83d7fd7_

_This PR was generated with [Oz](https://warp.dev/oz)._
