### PR TITLE
Docs: fix duplicated Custom routers heading in model-choice

### DIFF
--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -131,9 +131,9 @@ To change models, click the displayed model name (for example, _Claude Sonnet 5_
 
 ### Custom routers
 
-Beyond the built-in Auto models, you can define your own custom routers that automatically pick a concrete model for each task, based on task complexity or rules you write. Custom routers appear in the model picker alongside Auto and individual models.
+Beyond the built-in Auto models, you can define your own custom routers that automatically route each task to a concrete model based on task complexity or rules you write. Custom routers appear in the model picker alongside Auto and individual models.
 
-See [Custom routers](/agent-platform/inference/custom-routers/) to create one.
+Add and manage custom routers in **Settings** > **AI** > **Custom Routers**. See [Custom routers](/agent-platform/inference/custom-routers/) for details on creating one.
 
 ### Model fallback
 
@@ -150,12 +150,6 @@ Warp uses a model fallback system to ensure uninterrupted service if your select
 You can configure the base model for each [Agent Profile](/agent-platform/capabilities/agent-profiles-permissions/), alongside the Agent's autonomy, tool access, and other permissions. The base model is also used for [Planning](/agent-platform/capabilities/planning/).
 
 Edit your default profile or any other profile directly in **Settings** > **Agents** > **Profiles**.
-
-### Custom routers
-
-Custom model routers automatically route each task to a specific model based on task complexity or rules you define, instead of using a single fixed model for every prompt. Your custom routers appear in the [model selector](#how-to-change-models) alongside Warp's built-in models.
-
-Add and manage custom routers in **Settings** > **AI** > **Custom Routers**.
 
 ### Zero data retention policies
 


### PR DESCRIPTION
## Summary

`agent-platform/inference/model-choice.mdx` contained **two identical `### Custom routers` sections**, which also produced a duplicate `#custom-routers` anchor. This merges them into a single section that describes custom routers, points to **Settings** > **AI** > **Custom Routers**, and links to the dedicated Custom routers page.

Source of finding: `missing_docs` audit against the public `warpdotdev/warp` repo. (Custom routers themselves are already documented; this only removes the duplicate.)

_Conversation: https://staging.warp.dev/conversation/242a5572-723f-4523-bae2-5d1afffac657_
_Run: https://oz.staging.warp.dev/runs/019f3e82-58b3-7bf1-8117-5d26b83d7fd7_

_This PR was generated with [Oz](https://warp.dev/oz)._
