### PR TITLE
missing_docs: map newly-GA tab features and refresh audit references

### DIFF
--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -134,6 +134,13 @@ ShellSelector -> src/content/docs/getting-started/supported-shells.mdx
 WorkflowAliases -> src/content/docs/terminal/entry/yaml-workflows.mdx
 KittyImages -> src/content/docs/terminal/more-features/full-screen-apps.mdx
 UndoClosedPanes -> src/content/docs/terminal/windows/tabs.mdx
+# Tab groups (organize tabs into named, collapsible groups) — GA (in the default
+# feature set). Pinning tab groups is still Preview (PinnedTabs), so it stays out
+# of the docs for now.
+GroupedTabs -> src/content/docs/terminal/windows/tabs.mdx
+# Drag a tab out to its own window or between windows. GA on macOS and Windows
+# (RELEASE_FLAGS, cfg-gated), documented with that platform caveat.
+DragTabsToWindows -> src/content/docs/terminal/windows/tabs.mdx
 RevertDiffHunk -> src/content/docs/code/code-review.mdx
 SshRemoteServer -> src/content/docs/terminal/warpify/ssh.mdx
 
@@ -313,6 +320,7 @@ DELETE /memory_stores/{uid} -> gated:AIMemories
 GET /memory_stores/{uid}/agents -> gated:AIMemories
 GET /memory_stores/{uid}/memories -> gated:AIMemories
 POST /memory_stores/{uid}/memories -> gated:AIMemories
+GET /memory_stores/{uid}/memories/{memoryUid} -> gated:AIMemories
 DELETE /memory_stores/{uid}/memories/{memoryUid} -> gated:AIMemories
 PUT /memory_stores/{uid}/memories/{memoryUid} -> gated:AIMemories
 GET /memory_stores/{uid}/memories/{memoryUid}/versions -> gated:AIMemories
@@ -334,6 +342,11 @@ GET /memory_stores/{uid}/memories/{memoryUid}/versions -> gated:AIMemories
 # One-time internal state for the deprecated tmux SSH wrapper migration banner;
 # not a user-configurable setting.
 warpify.ssh.ssh_tmux_deprecation_notice_pending -> internal
+
+# TUI-only (warp-tui) background auto-updater toggle (surface: TUI). It isn't
+# present in the GUI settings UI, so it isn't documented in the all-settings
+# reference.
+general.autoupdate_enabled -> internal
 
 ## Unlisted docs pages to ignore
 
@@ -449,10 +462,6 @@ OwnerOrchestrationAncestorStreamer
 # rollout status (the audit computes that from code); entries here are ignored
 # because the toggle itself isn't a documentable surface, or because the
 # feature isn't user-facing yet — the snapshot diff flags promotions.
-# Grouped Tabs is a macOS-only Preview feature (organize tabs into named,
-# collapsible groups); public docs are pending GA promotion, which the snapshot
-# diff will flag.
-GroupedTabs
 # Pinned Tabs is a Preview feature (pin individual tabs and whole tab groups to
 # the front of the tab list); public docs are pending GA promotion, which the
 # snapshot diff will flag.
@@ -476,7 +485,6 @@ CodeModeChip
 # Internal agent file-search tool plumbing (read tools are not individually documented).
 GrepTool
 NativeShellCompletions
-DragTabsToWindows
 SshDragAndDrop
 ITermImages
 AIGeneratedOnboardingSuggestions

--- a/.agents/skills/missing_docs/references/surface_snapshot.json
+++ b/.agents/skills/missing_docs/references/surface_snapshot.json
@@ -101,7 +101,7 @@
     "DiffSetAsContext": "ga",
     "DirectoryTabColors": "ga",
     "DiscardPerFileAndAllChanges": "ga",
-    "DragTabsToWindows": "preview",
+    "DragTabsToWindows": "ga",
     "DriveObjectsAsContext": "ga",
     "DynamicWorkflowEnums": "ga",
     "EditableMarkdownMermaid": "dogfood",
@@ -154,6 +154,7 @@
     "IntegratedGPU": "other",
     "IntegrationCommand": "ga",
     "InteractiveConversationManagementView": "ga",
+    "JupyterNotebookRendering": "dogfood",
     "KittyImages": "ga",
     "KittyKeyboardProtocol": "ga",
     "KnowledgeSidebar": "other",
@@ -269,6 +270,7 @@
     "ValidateAutosuggestions": "ga",
     "VerticalTabs": "ga",
     "VerticalTabsSummaryMode": "ga",
+    "VideoRecording": "dogfood",
     "ViewingSharedSessions": "ga",
     "VimCodeEditor": "ga",
     "WaitForEventsParentRegistration": "dogfood",
@@ -1019,6 +1021,7 @@
     "code.indexing.agent_mode_codebase_context": "always_on",
     "code.indexing.agent_mode_codebase_context_auto_indexing": "always_on",
     "experimental.async_find_enabled": "always_on",
+    "general.autoupdate_enabled": "always_on",
     "general.default_session_mode": "always_on",
     "general.default_tab_config_path": "always_on",
     "general.link_tooltip": "always_on",
@@ -1214,5 +1217,5 @@
     "verify-ui-change-in-cloud": "dogfood",
     "warpctrl": "bundled"
   },
-  "changelog_last_version": "2026.06.24"
+  "changelog_last_version": "2026.07.03"
 }


### PR DESCRIPTION
## Summary

Surface-map and snapshot maintenance for the `missing_docs` skill, split out from the doc-content PRs. These changes keep the audit honest but don't touch user-facing docs.

- **Map `GroupedTabs` and `DragTabsToWindows`** to `terminal/windows/tabs.mdx` and remove them from the ignore list. Both had gone GA (verified in `app/Cargo.toml` default features / `RELEASE_FLAGS`) but were **stale-ignored as "Preview,"** which is exactly why the coverage audit never flagged them.
- **Defer** the new `GET /memory_stores/{uid}/memories/{memoryUid}` endpoint as `gated:AIMemories` (Agent Memory is research preview, so it stays out of public docs).
- **Mark `general.autoupdate_enabled` internal** — it's a TUI-only (`warp-tui`) setting not present in the GUI settings UI, so it doesn't belong in the all-settings reference.
- **Refresh `surface_snapshot.json`** so future `--diff` runs baseline against current code surfaces.

This is the companion to the doc PRs:
- #297 (CLI agents), #298 (tab groups + drag-to-window), #299 (`warp://settings`), #300 (custom-routers heading fix).

The `GroupedTabs`/`DragTabsToWindows` mappings point at `tabs.mdx` (which already exists), so this PR is independently mergeable in any order relative to #298.

_Conversation: https://staging.warp.dev/conversation/242a5572-723f-4523-bae2-5d1afffac657_
_Run: https://oz.staging.warp.dev/runs/019f3e82-58b3-7bf1-8117-5d26b83d7fd7_

_This PR was generated with [Oz](https://warp.dev/oz)._
