### PR TITLE
Add Grok 4.5 to model choice docs

### DIFF
--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -96,6 +96,9 @@ Anthropic requires data retention for Claude Fable 5 for safety, abuse monitorin
 
 | Model | `model_id` | Reasoning Level |
 | --- | --- | --- |
+| Grok 4.5 | `grok-4-5-low` | Low |
+| Grok 4.5 | `grok-4-5-medium` | Medium |
+| Grok 4.5 | `grok-4-5-high` | High |
 | Grok 4.3 | `grok-4-3-low` | Low |
 | Grok 4.3 | `grok-4-3-medium` | Medium |
 | Grok 4.3 | `grok-4-3-high` | High |


### PR DESCRIPTION
## Summary
Adds **Grok 4.5** to the [Model choice](https://docs.warp.dev/agent-platform/inference/model-choice) page. Grok 4.5 shipped to production but was missing from the docs.

The three reasoning variants (`grok-4-5-low`, `grok-4-5-medium`, `grok-4-5-high`) are added to the **xAI** section, listed above Grok 4.3 to match the newest-first ordering the table uses elsewhere.

## Audit of other public models
I cross-referenced the docs against the production feature flags (`warp-server/config/prod.yaml`) and the server model-picker builder (`GetModelChoices` in `logic/ai/llm/model_choice.go`). **Grok 4.5 was the only publicly-enabled model missing from the docs.** Everything else that's absent is intentional:

- **Off in prod:** `grok_4`, `gemini_2_5_flash`, `gpt_5_6_sol` / `gpt_5_6_terra` / `gpt_5_6_luna` are all `false`; `gpt_5_mini` and `fireworks_gpt_oss_120b` are unset (default false).
- **Deprecated:** older Fireworks/GLM models (GLM 4.6/4.7/5.1, Kimi K2.5) are in the picker's `DeprecatedBaseModels` list.
- **Deliberate curation:** the Anthropic families (Claude Sonnet 5, Fable 5, Opus 4.8) show only default-effort-and-up variants in the docs, so their low/medium reasoning variants are omitted by design.

## Note
Only `model-choice.mdx` needed changes — the BYOK, SuperGrok subscription, and Agent FAQ pages all defer to this page for the model list.

_Conversation: https://staging.warp.dev/conversation/ba0c620b-c9c5-4534-b459-4e03963893f5_

_Run: https://oz.staging.warp.dev/runs/019f43d0-3519-7ce8-92ea-4ed59b4aad03_

_This PR was generated with [Oz](https://warp.dev/oz)._
