### PR TITLE
Add GPT-5.6 Sol/Terra/Luna to model choice docs

### DIFF
--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -32,6 +32,18 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 
 | Model | `model_id` | Reasoning Level |
 | --- | --- | --- |
+| GPT-5.6 Sol | `gpt-5-6-sol-low` | Low |
+| GPT-5.6 Sol | `gpt-5-6-sol-medium` | Medium |
+| GPT-5.6 Sol | `gpt-5-6-sol-high` | High |
+| GPT-5.6 Sol | `gpt-5-6-sol-xhigh` | Extra High |
+| GPT-5.6 Terra | `gpt-5-6-terra-low` | Low |
+| GPT-5.6 Terra | `gpt-5-6-terra-medium` | Medium |
+| GPT-5.6 Terra | `gpt-5-6-terra-high` | High |
+| GPT-5.6 Terra | `gpt-5-6-terra-xhigh` | Extra High |
+| GPT-5.6 Luna | `gpt-5-6-luna-low` | Low |
+| GPT-5.6 Luna | `gpt-5-6-luna-medium` | Medium |
+| GPT-5.6 Luna | `gpt-5-6-luna-high` | High |
+| GPT-5.6 Luna | `gpt-5-6-luna-xhigh` | Extra High |
 | GPT-5.5 | `gpt-5-5-low` | Low |
 | GPT-5.5 | `gpt-5-5-medium` | Medium |
 | GPT-5.5 | `gpt-5-5-high` | High |


### PR DESCRIPTION
## Summary
Adds **GPT-5.6 Sol**, **GPT-5.6 Terra**, and **GPT-5.6 Luna** to the OpenAI section of the [Model choice](https://docs.warp.dev/agent-platform/inference/model-choice) page. Each variant is listed with all four reasoning levels (Low, Medium, High, Extra High).

These models are now live in production but were missing from the docs.

## Audit
Verified against `warp-server`:
- **Prod flags** (`config/prod.yaml`): `gpt_5_6_sol`, `gpt_5_6_terra`, `gpt_5_6_luna` are all `true`.
- **Model IDs / reasoning levels** (`model/types/ai/types.go`): `gpt-5-6-{sol,terra,luna}-{low,medium,high,xhigh}`.
- **Display names & ordering** (`logic/ai/llm/model_choice.go`): base names `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna`; the picker builder adds them in Sol → Terra → Luna order.

Placed above GPT-5.5 to match the newest-first ordering used elsewhere in the table.

Also audited the rest of the public model set against the prod feature flags and the server model-picker builder: **no other publicly-enabled models are missing.** Models still absent are intentionally off in prod (e.g. `grok_4`, `gemini_2_5_flash`, `fireworks_gpt_oss_120b`) or deprecated, and the Anthropic low/medium reasoning variants are deliberately curated out.

Note: the curated web-search-capable list in `web-search.mdx` is maintained separately (it doesn't include GPT-5.5 either), so it was left unchanged.

## Validation
`npm run build` completes successfully (346 pages built).

_Conversation: https://staging.warp.dev/conversation/97bfce4d-979f-4973-9872-fdb06b5242c6_
_Run: https://oz.staging.warp.dev/runs/019f4838-8f56-7cc8-b2d9-4cd9a5b5219d_

_This PR was generated with [Oz](https://warp.dev/oz)._
