### PR TITLE
docs: audit bookkeeping (2026-07-10 drift-watch)

### DIFF
--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -355,6 +355,8 @@ general.autoupdate_enabled -> internal
 # Per the page's frontmatter comment: not in the Guides sidebar yet, pending
 # team feedback.
 guides/agent-workflows/warp-vs-claude-code
+# Astro's built-in 404 page; intentionally not part of the sidebar navigation.
+404
 
 ## Flags to ignore (internal-only, not user-facing)
 

--- a/.agents/skills/missing_docs/references/surface_snapshot.json
+++ b/.agents/skills/missing_docs/references/surface_snapshot.json
@@ -183,6 +183,7 @@
     "NamedAgents": "ga",
     "NativeShellCompletions": "other",
     "NewTabStyling": "ga",
+    "NldPromptHistoryMatch": "dogfood",
     "OpenCodeNotifications": "ga",
     "OpenWarpLaunchModal": "ga",
     "OpenWarpNewSettingsModes": "ga",
@@ -634,11 +635,14 @@
       "--agent",
       "--attach",
       "--base-model",
+      "--claude-auth-secret",
+      "--codex-auth-secret",
       "--computer-use",
       "--conversation",
       "--cwd",
       "--description",
       "--environment",
+      "--harness",
       "--host",
       "--mcp",
       "--mcp-startup-timeout",
@@ -825,6 +829,7 @@
     "POST /api/v1/agent/schedules/{id}/resume",
     "POST /api/v1/agent/tasks/{id}/cancel",
     "POST /api/v1/factory",
+    "POST /api/v1/factory/avatar",
     "POST /api/v1/harness-support/block-snapshot",
     "POST /api/v1/harness-support/external-conversation",
     "POST /api/v1/harness-support/finish-task",
@@ -913,6 +918,7 @@
     "agents.third_party.cli_agent_toolbar_enabled_commands": "always_on",
     "agents.third_party.should_render_cli_agent_toolbar": "always_on",
     "agents.third_party.submit_on_ctrl_enter": "always_on",
+    "agents.usage_display_mode": "always_on",
     "agents.voice.voice_input_enabled": "always_on",
     "agents.voice.voice_input_toggle_key": "always_on",
     "agents.warp_agent.active_ai.agent_mode_query_suggestions_enabled": "always_on",
@@ -1217,5 +1223,5 @@
     "verify-ui-change-in-cloud": "dogfood",
     "warpctrl": "bundled"
   },
-  "changelog_last_version": "2026.07.03"
+  "changelog_last_version": "2026.07.09"
 }


### PR DESCRIPTION
Audit bookkeeping for the `missing_docs` drift-watch run on 2026-07-10. Collects the surface-map and snapshot updates that accompany the sibling feature PRs, and records every deferred finding so nothing is silently dropped.

## What changed
- `feature_surface_map.md`: allowlisted the `404` page in the **Unlisted docs pages** section (Astro's built-in 404 page, intentionally not in the sidebar).
- `surface_snapshot.json`: regenerated with `--update-snapshot` to re-baseline change detection (captures the new `agent` CLI flags, the `agents.usage_display_mode` setting, the `NldPromptHistoryMatch` dogfood flag, and the `POST /api/v1/factory/avatar` route).

## Companion feature PRs
- oz agent run-cloud harness flags (`reference/cli/index.mdx`) — #322
- `agents.usage_display_mode` setting (`terminal/settings/all-settings.mdx`) — #323

## Deferred findings (not addressed in this run)

### API endpoints — 19 (route via sync-openapi-spec, not hand-documented)
warp-server is a private repo, and these endpoints are not in the released OpenAPI spec (`developers/agent-api-openapi.yaml`), so per the skill's public/private guardrail they are NOT hand-documented. Confirm release status and route released ones through the `sync-openapi-spec` skill, or map internal:
- `GET /agent/artifacts/{uid}`
- `GET /agent/events`, `GET /agent/events/stream`, `POST /agent/events/{run_id}`
- `POST /agent/messages`, `POST /agent/messages/{id}/delivered`, `POST /agent/messages/{id}/read`, `GET /agent/messages/{run_id}`
- `GET /agent/schedules/{id}`, `PUT /agent/schedules/{id}`, `DELETE /agent/schedules/{id}`, `POST /agent/schedules/{id}/pause`, `POST /agent/schedules/{id}/resume`
- `GET /factory`, `POST /factory`, `POST /factory/avatar`, `GET /factory/{uid}`, `PATCH /factory/{uid}`, `DELETE /factory/{uid}`

### Terminology / staleness — 32 (owned by the style_lint skill)
32 `potentially_stale_docs` findings (e.g. "warp ai", "ai credits", "agent-mode", "warp terminal", "oz agent") are pure wording issues. Per the skill, terminology/style enforcement is owned by `style_lint`, not `missing_docs`. Deferred to a `style_lint` sweep.

### No docs needed
- `NldPromptHistoryMatch` feature flag (dogfood) — tracked by the snapshot only; re-flags on promotion to GA.
- Changelog "verify" items (2026.07.09): cross-window tab dragging is already documented in `terminal/windows/tabs.mdx`; markdown editor syntax highlighting, "Copy file path" right-click, scrollable custom-inference model lists, and the heap-profile command palette action are minor polish with no dedicated doc surface.

## Validation
- Coverage re-run: `undocumented_settings`, `unlisted_pages`, `surface_changes`, and `changelog_review` all → 0. Remaining findings are the deferred API (19) and staleness (32) items above.
- `npm run build` succeeded (346 pages).

_Conversation: https://staging.warp.dev/conversation/693d79a7-7cf9-4a67-b070-2aeb15986da6_
_Run: https://oz.staging.warp.dev/runs/019f4cf8-d573-7793-af78-d05ffd29cfd5_

_This PR was generated with [Oz](https://warp.dev/oz)._
