### PR TITLE
docs: update team-managed keys demo video

### DIFF
--- a/src/content/docs/enterprise/enterprise-features/team-managed-keys-and-endpoints.mdx
+++ b/src/content/docs/enterprise/enterprise-features/team-managed-keys-and-endpoints.mdx
@@ -10,7 +10,7 @@ Warp lets an **Enterprise team admin** configure shared provider API keys and Op
 
 This gives your organization one place to provision approved model providers, control spend, and keep inference on your own accounts across your whole team.
 
-<VideoEmbed url="https://www.loom.com/share/fcc462503a524f52b5363feca8cf4cf7" title="Team-managed API keys and endpoints demo" />
+<VideoEmbed url="https://www.youtube.com/watch?v=Ko1rFyL1jfo" title="Team-managed API keys and endpoints demo" />
 
 :::note
 Team-managed API keys and endpoints are available only on Warp's Enterprise plan. [Contact sales](https://www.warp.dev/contact-sales) to learn more.


### PR DESCRIPTION
## Summary
Updates the demo video on the [Team-managed LLM API keys and endpoints](https://docs.warp.dev/enterprise/enterprise-features/team-managed-keys-and-endpoints) page, replacing the previous Loom demo (from Jaiden) with the new YouTube walkthrough.

## Change
- `src/content/docs/enterprise/enterprise-features/team-managed-keys-and-endpoints.mdx`: swap `VideoEmbed` URL from the Loom share link to `https://www.youtube.com/watch?v=Ko1rFyL1jfo`.

The `VideoEmbed` component already supports `youtube.com/watch?v=` URLs, so no component changes are needed.

_Conversation: https://staging.warp.dev/conversation/f82700b2-1051-4d56-b9e3-3cf0232354a7_
_Run: https://oz.staging.warp.dev/runs/019f4d60-0dd8-72f9-8188-7bd14e64e420_

_This PR was generated with [Oz](https://warp.dev/oz)._
