### PR TITLE
docs: document agents.usage_display_mode setting

### DIFF
--- a/src/content/docs/terminal/settings/all-settings.mdx
+++ b/src/content/docs/terminal/settings/all-settings.mdx
@@ -262,6 +262,7 @@ Settings for Warp's agents, including model behavior, permissions, knowledge, MC
 
 * `cloud_conversation_storage_enabled` — Whether conversations are stored in the cloud. Type: boolean. Default: `true`.
 * `model` — The default model for the Warp Agent in the terminal. The desktop app's Agent Mode selects its model through [agent profiles](/agent-platform/capabilities/agent-profiles-permissions/) instead, so this key applies only to the terminal agent's settings file. Type: string. Default: `"auto"` (defers to Warp's automatic model selection).
+* `usage_display_mode` — Which unit the terminal agent's usage entry displays. Click the usage entry to flip between the two units. Like `model`, this key applies only to the terminal agent's settings file. Type: string. Default: `"credits"`. Options: `"credits"` (credits spent, matching the desktop app's usage footer), `"cost"` (provider dollar cost).
 
 ### Knowledge
 


### PR DESCRIPTION
## Summary
Documents the `agents.usage_display_mode` setting in the all-settings reference. Surfaced by the `missing_docs` drift-watch audit as an undocumented GA setting.

The setting controls which unit the terminal (TUI) agent's usage entry displays — credits spent (default) or provider dollar cost — and is flipped by clicking the entry. It's modeled like the existing `agents.model` key: a TUI-only, file-backed setting, so it's documented in the same `[agents]` section.

Source: `warp:app/src/settings/ai.rs` (`TuiUsageDisplayMode`, `toml_path: "agents.usage_display_mode"`).

## Validation
- `npm run build` passes.
- Re-ran the audit; this finding is resolved.

_Conversation: https://staging.warp.dev/conversation/0ee78198-1342-4558-b918-b484f4655005_
_Run: https://oz.staging.warp.dev/runs/019f5c6b-ee12-75f1-a353-e0ef6e3edd4f_

_This PR was generated with [Oz](https://warp.dev/oz)._
