### PR TITLE
docs: document harness flags on oz agent run-cloud

### DIFF
--- a/src/content/docs/reference/cli/index.mdx
+++ b/src/content/docs/reference/cli/index.mdx
@@ -270,7 +270,21 @@ oz agent run-cloud \
 * `--host <WORKER_ID>` — run on a specific self-hosted worker instead of Warp-hosted infrastructure.
 * `--attach <PATH>` — attach an image file to the agent query. Can be repeated (maximum 5).
 * `--computer-use` / `--no-computer-use` — enable or disable [Computer Use](/agent-platform/capabilities/computer-use/) for this run.
+* `--harness <HARNESS>` — choose the execution harness for the run. Defaults to `oz` (Warp Agent). Set `claude` or `codex` to run [Claude Code or Codex as a cloud agent](/platform/harnesses/).
+* `--claude-auth-secret <NAME>` — name of the [Warp-managed secret](/platform/secrets/) that authenticates the Claude Code harness. Only valid with `--harness claude`. See [Third-party cloud agent authentication](/platform/harnesses/authentication/).
+* `--codex-auth-secret <NAME>` — name of the [Warp-managed secret](/platform/secrets/) that authenticates the Codex harness. Only valid with `--harness codex`. See [Third-party cloud agent authentication](/platform/harnesses/authentication/).
 * `--file <PATH>` (`-f`) — load run configuration from a YAML or JSON file.
+
+To run a third-party harness, first store the provider credential as a Warp-managed secret, then pass it with the matching flag:
+
+```sh
+# Run Claude Code as a cloud agent, authenticating with a stored Anthropic secret
+oz agent run-cloud \
+  --environment <ENVIRONMENT_ID> \
+  --harness claude \
+  --claude-auth-secret ANTHROPIC_API_KEY \
+  --prompt "Review the latest PR and suggest fixes"
+```
 
 **Key differences from `run`**
 


### PR DESCRIPTION
## Summary
Documents the third-party harness flags on `oz agent run-cloud` in the CLI reference. Surfaced by the `missing_docs` drift-watch audit (new CLI flags since last snapshot).

The harnesses feature (running Claude Code or Codex as cloud agents) is GA and documented under `platform/harnesses/`, but the CLI reference didn't cover launching a harness run from the Oz CLI. This adds:

- `--harness <HARNESS>` — choose the execution harness (`oz` default, `claude`, `codex`).
- `--claude-auth-secret <NAME>` — Warp-managed secret for the Claude Code harness (only valid with `--harness claude`).
- `--codex-auth-secret <NAME>` — Warp-managed secret for the Codex harness (only valid with `--harness codex`).

Plus a worked example and cross-links to the harness authentication and secrets docs.

Source: `warp:crates/warp_cli/src/agent.rs` (`RunCloudArgs`, `Harness`).

## Validation
- `npm run build` passes.

_Conversation: https://staging.warp.dev/conversation/0ee78198-1342-4558-b918-b484f4655005_
_Run: https://oz.staging.warp.dev/runs/019f5c6b-ee12-75f1-a353-e0ef6e3edd4f_

_This PR was generated with [Oz](https://warp.dev/oz)._
