### PR TITLE
docs(audit): refresh missing_docs surface map and snapshot

### DIFF
--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -355,6 +355,13 @@ general.autoupdate_enabled -> internal
 # Per the page's frontmatter comment: not in the Guides sidebar yet, pending
 # team feedback.
 guides/agent-workflows/warp-vs-claude-code
+# Custom Starlight 404 page (template: splash). Starlight renders it through its
+# own prerendered /404 route, so it is intentionally not in the sidebar.
+404
+# Jira integration page is draft: true (private beta — the Oz Jira app is not yet
+# published to the Atlassian marketplace). Kept out of the sidebar until the
+# integration goes GA; the snapshot diff will flag it for docs on promotion.
+platform/integrations/jira
 
 ## Flags to ignore (internal-only, not user-facing)
 

--- a/.agents/skills/missing_docs/references/surface_snapshot.json
+++ b/.agents/skills/missing_docs/references/surface_snapshot.json
@@ -183,6 +183,7 @@
     "NamedAgents": "ga",
     "NativeShellCompletions": "other",
     "NewTabStyling": "ga",
+    "NldPromptHistoryMatch": "dogfood",
     "OpenCodeNotifications": "ga",
     "OpenWarpLaunchModal": "ga",
     "OpenWarpNewSettingsModes": "ga",
@@ -634,11 +635,14 @@
       "--agent",
       "--attach",
       "--base-model",
+      "--claude-auth-secret",
+      "--codex-auth-secret",
       "--computer-use",
       "--conversation",
       "--cwd",
       "--description",
       "--environment",
+      "--harness",
       "--host",
       "--mcp",
       "--mcp-startup-timeout",
@@ -825,6 +829,7 @@
     "POST /api/v1/agent/schedules/{id}/resume",
     "POST /api/v1/agent/tasks/{id}/cancel",
     "POST /api/v1/factory",
+    "POST /api/v1/factory/avatar",
     "POST /api/v1/harness-support/block-snapshot",
     "POST /api/v1/harness-support/external-conversation",
     "POST /api/v1/harness-support/finish-task",
@@ -913,6 +918,7 @@
     "agents.third_party.cli_agent_toolbar_enabled_commands": "always_on",
     "agents.third_party.should_render_cli_agent_toolbar": "always_on",
     "agents.third_party.submit_on_ctrl_enter": "always_on",
+    "agents.usage_display_mode": "always_on",
     "agents.voice.voice_input_enabled": "always_on",
     "agents.voice.voice_input_toggle_key": "always_on",
     "agents.warp_agent.active_ai.agent_mode_query_suggestions_enabled": "always_on",
@@ -1217,5 +1223,5 @@
     "verify-ui-change-in-cloud": "dogfood",
     "warpctrl": "bundled"
   },
-  "changelog_last_version": "2026.07.03"
+  "changelog_last_version": "2026.07.09"
 }


### PR DESCRIPTION
## Summary
Companion audit-bookkeeping PR for the `missing_docs` drift-watch run. Collects the shared surface-map and snapshot changes so they don't conflict across the feature PRs.

- **Surface map**: allowlist two intentionally unlisted pages in the "Unlisted docs pages" section:
  - `404` — the custom Starlight 404 page (`template: splash`), rendered through Starlight's own `/404` route, so it's intentionally not in the sidebar.
  - `platform/integrations/jira` — the Jira integration page is `draft: true` (private beta; the Oz Jira app isn't published to the Atlassian marketplace yet). Kept out of the sidebar until GA; the snapshot diff will re-flag it on promotion.
- **Snapshot**: regenerated via `--update-snapshot`. Advances the changelog baseline to `2026.07.09` and records the new `agents.usage_display_mode` setting, the `oz agent run-cloud` harness flags, the `NldPromptHistoryMatch` dogfood flag, and the `POST /factory/avatar` route.

## Findings addressed in sibling PRs
- `agents.usage_display_mode` setting → #330
- `oz agent run-cloud` harness flags (`--harness`, `--claude-auth-secret`, `--codex-auth-secret`) → #331

## Deferred findings (nothing silently dropped)
**API endpoints — deferred to the `sync-openapi-spec` skill (kept separate per policy).** warp-server is private; these 19 public-API routes are not in the released OpenAPI spec, so they must not be hand-documented. Route released ones through `sync-openapi-spec`; map the rest internal after confirming status:
- `GET /agent/artifacts/{uid}`
- `GET /agent/events`, `GET /agent/events/stream`, `POST /agent/events/{run_id}`
- `POST /agent/messages`, `GET /agent/messages/{run_id}`, `POST /agent/messages/{id}/read`, `POST /agent/messages/{id}/delivered`
- `GET|PUT|DELETE /agent/schedules/{id}`, `POST /agent/schedules/{id}/pause`, `POST /agent/schedules/{id}/resume`
- `GET|POST /factory`, `GET|PATCH|DELETE /factory/{uid}`, `POST /factory/avatar`

**Terminology / staleness (32 low-severity findings) — deferred to the `style_lint` skill**, which owns terminology and style enforcement (e.g. "warp ai", "ai credits", "agent-mode", "warp terminal", "ambient agent" phrasings across ~32 pages).

**Changelog items (verified, no dedicated docs needed):**
- Cross-window tab dragging re-enabled (#13411) — already documented in `terminal/windows/tabs.mdx` ("Move a tab to another window").
- Markdown syntax highlighting in the editor (#13034), "Copy file path" in the file viewer menu (#13145), scrollable custom-inference model lists (#12647), and the heap-profile command palette action (#13107) — minor UI polish covered by the changelog; no dedicated docs warranted.

**Snapshot-only:** `NldPromptHistoryMatch` (dogfood) — tracked only; no docs until promotion.

## Validation
- Audit re-run: addressed coverage findings resolved; remaining findings are the deferred API + terminology items above.
- `npm run build` passes on the combined tree.

_Conversation: https://staging.warp.dev/conversation/0ee78198-1342-4558-b918-b484f4655005_
_Run: https://oz.staging.warp.dev/runs/019f5c6b-ee12-75f1-a353-e0ef6e3edd4f_

_This PR was generated with [Oz](https://warp.dev/oz)._
