### PR TITLE
docs: clarify how Grok subscription usage counts against xAI's shared pool

### DIFF
--- a/src/content/docs/agent-platform/inference/grok-subscription.mdx
+++ b/src/content/docs/agent-platform/inference/grok-subscription.mdx
@@ -2,10 +2,11 @@
 title: SuperGrok subscription
 description: >-
   Connect your SuperGrok subscription to Warp and use Grok models through
-  your xAI account instead of Warp credits.
+  your xAI account instead of Warp credits. Usage draws from the same shared
+  weekly pool as xAI's other Grok products, including Grok Build.
 ---
 
-Warp lets you connect your **SuperGrok subscription** to use Grok models in Warp's agents through your xAI account. If you already subscribe to Grok, you can run Grok models in Warp without consuming your Warp [credits](/support-and-community/plans-and-billing/credits/).
+Warp lets you connect your **SuperGrok subscription** to use Grok models in Warp's agents through your xAI account. If you already subscribe to Grok, you can run Grok models in Warp without consuming your Warp [credits](/support-and-community/plans-and-billing/credits/). X Premium subscriptions that include Grok access work the same way: the connection signs in to your xAI account, and xAI determines which subscription tiers are eligible and how much usage they include.
 
 Connecting a subscription works like [Bring Your Own API Key (BYOK)](/agent-platform/inference/bring-your-own-api-key/), except you sign in to your xAI account instead of pasting an API key. There is no xAI API key field in Warp today — the subscription is the way to bring your own Grok access.
 
@@ -25,7 +26,7 @@ When you send a prompt with a Grok model selected and a subscription connected:
 
 Your token passes through Warp's servers on each request but is used only in-flight to call xAI, then discarded — the same model as [BYOK](/agent-platform/inference/bring-your-own-api-key/#how-byok-works).
 
-Once connected, supported Grok models show a **key icon** in the model picker, indicating requests will route through your xAI account. Usage and rate limits for these requests are governed by your SuperGrok subscription with xAI.
+Once connected, supported Grok models show a **key icon** in the model picker, indicating requests will route through your xAI account. Usage and rate limits for these requests are governed by your xAI subscription — see [How usage counts against your xAI subscription](#how-usage-counts-against-your-xai-subscription).
 
 ## Connecting your SuperGrok subscription
 
@@ -41,6 +42,14 @@ When a Grok model with the key icon is selected:
 * Warp **does not consume** any of your [credits](/support-and-community/plans-and-billing/credits/) for the request.
 * Inference runs through your xAI account, within your SuperGrok subscription's usage limits.
 * If a request fails because your subscription hits a limit, Warp does not retry with Warp credits unless you enable **Warp credit fallback** in the same settings section. See [failover and fallback behavior](/agent-platform/inference/bring-your-own-api-key/#failover-and-fallback-behavior).
+
+### How usage counts against your xAI subscription
+
+xAI gives every paid Grok subscription one weekly usage pool that is shared across all Grok products — Grok chat, [Grok Build](https://docs.x.ai/build/overview) (xAI's own coding agent), and API access all draw down the same pool. Requests you send from Warp draw from that same shared pool.
+
+In xAI's usage dashboard (**Settings** > **Usage** on grok.com), requests from Warp appear under the **API** product label because Warp calls xAI's API on your behalf. The label only describes how the usage reached xAI, not a separate quota: API and Grok Build usage share the same pool, so you get the same amount of usage running Grok models in Warp as you would using Grok Build directly.
+
+When you use up your weekly pool, xAI pauses paid usage until the reset time shown in its Usage tab. Extra usage credits and plan upgrades for the pool are managed through your xAI account, not Warp.
 
 ### Auto models
 

--- a/src/content/docs/agent-platform/inference/grok-subscription.mdx
+++ b/src/content/docs/agent-platform/inference/grok-subscription.mdx
@@ -1,12 +1,12 @@
 ---
 title: SuperGrok subscription
 description: >-
-  Connect your SuperGrok subscription to Warp and use Grok models through
-  your xAI account instead of Warp credits. Usage draws from the same shared
-  weekly pool as xAI's other Grok products, including Grok Build.
+  Connect your SuperGrok or X Premium subscription to use Grok models in
+  Warp through your xAI account. Usage draws from the same weekly pool as
+  Grok Build.
 ---
 
-Warp lets you connect your **SuperGrok subscription** to use Grok models in Warp's agents through your xAI account. If you already subscribe to Grok, you can run Grok models in Warp without consuming your Warp [credits](/support-and-community/plans-and-billing/credits/). X Premium subscriptions that include Grok access work the same way: the connection signs in to your xAI account, and xAI determines which subscription tiers are eligible and how much usage they include.
+Warp lets you connect your **SuperGrok subscription** to use Grok models in Warp's agents through your xAI account. If you already subscribe to Grok, you can run Grok models in Warp without consuming your Warp [credits](/support-and-community/plans-and-billing/credits/). X Premium subscriptions that include Grok access work the same way: you sign in to your xAI account, and xAI determines which subscription tiers are eligible and how much usage they include.
 
 Connecting a subscription works like [Bring Your Own API Key (BYOK)](/agent-platform/inference/bring-your-own-api-key/), except you sign in to your xAI account instead of pasting an API key. There is no xAI API key field in Warp today — the subscription is the way to bring your own Grok access.
 
@@ -40,16 +40,16 @@ Once connected, supported Grok models show a **key icon** in the model picker, i
 When a Grok model with the key icon is selected:
 
 * Warp **does not consume** any of your [credits](/support-and-community/plans-and-billing/credits/) for the request.
-* Inference runs through your xAI account, within your SuperGrok subscription's usage limits.
+* Inference runs through your xAI account, within your xAI subscription's usage limits.
 * If a request fails because your subscription hits a limit, Warp does not retry with Warp credits unless you enable **Warp credit fallback** in the same settings section. See [failover and fallback behavior](/agent-platform/inference/bring-your-own-api-key/#failover-and-fallback-behavior).
 
 ### How usage counts against your xAI subscription
 
-xAI gives every paid Grok subscription one weekly usage pool that is shared across all Grok products — Grok chat, [Grok Build](https://docs.x.ai/build/overview) (xAI's own coding agent), and API access all draw down the same pool. Requests you send from Warp draw from that same shared pool.
+xAI gives every paid Grok subscription one weekly usage pool that is shared across all Grok products — Grok chat, [Grok Build](https://docs.x.ai/build/overview) (xAI's own coding agent), and API access all draw down the same pool. Requests you send from Warp count against that same pool.
 
-In xAI's usage dashboard (**Settings** > **Usage** on grok.com), requests from Warp appear under the **API** product label because Warp calls xAI's API on your behalf. The label only describes how the usage reached xAI, not a separate quota: API and Grok Build usage share the same pool, so you get the same amount of usage running Grok models in Warp as you would using Grok Build directly.
+In xAI's usage dashboard (**Settings** > **Usage** on grok.com), requests from Warp appear under the **API** product label because Warp calls xAI's API on your behalf. The label reflects where the usage came from, not a separate quota: API and Grok Build usage share the same pool, so you get the same amount of usage running Grok models in Warp as you would using Grok Build directly.
 
-When you use up your weekly pool, xAI pauses paid usage until the reset time shown in its Usage tab. Extra usage credits and plan upgrades for the pool are managed through your xAI account, not Warp.
+When you use up your weekly pool, xAI pauses paid usage until the reset time shown in its Usage tab. Extra Usage Credits and plan upgrades for the pool are managed through your xAI account, not Warp.
 
 ### Auto models
 


### PR DESCRIPTION
## Summary
Clarifies how usage is counted on xAI's side when a SuperGrok (or X Premium) subscription is connected to Warp. Users saw their Warp usage labeled "API" in xAI's usage dashboard and assumed it drained a separate, faster-burning quota than xAI's own Grok Build. xAI confirmed (Slack, Jul 9–10) that the API vs. Build labels are a per-product breakdown of one shared weekly quota bucket — you get the same usage in Warp as you would in Grok Build.

## Changes

### src/content/docs/agent-platform/inference/grok-subscription.mdx
- Added a **How usage counts against your xAI subscription** subsection under "Usage and billing behavior": Warp requests draw from xAI's single shared weekly usage pool; the **API** label in xAI's usage dashboard describes where usage came from, not a separate quota; usage in Warp matches Grok Build; xAI pauses paid usage at the weekly limit until the reset time, with top-ups managed through xAI.
- Updated the "How it works" rate-limits sentence to link to the new subsection.
- Mentioned X Premium subscriptions with Grok access in the intro, for consistency with the four pages that link here as "SuperGrok or X Premium subscription" (eligibility hedged as determined by xAI).
- Extended the frontmatter description to cover the shared-pool behavior.

## Additional context
- Source: internal Slack thread (fa-app / ext-warp-xai, Jul 9–10) where xAI confirmed the shared quota bucket; corroborated by xAI's public FAQ (one weekly usage pool across API, Build, Chat, Imagine, Voice).
- Validation: `npm run build` (347 pages), `style_lint --changed` (0 issues), internal link check (0 broken links).

_Conversation: https://staging.warp.dev/conversation/9f5a7db4-f0cb-4698-9e4c-df3233e6e5a6_
_Run: https://oz.staging.warp.dev/runs/019f5c6f-cb8b-7ed0-8942-81c294125a96_
_Plans:_
- _[Clarify xAI subscription usage semantics in Grok docs](https://staging.warp.dev/drive/notebook/EeOOp0aNb80eLGLXWFk0Fi)_

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
