### PR TITLE
docs: fix downgrade billing cycle FAQ answer

### DIFF
--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -88,8 +88,10 @@ You can use your Warp account on multiple personal computers. Warp is designed t
 
 ### What happens when I downgrade during a billing cycle?
 
-The subscription will downgrade to the lower plan limits at the end of the billing cycle. If you’re switching between paid plans, any AI usage you've already accumulated will carry over.\
-\
+Downgrades take effect immediately. Warp issues an account balance for the prorated difference based on the time remaining in your billing cycle, not on unused monthly AI credits. You can apply that balance toward future subscription payments or AI credit purchases. The account balance amount is visible in the billing portal invoice history.
+
+Any credits you've already used in the current cycle carry over to the lower plan. If your usage has already exceeded the lower plan's monthly limit, you won't receive more AI credits until your next billing cycle.
+
 You can downgrade at any point throughout your subscription through the billing portal by going to **Settings** > **Billing and usage** > **Manage billing**.
 
 ### What happens when I cancel during a billing cycle?

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -90,7 +90,7 @@ You can use your Warp account on multiple personal computers. Warp is designed t
 
 Downgrades take effect immediately. Warp issues an account balance for the prorated difference based on the time remaining in your billing cycle, not on unused monthly AI credits. You can apply that balance toward future subscription payments or AI credit purchases. The account balance amount is visible in the billing portal invoice history.
 
-Any credits you've already used in the current cycle carry over to the lower plan. If your usage has already exceeded the lower plan's monthly limit, you won't receive more AI credits until your next billing cycle.
+Any AI credits you've already used in the current cycle count against the lower plan's monthly limit. If your usage has already exceeded that limit, you won't receive more AI credits until your next billing cycle.
 
 You can downgrade at any point throughout your subscription through the billing portal by going to **Settings** > **Billing and usage** > **Manage billing**.
 


### PR DESCRIPTION
## Summary

Fixes incorrect information in the "What happens when I downgrade during a billing cycle?" FAQ entry on the pricing FAQs page.

## Changes

### `src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx`

- Corrected that downgrades take effect **immediately** (the old copy said "at the end of the billing cycle")
- Clarified that the prorated Stripe balance credit is based on **time remaining in the cycle**, not unused monthly credits
- Added that the balance can be applied to future subscription payments or credit purchases, and is visible in the billing portal invoice history
- Added that already-used credits carry over to the lower plan, and if usage has already exceeded the lower plan's monthly limit, new credits won't arrive until the next billing cycle

Co-Authored-By: Oz <oz-agent@warp.dev>
