### PR TITLE
docs: publish Jira integration page with self-serve setup flow

### DIFF
--- a/src/content/docs/platform/integrations/index.mdx
+++ b/src/content/docs/platform/integrations/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 import VideoEmbed from '@components/VideoEmbed.astro';
 
-Warp integrations let your team trigger agents directly from the terminal, or from tools like [Slack](/platform/integrations/slack/) and [Linear](/platform/integrations/linear/). Once set up, agents can:
+Warp integrations let your team trigger agents directly from the terminal, or from tools like [Slack](/platform/integrations/slack/), [Linear](/platform/integrations/linear/), and [Jira](/platform/integrations/jira/). Once set up, agents can:
 
 * Read conversation or issue context
 * Run code inside your codebase in a remote environment
@@ -31,7 +31,7 @@ Use the setup walkthrough below for a quick look at how environments connect to 
 
 * [Integrations quickstart](/platform/integrations/quickstart/) - Trigger your first agent from Slack and watch the run from start to finish.
 * [Integration setup](/reference/cli/integration-setup/) - Configure environments, GitHub authorization, CLI flags, and integrations in more detail.
-* [Slack](/platform/integrations/slack/) and [Linear](/platform/integrations/linear/) - Trigger agents from team conversations, issues, and comments.
+* [Slack](/platform/integrations/slack/), [Linear](/platform/integrations/linear/), and [Jira](/platform/integrations/jira/) - Trigger agents from team conversations, issues, and comments.
 * [GitHub Actions](/platform/integrations/github-actions/) - Run agents from CI workflows and repository events.
 * [GitLab](/platform/integrations/gitlab/), [Bitbucket](/platform/integrations/bitbucket/), and [Azure DevOps](/platform/integrations/azure-devops/) - Connect non-GitHub repositories with tokens and Warp-managed secrets.
 * [AWS, GCP, and other cloud providers](/platform/integrations/cloud-providers/) - Give cloud agents short-lived access to cloud services.

--- a/src/content/docs/platform/integrations/jira.mdx
+++ b/src/content/docs/platform/integrations/jira.mdx
@@ -37,10 +37,10 @@ In your Jira site, open **Manage apps**. Find Oz, open its three-dot actions men
 The configuration page URL for the production app follows this pattern:
 
 ```text
-https://<your-site-id>.atlassian.net/jira/settings/apps/configure/40dbc167-16d9-4b68-9752-277c5a52aa01/34808a52-a321-44c2-bac4-a15eb316df50/static/warp-jira-configure/34808a52-a321-44c2-bac4-a15eb316df50
+https://<your-site-subdomain>.atlassian.net/jira/settings/apps/configure/40dbc167-16d9-4b68-9752-277c5a52aa01/34808a52-a321-44c2-bac4-a15eb316df50/static/warp-jira-configure/34808a52-a321-44c2-bac4-a15eb316df50
 ```
 
-Replace `<your-site-id>` with your Jira Cloud site ID.
+Replace `<your-site-subdomain>` with your Jira Cloud site subdomain.
 
 #### 4. Connect Jira to your Warp workspace
 
@@ -67,7 +67,7 @@ The first time you trigger a run, Oz posts a comment prompting you to connect yo
 1. Follow the link in the comment to open the Warp page in your Jira personal settings. The link for the production app follows this pattern:
 
    ```text
-   https://<your-site-id>.atlassian.net/jira/settings/personal/apps/40dbc167-16d9-4b68-9752-277c5a52aa01/34808a52-a321-44c2-bac4-a15eb316df50
+   https://<your-site-subdomain>.atlassian.net/jira/settings/personal/apps/40dbc167-16d9-4b68-9752-277c5a52aa01/34808a52-a321-44c2-bac4-a15eb316df50
    ```
 
 2. Click **Connect to Warp**. A Warp page opens and links your account automatically. Sign in to Warp first if prompted.

--- a/src/content/docs/platform/integrations/jira.mdx
+++ b/src/content/docs/platform/integrations/jira.mdx
@@ -1,6 +1,5 @@
 ---
 title: Jira integration
-draft: true
 sidebar:
   label: "Jira"
 description: >-
@@ -23,19 +22,35 @@ The Jira integration lets your team kick off cloud agent runs directly from Jira
 
 ### Setup
 
-#### 1. Install the Oz app in Jira
+#### 1. Open the Jira app installation page
 
-The Oz app is not yet published to the Atlassian marketplace. Install the Oz app into your Jira Cloud site using the link provided by your Warp contact. Only Jira site admins can install apps.
+In the [Oz web app](https://oz.warp.dev/integrations), find Jira and click **Set up**. On the Atlassian installation page, click **Get app**.
 
-#### 2. Connect your Jira site to Warp
+#### 2. Install Oz on your Jira site
 
-After installing the app, open the app's **Configure** screen inside Jira. This takes you to a Warp page to connect your app installation to your Warp workspace.
+Choose the Jira Cloud site you want to connect, review the requested permissions, and install Oz. Only Jira site admins can install apps.
 
-Once connected, the integration is active for all members of your Warp team.
+#### 3. Open the Oz configuration page
 
-#### 3. (Optional) Configure the default environment, model, and harness
+In your Jira site, open **Manage apps**. Find Oz, open its three-dot actions menu, then click **Configure**.
 
-In the [Oz web app](https://oz.warp.dev/integrations), open your Jira integration to set the default [environment](/platform/environments/), model, and harness Oz uses for Jira-triggered runs. If you don't set these, Oz uses your team's default configuration.
+The configuration page URL for the production app follows this pattern:
+
+```text
+https://<your-site-id>.atlassian.net/jira/settings/apps/configure/40dbc167-16d9-4b68-9752-277c5a52aa01/34808a52-a321-44c2-bac4-a15eb316df50/static/warp-jira-configure/34808a52-a321-44c2-bac4-a15eb316df50
+```
+
+Replace `<your-site-id>` with your Jira Cloud site ID.
+
+#### 4. Connect Jira to your Warp workspace
+
+On the Oz configuration page in Jira, click **Connect to Warp**. Sign in to Warp if prompted. Warp automatically binds the Jira installation to your Warp workspace.
+
+The confirmation page displays **Jira connected** when the connection succeeds. Jira-triggered runs are now available to members of the connected Warp workspace.
+
+#### 5. (Optional) Configure the default environment, model, and harness
+
+Return to the [Integrations page in the Oz web app](https://oz.warp.dev/integrations), then click **Edit Jira** to set the default [environment](/platform/environments/), model, harness, and agent for Jira-triggered runs. If you don't change these settings, Oz uses your workspace's default configuration.
 
 ---
 
@@ -44,6 +59,20 @@ In the [Oz web app](https://oz.warp.dev/integrations), open your Jira integratio
 Add the label **`oz-agent`** to any Jira issue. Oz will pick it up, post a comment to let you know it's started, and begin working through the task using the issue title, description, and recent comments as context.
 
 When the run finishes, Oz posts a summary comment to the issue with links to any pull requests or branches it created, along with a link to the full conversation in Warp. To track runs across your team, open the [Agent Management Panel](/platform/managing-cloud-agents/) in the Warp app, where Jira-triggered runs appear in the **All** tab.
+
+#### Connecting your Jira account to Warp
+
+The first time you trigger a run, Oz posts a comment prompting you to connect your Jira account to Warp. Connecting attributes your Jira-triggered runs to your Warp account; the run starts either way.
+
+1. Follow the link in the comment to open the Warp page in your Jira personal settings. The link for the production app follows this pattern:
+
+   ```text
+   https://<your-site-id>.atlassian.net/jira/settings/personal/apps/40dbc167-16d9-4b68-9752-277c5a52aa01/34808a52-a321-44c2-bac4-a15eb316df50
+   ```
+
+2. Click **Connect to Warp**. A Warp page opens and links your account automatically. Sign in to Warp first if prompted.
+
+The page displays **Jira account connected** when the link succeeds, and the settings page shows a **Connected to Warp** badge. Runs you trigger from then on are attributed to you.
 
 ---
 
@@ -54,11 +83,8 @@ If Oz doesn't respond after adding the label, check that:
 * The Oz app is installed and the workspace is connected (see the app's **Configure** screen in Jira).
 * The issue is in Jira Cloud (not Server or Data Center).
 
-:::tip
-When a Jira-triggered run can't start, Oz posts an error comment on the issue. Common codes:
-
-* [`feature_not_available`](/reference/api-and-sdk/troubleshooting/errors/feature-not-available/) - your plan doesn't support integrations.
-* [`integration_disabled`](/reference/api-and-sdk/troubleshooting/errors/integration-disabled/) - the integration was removed or disabled.
+:::note
+When a Jira-triggered run fails to start, Oz updates its comment on the issue to say it could not start the task. Re-add the `oz-agent` label to try again; a new attempt starts a new comment thread.
 :::
 
 For other issues, reach out to your Warp contact or join the [Warp community on Slack](https://go.warp.dev/join-preview).

--- a/src/content/docs/platform/integrations/jira.mdx
+++ b/src/content/docs/platform/integrations/jira.mdx
@@ -3,10 +3,10 @@ title: Jira integration
 sidebar:
   label: "Jira"
 description: >-
-  Trigger cloud agent runs directly from Jira issues using the oz-agent label.
+  Trigger cloud agent runs directly from Jira issues using the warp-agent label.
 ---
 
-The Jira integration lets your team kick off cloud agent runs directly from Jira Cloud issues. When you add the `oz-agent` label to an issue, an agent starts in the cloud and gets to work — then posts status updates and a summary back as Jira comments when it's done.
+The Jira integration lets your team kick off cloud agent runs directly from Jira Cloud issues. When you add the `warp-agent` label to an issue, an agent starts in the cloud and gets to work — then posts status updates and a summary as Jira comments when it's done.
 
 ---
 
@@ -44,9 +44,9 @@ Replace `<your-site-subdomain>` with your Jira Cloud site subdomain.
 
 #### 4. Connect Jira to your Warp workspace
 
-On the Oz configuration page in Jira, click **Connect to Warp**. Sign in to Warp if prompted. Warp automatically binds the Jira installation to your Warp workspace.
+On the app configuration page in Jira, click **Connect to Warp**. Sign in to Warp if prompted. Warp automatically binds the Jira installation to your Warp workspace.
 
-The confirmation page displays **Jira connected** when the connection succeeds. Jira-triggered runs are now available to members of the connected Warp workspace.
+The confirmation page displays **Jira connected** when the connection succeeds. Jira-triggered runs are now available to members of the connected Warp workspace. Installing the app doesn't require any action from individual teammates up front — each member connects their own Jira account to Warp the first time they trigger a run (see [Connecting your Jira account to Warp](#connecting-your-jira-account-to-warp)).
 
 #### 5. (Optional) Configure the default environment, model, and harness
 
@@ -56,13 +56,13 @@ Return to the [Integrations page in the Oz web app](https://oz.warp.dev/integrat
 
 ### How to start a run
 
-Add the label **`oz-agent`** to any Jira issue. Oz will pick it up, post a comment to let you know it's started, and begin working through the task using the issue title, description, and recent comments as context.
+Add the label **`warp-agent`** to any Jira issue. Oz will pick it up, post a comment to let you know it's started, and begin working through the task using the issue title, description, and recent comments as context.
 
 When the run finishes, Oz posts a summary comment to the issue with links to any pull requests or branches it created, along with a link to the full conversation in Warp. To track runs across your team, open the [Agent Management Panel](/platform/managing-cloud-agents/) in the Warp app, where Jira-triggered runs appear in the **All** tab.
 
 #### Connecting your Jira account to Warp
 
-The first time you trigger a run, Oz posts a comment prompting you to connect your Jira account to Warp. Connecting attributes your Jira-triggered runs to your Warp account; the run starts either way.
+This step is for any user who triggers runs — it doesn't require Jira admin permissions. The first time you trigger a run, Oz posts a comment prompting you to connect your Jira account to Warp. Connecting attributes your Jira-triggered runs to your Warp account; the run doesn't start until your account is connected. After connecting, re-add the `warp-agent` label to start the run.
 
 1. Follow the link in the comment to open the Warp page in your Jira personal settings. The link for the production app follows this pattern:
 
@@ -84,7 +84,7 @@ If Oz doesn't respond after adding the label, check that:
 * The issue is in Jira Cloud (not Server or Data Center).
 
 :::note
-When a Jira-triggered run fails to start, Oz updates its comment on the issue to say it could not start the task. Re-add the `oz-agent` label to try again; a new attempt starts a new comment thread.
+When a Jira-triggered run fails to start, Oz updates its comment on the issue to say it could not start the task. Re-add the `warp-agent` label to try again; a new attempt starts a new comment thread.
 :::
 
 For other issues, reach out to your Warp contact or join the [Warp community on Slack](https://go.warp.dev/join-preview).

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -363,6 +363,7 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 						{ slug: 'platform/integrations/quickstart', label: 'Quickstart' },
 						'platform/integrations/slack',
 						'platform/integrations/linear',
+						'platform/integrations/jira',
 						{
 							label: 'GitHub Actions',
 							collapsed: true,


### PR DESCRIPTION
## Summary
Publishes the Jira integration page and rewrites the setup instructions for the current self-serve flow, replacing the old "contact Warp for an install link" guidance.

## Changes

### src/content/docs/platform/integrations/jira.mdx
- Removed the `draft: true` flag so the page publishes
- Rewrote setup as five steps matching the shipped flow: **Set up** in the Oz web app → **Get app** on Atlassian → install on the Jira Cloud site → **Manage apps** > Oz > **Configure** → **Connect to Warp** (automatic workspace binding)
- Added URL patterns for the Oz configuration page and the Jira personal settings page, with production app/environment IDs
- Added a "Connecting your Jira account to Warp" section documenting the account-binding comment and flow for run attribution
- Replaced the error-code troubleshooting tip (verified inaccurate against warp-server: the Jira notifier no-ops on platform errors) with the actual failed-to-start comment behavior

### src/sidebar.ts
- Added Jira under **Integrations** after Linear

### src/content/docs/platform/integrations/index.mdx
- Added Jira links alongside Slack and Linear in the intro and Get started list

## Additional context
- Setup and binding flows verified against `warp-server` (`jira/jira_forge.go`, `jira/jira_forge_claim.go`, `forge-jira/`, `client/src/jira/`)
- `npm run build` and the internal link checker pass

Co-Authored-By: Oz <oz-agent@warp.dev>
