### PR TITLE
docs: document Pinned tabs

### DIFF
--- a/src/content/docs/terminal/windows/tabs.mdx
+++ b/src/content/docs/terminal/windows/tabs.mdx
@@ -127,6 +127,26 @@ Click a group's header to collapse or expand it. Collapsed groups hide their mem
 You can assign keyboard shortcuts for creating a group from the active or selected tabs and for removing tabs from a group in **Settings** > **Keyboard shortcuts**.
 :::
 
+## Pinned tabs
+
+Pin the tabs and tab groups you rely on so they stay at the front of the tab bar and are protected from reordering. A pinned tab keeps its position when you open, close, move, or drag other tabs, which keeps your most important sessions in a predictable spot. Pinning works in both the horizontal tab bar and the [vertical tabs](/terminal/windows/vertical-tabs/) panel.
+
+### Pin or unpin a tab
+
+* Right-click a tab and choose **Pin tab**. The tab moves to the front of the tab bar and stays there.
+* Right-click a pinned tab and choose **Unpin tab** to unpin it. The tab moves back to the start of the unpinned tabs.
+
+Pinning a tab that belongs to a [group](#tab-groups) removes it from the group first, because pinning a tab and pinning a group are independent.
+
+### Pin or unpin a tab group
+
+* Right-click a [tab group's](#tab-groups) header and choose **Pin group**. The group keeps its member tabs together and moves to the front of the tab bar.
+* Right-click a pinned group's header and choose **Unpin group** to unpin it.
+
+### Keyboard shortcuts
+
+Pinning actions ship without default keyboard shortcuts. Assign your own in **Settings** > **Keyboard shortcuts** for **Pin current tab**, **Unpin current tab**, **Pin current tab group**, and **Unpin current tab group**.
+
 ## Move a tab to another window
 
 You can pull a tab out of the tab bar to reorganize your windows, similar to a web browser:


### PR DESCRIPTION
## Summary
Documents the **Pinned tabs** feature, which went GA (the `PinnedTabs` feature flag is now enabled by default). Users can pin individual tabs and whole tab groups so they stay at the front of the tab bar and are protected from reordering.

## What changed
- Added a **Pinned tabs** section to `terminal/windows/tabs.mdx` covering:
  - Pin/unpin an individual tab (**Pin tab** / **Unpin tab** from the tab right-click menu).
  - Pin/unpin a whole tab group (**Pin group** / **Unpin group** from the group header menu).
  - The keyless keyboard shortcuts (assignable in **Settings** > **Keyboard shortcuts**).

Source of truth: `app/src/workspace/view/tab_grouping.rs`, `app/src/tab.rs`, and the `PinnedTabs` flag in `crates/warp_features/src/lib.rs` (public warpdotdev/warp repo).

## Audit context
Generated by the `missing_docs` drift-watch audit. This finding came from the `PinnedTabs` flag moving `preview -> ga`. The companion surface-map + snapshot updates ship in the audit-bookkeeping PR.

_Conversation: https://staging.warp.dev/conversation/ce1c5f13-b8a2-497f-843e-57f84d63b745_
_Run: https://oz.staging.warp.dev/runs/019f7105-5e3a-7d03-8d21-1a7784c46f9a_

_This PR was generated with [Oz](https://warp.dev/oz)._
