### PR TITLE
docs(missing_docs): audit bookkeeping (surface map + snapshot)

### DIFF
--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -104,7 +104,9 @@ AgentViewBlockContext -> src/content/docs/agent-platform/local-agents/agent-cont
 CloudConversations -> src/content/docs/agent-platform/local-agents/cloud-conversations.mdx
 CloudModeFromLocalSession -> src/content/docs/platform/index.mdx
 TeamApiKeys -> src/content/docs/reference/cli/api-keys.md
-PRCommentsSlashCommand -> src/content/docs/agent-platform/capabilities/slash-commands.mdx
+# The PRCommentsSlashCommand flag was removed: the /pr-comments slash command was
+# replaced by the bundled PR Comments skill (invoked via /skills), so the slash
+# command was dropped from the docs.
 PRCommentsV2 -> src/content/docs/agent-platform/local-agents/interacting-with-agents/index.mdx
 CLIAgentRichInput -> src/content/docs/agent-platform/cli-agents/rich-input.md
 HOANotifications -> src/content/docs/agent-platform/capabilities/agent-notifications.mdx
@@ -135,9 +137,10 @@ WorkflowAliases -> src/content/docs/terminal/entry/yaml-workflows.mdx
 KittyImages -> src/content/docs/terminal/more-features/full-screen-apps.mdx
 UndoClosedPanes -> src/content/docs/terminal/windows/tabs.mdx
 # Tab groups (organize tabs into named, collapsible groups) — GA (in the default
-# feature set). Pinning tab groups is still Preview (PinnedTabs), so it stays out
-# of the docs for now.
+# feature set).
 GroupedTabs -> src/content/docs/terminal/windows/tabs.mdx
+# Pin individual tabs and whole tab groups to the front of the tab bar — GA.
+PinnedTabs -> src/content/docs/terminal/windows/tabs.mdx
 # Drag a tab out to its own window or between windows. GA on macOS and Windows
 # (RELEASE_FLAGS, cfg-gated), documented with that platform caveat.
 DragTabsToWindows -> src/content/docs/terminal/windows/tabs.mdx
@@ -175,8 +178,9 @@ OzHandoff -> src/content/docs/platform/handoff/index.mdx
 HandoffLocalCloud -> src/content/docs/platform/handoff/local-to-cloud.mdx
 HandoffCloudCloud -> src/content/docs/platform/handoff/cloud-to-cloud.mdx
 
-# Orchestration / multi-agent runs
-RunAgentsTool -> src/content/docs/platform/orchestration/multi-agent-runs.mdx
+# Orchestration / multi-agent runs is documented at
+# platform/orchestration/multi-agent-runs.mdx. The RunAgentsTool flag was removed
+# after the feature stabilized (GA), so it no longer needs a map entry.
 
 # Prompt queueing
 QueueSlashCommand -> src/content/docs/agent-platform/local-agents/interacting-with-agents/prompt-queueing.mdx
@@ -252,6 +256,16 @@ oz memory-store update -> gated:AIMemories
 oz provider -> gated:ProviderCommand
 oz provider setup -> gated:ProviderCommand
 oz provider list -> gated:ProviderCommand
+
+# `oz runner` (manage cloud agent runners) is gated by CloudAgentRunnerCLICommands,
+# which is non-GA (dogfood), so the command group is deferred via `gated:` — it
+# auto-surfaces for docs when the flag goes GA. See "Public vs. private surfaces"
+# in SKILL.md.
+oz runner -> gated:CloudAgentRunnerCLICommands
+oz runner list -> gated:CloudAgentRunnerCLICommands
+oz runner create -> gated:CloudAgentRunnerCLICommands
+oz runner update -> gated:CloudAgentRunnerCLICommands
+oz runner delete -> gated:CloudAgentRunnerCLICommands
 
 # Internal/hidden command — not a user-facing surface, so no public docs.
 oz harness-support -> internal
@@ -461,18 +475,14 @@ CloudModeSetupV2
 CloudModeInputV2
 # Internal GitHub credential refresh during task runs (changelog-only behavior fix).
 GitCredentialRefresh
-# Internal SSE streaming infrastructure for orchestration viewers/owners.
-OrchestrationViewerStreamer
-OwnerOrchestrationAncestorStreamer
+# State-mutating recovery for abnormal terminal lifecycle sequences — an internal
+# reliability mechanism with no user-facing configuration or UI, so it needs no docs.
+TerminalLifecycleRecovery
 
 # Sub-feature toggles and pre-launch flags. Section placement does NOT assert
 # rollout status (the audit computes that from code); entries here are ignored
 # because the toggle itself isn't a documentable surface, or because the
 # feature isn't user-facing yet — the snapshot diff flags promotions.
-# Pinned Tabs is a Preview feature (pin individual tabs and whole tab groups to
-# the front of the tab list); public docs are pending GA promotion, which the
-# snapshot diff will flag.
-PinnedTabs
 LSPAsATool
 EmbeddedCodeReviewComments
 InteractiveConversationManagementView

--- a/.agents/skills/missing_docs/references/surface_snapshot.json
+++ b/.agents/skills/missing_docs/references/surface_snapshot.json
@@ -39,7 +39,7 @@
     "AmbientAgentsRTC": "ga",
     "ArtifactCommand": "ga",
     "AskUserQuestion": "ga",
-    "AsyncFind": "preview",
+    "AsyncFind": "ga",
     "AtMenuOutsideOfAIMode": "ga",
     "AutoOpenCodeReviewPane": "ga",
     "Autoupdate": "ga",
@@ -49,6 +49,7 @@
     "BillingAndUsagePageV2": "ga",
     "BlocklistMarkdownImages": "ga",
     "BlocklistMarkdownTableRendering": "ga",
+    "BoxDrawingGlyphs": "dogfood",
     "BuildPlanAutoReloadBannerToggle": "other",
     "BuildPlanAutoReloadPostPurchaseModal": "other",
     "BundledSkills": "ga",
@@ -56,6 +57,7 @@
     "Changelog": "ga",
     "ClassicCompletions": "ga",
     "ClearAutosuggestionOnEscape": "ga",
+    "CloudAgentRunnerCLICommands": "dogfood",
     "CloudConversations": "ga",
     "CloudEnvironments": "ga",
     "CloudMode": "ga",
@@ -123,7 +125,7 @@
     "FullScreenZenMode": "ga",
     "FullSourceCodeEmbedding": "dogfood",
     "GPTConfigurableContextWindow": "dogfood",
-    "GeminiEnterprise": "other",
+    "GeminiEnterprise": "dogfood",
     "GeminiNotifications": "dogfood",
     "GetStartedTab": "ga",
     "GitCredentialRefresh": "ga",
@@ -183,24 +185,22 @@
     "NamedAgents": "ga",
     "NativeShellCompletions": "other",
     "NewTabStyling": "ga",
-    "NldPromptHistoryMatch": "dogfood",
+    "NldPromptHistoryMatch": "other",
     "OpenCodeNotifications": "ga",
     "OpenWarpLaunchModal": "ga",
     "OpenWarpNewSettingsModes": "ga",
     "OrchestrationLaunchModal": "ga",
-    "OrchestrationViewerStreamer": "ga",
-    "OwnerOrchestrationAncestorStreamer": "ga",
+    "OscHyperlinks": "dogfood",
     "OzChangelogUpdates": "ga",
     "OzHandoff": "ga",
     "OzIdentityFederation": "ga",
     "OzLaunchModal": "ga",
     "OzPlatformSkills": "ga",
     "PRCommentsSkill": "ga",
-    "PRCommentsSlashCommand": "ga",
     "PRCommentsV2": "ga",
     "PartialNextCommandSuggestions": "other",
     "PendingUserQueryIndicator": "ga",
-    "PinnedTabs": "preview",
+    "PinnedTabs": "ga",
     "PluggableNotifications": "ga",
     "PredictAMQueries": "other",
     "ProfilesDesignRevamp": "ga",
@@ -226,7 +226,6 @@
     "RevertToCheckpoints": "ga",
     "RewindSlashCommand": "ga",
     "RichTextMultiselect": "ga",
-    "RunAgentsTool": "ga",
     "RunGeneratorsWithCmdExe": "dogfood",
     "RuntimeFeatureFlags": "other",
     "ScheduledAmbientAgents": "ga",
@@ -258,7 +257,7 @@
     "TabConfigs": "ga",
     "TabbedEditorView": "ga",
     "TeamApiKeys": "ga",
-    "TerminalLifecycleRecovery": "dogfood",
+    "TerminalLifecycleRecovery": "ga",
     "ThinStrokes": "other",
     "ToggleBootstrapBlock": "dogfood",
     "TransferControlTool": "ga",
@@ -572,6 +571,26 @@
       "hidden": false
     },
     {
+      "command": "oz runner",
+      "hidden": false
+    },
+    {
+      "command": "oz runner create",
+      "hidden": false
+    },
+    {
+      "command": "oz runner delete",
+      "hidden": false
+    },
+    {
+      "command": "oz runner list",
+      "hidden": false
+    },
+    {
+      "command": "oz runner update",
+      "hidden": false
+    },
+    {
       "command": "oz schedule",
       "hidden": false
     },
@@ -717,6 +736,18 @@
     "model": [
       "--model"
     ],
+    "runner": [
+      "--arch",
+      "--description",
+      "--docker-image",
+      "--macos-version",
+      "--memory-gb",
+      "--name",
+      "--os",
+      "--setup-command",
+      "--sort-by",
+      "--vcpus"
+    ],
     "schedule": [
       "--cron",
       "--host",
@@ -772,12 +803,15 @@
   "api_routes": [
     "DELETE /api/v1/agent/identities/{uid}",
     "DELETE /api/v1/agent/schedules/{id}",
+    "DELETE /api/v1/factory/automations/{id}",
+    "DELETE /api/v1/factory/automations/{id}/subscriptions/{subscription_id}",
     "DELETE /api/v1/factory/{uid}",
     "DELETE /api/v1/memory_stores/{uid}",
     "DELETE /api/v1/memory_stores/{uid}/memories/{memoryUid}",
     "GET /.well-known/openid-configuration",
     "GET /api/v1/agent",
     "GET /api/v1/agent/artifacts/{uid}",
+    "GET /api/v1/agent/artifacts/{uid}/download",
     "GET /api/v1/agent/connected-self-hosted-workers",
     "GET /api/v1/agent/conversations/{conversation_id}/block-snapshot",
     "GET /api/v1/agent/conversations/{conversation_id}/redirect",
@@ -799,6 +833,9 @@
     "GET /api/v1/agent/tasks",
     "GET /api/v1/agent/tasks/{id}",
     "GET /api/v1/factory",
+    "GET /api/v1/factory/automations",
+    "GET /api/v1/factory/automations/events/{provider}",
+    "GET /api/v1/factory/automations/{id}",
     "GET /api/v1/factory/{uid}",
     "GET /api/v1/harness-support/transcript",
     "GET /api/v1/memory_stores",
@@ -829,6 +866,7 @@
     "POST /api/v1/agent/schedules/{id}/resume",
     "POST /api/v1/agent/tasks/{id}/cancel",
     "POST /api/v1/factory",
+    "POST /api/v1/factory/automations",
     "POST /api/v1/factory/avatar",
     "POST /api/v1/harness-support/block-snapshot",
     "POST /api/v1/harness-support/external-conversation",
@@ -846,6 +884,7 @@
     "POST /api/v1/oauth/token",
     "PUT /api/v1/agent/identities/{uid}",
     "PUT /api/v1/agent/schedules/{id}",
+    "PUT /api/v1/factory/automations/{id}/subscriptions",
     "PUT /api/v1/memory_stores/{uid}",
     "PUT /api/v1/memory_stores/{uid}/memories/{memoryUid}"
   ],
@@ -876,6 +915,7 @@
     "/host",
     "/index",
     "/init",
+    "/mcp",
     "/model",
     "/new",
     "/open-code-review",
@@ -886,7 +926,6 @@
     "/open-rules",
     "/open-settings-file",
     "/open-skill",
-    "/pr-comments",
     "/profile",
     "/prompts",
     "/queue",
@@ -1223,5 +1262,5 @@
     "verify-ui-change-in-cloud": "dogfood",
     "warpctrl": "bundled"
   },
-  "changelog_last_version": "2026.07.09"
+  "changelog_last_version": "2026.07.16"
 }


### PR DESCRIPTION
## Summary
Companion audit-bookkeeping PR for the `missing_docs` drift-watch run. Updates the surface map and regenerates the surface snapshot so the next audit diffs against a clean baseline. No user-facing docs change here (those ship in the sibling feature PRs).

## Surface map changes (`references/feature_surface_map.md`)
- **PinnedTabs** → `terminal/windows/tabs.mdx` (feature went GA; documented in #339). Removed its old ignore-list entry.
- **TerminalLifecycleRecovery** → ignore list. It's an internal reliability mechanism (state-mutating recovery for abnormal terminal lifecycle sequences) with no user-facing configuration or UI.
- **`oz runner`** CRUD → `gated:CloudAgentRunnerCLICommands`. The command group is gated by a dogfood-only flag, so it auto-defers until GA.
- Pruned stale entries for removed flags: `RunAgentsTool` (orchestration stabilized/GA; still documented at `platform/orchestration/multi-agent-runs.mdx`), `PRCommentsSlashCommand` (slash command removed; see #340), and ignore-list entries `OrchestrationViewerStreamer` / `OwnerOrchestrationAncestorStreamer` (flags removed from code).

## Snapshot
- Regenerated `references/surface_snapshot.json` (`--update-snapshot`). This clears the `surface_changes` and `changelog_review` diffs for this run.

## Validation
- Coverage audit: addressed findings resolved (feature-flag, CLI, slash, and map-hygiene findings all at 0; completeness accounting clean, `unaccounted: none`).
- Diff audit: `surface_changes` and `changelog_review` cleared.
- `npm run build` passed (347 pages built).

## Deferred findings (not silently dropped)
These remain open by design and are **not** addressed in this run:

**Public Oz Agent API endpoints missing from the OpenAPI spec (27) — route via `sync-openapi-spec`, do not hand-document.** `warp-server` is private, and none of these are in the released `developers/agent-api-openapi.yaml`, so per the skill's public/private guardrail they are deferred pending release-status confirmation:
- `agent/artifacts/{uid}`, `agent/artifacts/{uid}/download`
- `agent/events`, `agent/events/stream`, `agent/events/{run_id}`
- `agent/messages`, `agent/messages/{id}/delivered`, `agent/messages/{id}/read`, `agent/messages/{run_id}`
- `agent/schedules/{id}` (GET/PUT/DELETE), `agent/schedules/{id}/pause`, `agent/schedules/{id}/resume`
- `factory`, `factory/{uid}` (GET/PATCH/DELETE), `factory/avatar`, `factory/automations` (+ `{id}`, `events/{provider}`, `{id}/subscriptions`, `{id}/subscriptions/{subscription_id}`)

**Terminology / staleness findings (32) — owned by the `style_lint` skill.** Pure wording issues (e.g. "warp ai", "ai credits", "agent-mode", "ambient agent", "warp terminal") across billing, inference, harness, privacy, and terminal pages are delegated to `style_lint` rather than fixed here.

**Dogfood-only / non-GA surfaces — tracked, no docs.** `BoxDrawingGlyphs`, `OscHyperlinks`, `CloudAgentRunnerCLICommands`, `GeminiEnterprise`, `NldPromptHistoryMatch`. The snapshot will re-flag them on GA promotion.

**Other verified-covered items:** the `/mcp` slash command is TUI-only and already counts as doc-covered; `AsyncFind` (now GA) is already covered by the documented `experimental.async_find_enabled` setting. Changelog "improvements" items were reviewed and are minor UI changes not needing dedicated docs.

_Conversation: https://staging.warp.dev/conversation/ce1c5f13-b8a2-497f-843e-57f84d63b745_
_Run: https://oz.staging.warp.dev/runs/019f7105-5e3a-7d03-8d21-1a7784c46f9a_

_This PR was generated with [Oz](https://warp.dev/oz)._
