### PR TITLE
fix: use BUZZ_SLACK_TOKEN for Slack notifications in cloud agent

### DIFF
--- a/.agents/skills/validate_ui_refs/SKILL.md
+++ b/.agents/skills/validate_ui_refs/SKILL.md
@@ -132,13 +132,14 @@ Slack notifications are designed for automated runs, not ad-hoc usage. When runn
 
 The `--slack-notify` flag posts a summary to `#growth-docs` when unfixed issues remain after a run. If the scan is clean (0 issues), no notification is sent.
 
-### Setup (one-time)
+### Setup
 
-Add `SLACK_BOT_TOKEN` as a repository secret in `warpdotdev/docs` (**Settings** > **Secrets and variables** > **Actions**). The token needs `chat:write` scope.
+For **automated runs**, the Slack token is provided by the Docs Agent Oz environment via `BUZZ_SLACK_TOKEN` — no GHA secret needed.
 
-### Usage
+For **manual runs** from the command line, export a Slack bot token with `chat:write` scope before running:
 
 ```bash
+export SLACK_BOT_TOKEN=xoxb-...
 python3 .agents/skills/validate_ui_refs/validate_ui_refs.py --all --slack-notify
 ```
 

--- a/.agents/skills/validate_ui_refs/SKILL.md
+++ b/.agents/skills/validate_ui_refs/SKILL.md
@@ -160,7 +160,7 @@ python3 .agents/skills/validate_ui_refs/validate_ui_refs.py --all --slack-notify
 |---|---|---|---|
 | `DOCS_REPOSITORY_DISPATCH_TOKEN` | `warpdotdev/warp` GHA secrets | ✅ Already provisioned | Sends the `settings-ui-changed` event to docs via `peter-evans/repository-dispatch` |
 | `WARP_API_KEY` | `warpdotdev/docs` GHA secrets | ✅ Already provisioned | Used by the GHA workflow to dispatch the Oz cloud agent |
-| `DOCS_SLACK_BOT_TOKEN` | Docs Agent Oz environment | ✅ Already provisioned | Used by the cloud agent for `#growth-docs` Slack notifications |
+| `BUZZ_SLACK_TOKEN` | Docs Agent Oz environment | ✅ Already provisioned | Used by the cloud agent for `#growth-docs` Slack notifications (same bot that posts 404 reports, etc.) |
 
 `warp-internal` access is provided by the Docs Agent Oz environment (environment ID `K5KStCm5aYvhfBJb8cHol6`), which has `warpdotdev/warp-internal` in its configured repos. No `WARP_INTERNAL_READ_PAT` GHA secret is needed.
 

--- a/.agents/skills/validate_ui_refs/validate_ui_refs.py
+++ b/.agents/skills/validate_ui_refs/validate_ui_refs.py
@@ -1128,11 +1128,11 @@ def notify_slack(
     channel: str,
     pr_url: Optional[str] = None,
 ) -> bool:
-    """Post a summary to Slack. Requires SLACK_BOT_TOKEN or DOCS_SLACK_BOT_TOKEN env var."""
+    """Post a summary to Slack. Requires SLACK_BOT_TOKEN, BUZZ_SLACK_TOKEN, or DOCS_SLACK_BOT_TOKEN env var."""
     token = (
         os.environ.get("SLACK_BOT_TOKEN")
-        or os.environ.get("DOCS_SLACK_BOT_TOKEN")
         or os.environ.get("BUZZ_SLACK_TOKEN")
+        or os.environ.get("DOCS_SLACK_BOT_TOKEN")
     )
     if not token:
         print("Warning: no Slack token found (checked SLACK_BOT_TOKEN, DOCS_SLACK_BOT_TOKEN, BUZZ_SLACK_TOKEN), skipping notification.", file=sys.stderr)

--- a/.agents/skills/validate_ui_refs/validate_ui_refs.py
+++ b/.agents/skills/validate_ui_refs/validate_ui_refs.py
@@ -1129,9 +1129,13 @@ def notify_slack(
     pr_url: Optional[str] = None,
 ) -> bool:
     """Post a summary to Slack. Requires SLACK_BOT_TOKEN or DOCS_SLACK_BOT_TOKEN env var."""
-    token = os.environ.get("SLACK_BOT_TOKEN") or os.environ.get("DOCS_SLACK_BOT_TOKEN")
+    token = (
+        os.environ.get("SLACK_BOT_TOKEN")
+        or os.environ.get("DOCS_SLACK_BOT_TOKEN")
+        or os.environ.get("BUZZ_SLACK_TOKEN")
+    )
     if not token:
-        print("Warning: SLACK_BOT_TOKEN (or DOCS_SLACK_BOT_TOKEN) not set, skipping Slack notification.", file=sys.stderr)
+        print("Warning: no Slack token found (checked SLACK_BOT_TOKEN, DOCS_SLACK_BOT_TOKEN, BUZZ_SLACK_TOKEN), skipping notification.", file=sys.stderr)
         return False
 
     try:

--- a/.agents/skills/validate_ui_refs/validate_ui_refs.py
+++ b/.agents/skills/validate_ui_refs/validate_ui_refs.py
@@ -1135,7 +1135,7 @@ def notify_slack(
         or os.environ.get("DOCS_SLACK_BOT_TOKEN")
     )
     if not token:
-        print("Warning: no Slack token found (checked SLACK_BOT_TOKEN, DOCS_SLACK_BOT_TOKEN, BUZZ_SLACK_TOKEN), skipping notification.", file=sys.stderr)
+        print("Warning: no Slack token found (checked SLACK_BOT_TOKEN, BUZZ_SLACK_TOKEN, DOCS_SLACK_BOT_TOKEN), skipping notification.", file=sys.stderr)
         return False
 
     try:

--- a/.github/workflows/refresh-ui-paths.yml
+++ b/.github/workflows/refresh-ui-paths.yml
@@ -53,8 +53,8 @@ jobs:
                  --all --fix --create-pr --slack-notify \\
                  --slack-channel C09BVK0PL3Y
              The script auto-fixes high-confidence issues, opens a PR, and posts to
-             #growth-docs if issues remain. DOCS_SLACK_BOT_TOKEN is available as a
-             fallback for SLACK_BOT_TOKEN.
+             #growth-docs if issues remain. BUZZ_SLACK_TOKEN is available in this
+             environment and is used as a fallback for SLACK_BOT_TOKEN.
           4. Report the outcome (PR URL if created, or "no changes" if already up to date).
 
           Full instructions: .agents/skills/validate_ui_refs/SKILL.md


### PR DESCRIPTION
The Docs Agent Oz environment now has `BUZZ_SLACK_TOKEN` provisioned — the same Buzz bot that posts 404 reports and other messages to `#growth-docs`. The previous `DOCS_SLACK_BOT_TOKEN` caused `not_in_channel` errors because it was a different token without channel membership.

## Changes
- `validate_ui_refs.py`: add `BUZZ_SLACK_TOKEN` as third fallback (after `SLACK_BOT_TOKEN` and `DOCS_SLACK_BOT_TOKEN`)
- `refresh-ui-paths.yml`: update cloud agent prompt to reference `BUZZ_SLACK_TOKEN`
- `SKILL.md`: update secrets table to reflect `BUZZ_SLACK_TOKEN`

Co-Authored-By: Oz <oz-agent@warp.dev>