### PR TITLE
fix: robust warp repo discovery in Oz prompt

### DIFF
--- a/.github/workflows/refresh-ui-paths.yml
+++ b/.github/workflows/refresh-ui-paths.yml
@@ -42,14 +42,16 @@ jobs:
           This was triggered by a change to app/src/settings_view/ in warpdotdev/warp.
 
           Steps:
-          1. Locate warpdotdev/warp. It should be checked out at
-             /workspace/warp in this environment. If that path does
-             not exist, clone it:
-               git clone git@github.com:warpdotdev/warp.git /workspace/warp
-             Then run:
+          1. Locate the warpdotdev/warp checkout. Try these in order:
+             a. Check if /workspace/warp/app/src/settings_view/ exists
+             b. Search: find /workspace /home -name "settings_view" -type d 2>/dev/null | head -1
+             c. If not found anywhere, clone it (public repo, HTTPS works):
+                  git clone https://github.com/warpdotdev/warp.git /tmp/warp --depth 1
+                  WARP_PATH=/tmp/warp
+             Set WARP_PATH to whichever path was found, then run:
                python3 .agents/skills/validate_ui_refs/validate_ui_refs.py \\
                  --refresh-valid-paths \\
-                 --warp-internal-path /workspace/warp
+                 --warp-internal-path $WARP_PATH
           2. Compare valid_paths.json before and after (strip generated_at from both,
              then diff). If unchanged, exit — no PR needed.
           3. If the snapshot changed, run:


### PR DESCRIPTION
The workflow was failing because the Oz agent prompt assumed `warpdotdev/warp` is checked out at `/workspace/warp`, but the actual checkout path in the Docs Agent environment may be different.

## Fix

The agent now uses a three-step discovery approach:
1. Check `/workspace/warp/app/src/settings_view/` (most likely path)
2. Search `/workspace` and `/home` with `find` for any `settings_view` directory
3. If neither works, fall back to HTTPS clone (`warpdotdev/warp` is a public repo — no credentials needed) with `--depth 1` for speed

This makes the prompt self-sufficient regardless of what path the Oz environment uses for repo checkouts.

Co-Authored-By: Oz <oz-agent@warp.dev>