### PR TITLE
fix: extractor bug, refresh snapshot, apply doc path fixes

### DIFF
--- a/.agents/skills/validate_ui_refs/valid_paths.json
+++ b/.agents/skills/validate_ui_refs/valid_paths.json
@@ -82,84 +82,15 @@
       "sub_sections": [],
       "source_file": "app/src/settings_view/mod.rs"
     },
-    "Oz": {
-      "display_name": "Oz",
-      "umbrella": "Agents",
-      "sub_sections": [
-        "Active AI",
-        "Input",
-        "Voice",
-        "Other",
-        "Experimental"
-      ],
-      "source_file": "app/src/settings_view/ai_page.rs"
-    },
-    "Profiles": {
-      "display_name": "Profiles",
-      "umbrella": "Agents",
-      "sub_sections": [
-        "Usage",
-        "Profiles",
-        "Agents",
-        "Permissions",
-        "Command allowlist",
-        "Command denylist",
-        "MCP permissions"
-      ],
-      "source_file": "app/src/settings_view/ai_page.rs"
-    },
-    "MCP servers": {
-      "display_name": "MCP servers",
-      "umbrella": "Agents",
+    "MCP Servers": {
+      "display_name": "MCP Servers",
       "sub_sections": [],
       "source_file": "app/src/settings_view/mcp_servers_page.rs"
-    },
-    "Knowledge": {
-      "display_name": "Knowledge",
-      "umbrella": "Agents",
-      "sub_sections": [],
-      "source_file": "app/src/settings_view/ai_page.rs"
-    },
-    "Third party CLI agents": {
-      "display_name": "Third party CLI agents",
-      "umbrella": "Agents",
-      "sub_sections": [],
-      "source_file": "app/src/settings_view/ai_page.rs"
     },
     "Billing and usage": {
       "display_name": "Billing and usage",
       "sub_sections": [],
-      "source_file": "app/src/settings_view/billing_and_usage_page.rs"
-    },
-    "Indexing and projects": {
-      "display_name": "Indexing and projects",
-      "umbrella": "Code",
-      "sub_sections": [
-        "Codebase Indexing"
-      ],
-      "source_file": "app/src/settings_view/code_page.rs"
-    },
-    "Editor and Code Review": {
-      "display_name": "Editor and Code Review",
-      "umbrella": "Code",
-      "sub_sections": [
-        "Code Editor and Review"
-      ],
-      "source_file": "app/src/settings_view/code_page.rs"
-    },
-    "Environments": {
-      "display_name": "Environments",
-      "umbrella": "Cloud platform",
-      "sub_sections": [],
-      "source_file": "app/src/settings_view/environments_page.rs"
-    },
-    "Oz Cloud API Keys": {
-      "display_name": "Oz Cloud API Keys",
-      "umbrella": "Cloud platform",
-      "sub_sections": [
-        "API Keys"
-      ],
-      "source_file": "app/src/settings_view/platform_page.rs"
+      "source_file": "app/src/settings_view/mod.rs"
     },
     "Appearance": {
       "display_name": "Appearance",
@@ -167,6 +98,7 @@
         "Themes",
         "Icon",
         "Window",
+        "Tools panel",
         "Input",
         "Panes",
         "Blocks",
@@ -205,7 +137,12 @@
     "Referrals": {
       "display_name": "Referrals",
       "sub_sections": [],
-      "source_file": "app/src/settings_view/referrals_page.rs"
+      "source_file": "app/src/settings_view/mod.rs"
+    },
+    "Scripting": {
+      "display_name": "Scripting",
+      "sub_sections": [],
+      "source_file": "app/src/settings_view/mod.rs"
     },
     "Shared blocks": {
       "display_name": "Shared blocks",
@@ -215,12 +152,12 @@
     "Teams": {
       "display_name": "Teams",
       "sub_sections": [],
-      "source_file": "app/src/settings_view/teams_page.rs"
+      "source_file": "app/src/settings_view/mod.rs"
     },
     "Warp Drive": {
       "display_name": "Warp Drive",
       "sub_sections": [],
-      "source_file": "app/src/settings_view/warp_drive_page.rs"
+      "source_file": "app/src/settings_view/mod.rs"
     },
     "Warpify": {
       "display_name": "Warpify",
@@ -229,6 +166,179 @@
         "SSH"
       ],
       "source_file": "app/src/settings_view/warpify_page.rs"
+    },
+    "AI": {
+      "display_name": "AI",
+      "sub_sections": [
+        "Usage",
+        "Active AI",
+        "Agents",
+        "Profiles",
+        "Input",
+        "MCP Servers",
+        "Knowledge",
+        "Voice",
+        "Other",
+        "Third party CLI agents",
+        "Agent Attribution",
+        "Experimental",
+        "Cloud Handoff",
+        "Custom Inference",
+        "API Keys",
+        "AWS Bedrock",
+        "Gemini Enterprise",
+        "Custom Routers"
+      ],
+      "source_file": "app/src/settings_view/ai_page.rs"
+    },
+    "Warp Agent": {
+      "display_name": "Warp Agent",
+      "sub_sections": [
+        "Usage",
+        "Active AI",
+        "Agents",
+        "Profiles",
+        "Input",
+        "MCP Servers",
+        "Knowledge",
+        "Voice",
+        "Other",
+        "Third party CLI agents",
+        "Agent Attribution",
+        "Experimental",
+        "Cloud Handoff",
+        "Custom Inference",
+        "API Keys",
+        "AWS Bedrock",
+        "Gemini Enterprise",
+        "Custom Routers"
+      ],
+      "source_file": "app/src/settings_view/ai_page.rs"
+    },
+    "Profiles": {
+      "display_name": "Profiles",
+      "sub_sections": [
+        "Usage",
+        "Active AI",
+        "Agents",
+        "Profiles",
+        "Input",
+        "MCP Servers",
+        "Knowledge",
+        "Voice",
+        "Other",
+        "Third party CLI agents",
+        "Agent Attribution",
+        "Experimental",
+        "Cloud Handoff",
+        "Custom Inference",
+        "API Keys",
+        "AWS Bedrock",
+        "Gemini Enterprise",
+        "Custom Routers"
+      ],
+      "source_file": "app/src/settings_view/ai_page.rs",
+      "umbrella": "Agents"
+    },
+    "MCP servers": {
+      "display_name": "MCP servers",
+      "sub_sections": [],
+      "source_file": "app/src/settings_view/mcp_servers_page.rs",
+      "umbrella": "Agents"
+    },
+    "Knowledge": {
+      "display_name": "Knowledge",
+      "sub_sections": [
+        "Usage",
+        "Active AI",
+        "Agents",
+        "Profiles",
+        "Input",
+        "MCP Servers",
+        "Knowledge",
+        "Voice",
+        "Other",
+        "Third party CLI agents",
+        "Agent Attribution",
+        "Experimental",
+        "Cloud Handoff",
+        "Custom Inference",
+        "API Keys",
+        "AWS Bedrock",
+        "Gemini Enterprise",
+        "Custom Routers"
+      ],
+      "source_file": "app/src/settings_view/ai_page.rs",
+      "umbrella": "Agents"
+    },
+    "Third party CLI agents": {
+      "display_name": "Third party CLI agents",
+      "sub_sections": [
+        "Usage",
+        "Active AI",
+        "Agents",
+        "Profiles",
+        "Input",
+        "MCP Servers",
+        "Knowledge",
+        "Voice",
+        "Other",
+        "Third party CLI agents",
+        "Agent Attribution",
+        "Experimental",
+        "Cloud Handoff",
+        "Custom Inference",
+        "API Keys",
+        "AWS Bedrock",
+        "Gemini Enterprise",
+        "Custom Routers"
+      ],
+      "source_file": "app/src/settings_view/ai_page.rs",
+      "umbrella": "Agents"
+    },
+    "Code": {
+      "display_name": "Code",
+      "sub_sections": [
+        "Codebase Indexing",
+        "Code Editor and Review",
+        "Codebase Indexing",
+        "Code Editor and Review"
+      ],
+      "source_file": "app/src/settings_view/code_page.rs"
+    },
+    "Indexing and projects": {
+      "display_name": "Indexing and projects",
+      "sub_sections": [
+        "Codebase Indexing",
+        "Code Editor and Review",
+        "Codebase Indexing",
+        "Code Editor and Review"
+      ],
+      "source_file": "app/src/settings_view/code_page.rs",
+      "umbrella": "Code"
+    },
+    "Editor and Code Review": {
+      "display_name": "Editor and Code Review",
+      "sub_sections": [
+        "Codebase Indexing",
+        "Code Editor and Review",
+        "Codebase Indexing",
+        "Code Editor and Review"
+      ],
+      "source_file": "app/src/settings_view/code_page.rs",
+      "umbrella": "Code"
+    },
+    "Environments": {
+      "display_name": "Environments",
+      "sub_sections": [],
+      "source_file": "app/src/settings_view/environments_page.rs",
+      "umbrella": "Cloud platform"
+    },
+    "Oz Cloud API Keys": {
+      "display_name": "Oz Cloud API Keys",
+      "sub_sections": [],
+      "source_file": "app/src/settings_view/platform_page.rs",
+      "umbrella": "Cloud platform"
     }
   },
   "top_level_sidebar": [
@@ -290,159 +400,662 @@
     ]
   },
   "command_palette_commands": [
-    {"name": "terminal:warpify_subshell", "description": "Warpify subshell"},
-    {"name": "terminal:warpify_ssh_session", "description": "Warpify ssh session"},
-    {"name": "terminal:accept_prompt_suggestion", "description": "Accept Prompt Suggestion"},
-    {"name": "terminal:cancel_command", "description": "Cancel active process"},
-    {"name": "terminal:focus_input", "description": "Focus terminal input"},
-    {"name": "terminal:paste", "description": "Paste"},
-    {"name": "terminal:copy", "description": "Copy"},
-    {"name": "terminal:reinput_commands", "description": "Reinput selected commands"},
-    {"name": "terminal:reinput_commands_with_sudo", "description": "Reinput selected commands as root"},
-    {"name": "terminal:find", "description": "Find in Terminal"},
-    {"name": "terminal:select_bookmark_up", "description": "Select the closest bookmark up"},
-    {"name": "terminal:select_bookmark_down", "description": "Select the closest bookmark down"},
-    {"name": "terminal:open_block_list_context_menu_via_keybinding", "description": "Open block context menu"},
-    {"name": "terminal:toggle_teams_modal", "description": "Toggle team workflows modal"},
-    {"name": "terminal:copy_git_branch", "description": "Copy git branch"},
-    {"name": "terminal:clear_blocks", "description": "Clear Blocks"},
-    {"name": "terminal:executing_command_move_cursor_word_left", "description": "Move cursor one word to the left within an executing command"},
-    {"name": "terminal:executing_command_move_cursor_word_right", "description": "Move cursor one word to the right within an executing command"},
-    {"name": "terminal:executing_command_move_cursor_home", "description": "Move cursor home within an executing command"},
-    {"name": "terminal:executing_command_move_cursor_end", "description": "Move cursor end within an executing command"},
-    {"name": "terminal:executing_command_delete_word_left", "description": "Delete word left within an executing command"},
-    {"name": "terminal:executing_command_delete_line_start", "description": "Delete to line start within an executing command"},
-    {"name": "terminal:executing_command_delete_line_end", "description": "Delete to line end within an executing command"},
-    {"name": "terminal:backward_tabulation", "description": "Backward tabulation within an executing command"},
-    {"name": "terminal:select_previous_block", "description": "Select previous block"},
-    {"name": "terminal:select_next_block", "description": "Select next block"},
-    {"name": "terminal:open_share_block_modal", "description": "Share selected block"},
-    {"name": "terminal:bookmark_selected_block", "description": "Bookmark selected block"},
-    {"name": "terminal:find_within_block", "description": "Find within selected block"},
-    {"name": "terminal:copy_block", "description": "Copy Command and Output"},
-    {"name": "terminal:copy_outputs", "description": "Copy command output"},
-    {"name": "terminal:copy_commands", "description": "Copy command"},
-    {"name": "terminal:scroll_up_one_line", "description": "Scroll terminal output up one line"},
-    {"name": "terminal:scroll_down_one_line", "description": "Scroll terminal output down one line"},
-    {"name": "terminal:scroll_to_top_of_selected_block", "description": "Scroll to top of selected block"},
-    {"name": "terminal:scroll_to_bottom_of_selected_block", "description": "Scroll to bottom of selected block"},
-    {"name": "terminal:select_all_blocks", "description": "Select all blocks"},
-    {"name": "terminal:expand_block_selection_above", "description": "Expand selected blocks above"},
-    {"name": "terminal:expand_block_selection_below", "description": "Expand selected blocks below"},
-    {"name": "terminal:ask_ai_assistant", "description": "Attach Selected Block as Agent Context"},
-    {"name": "terminal:ask_ai_assistant_text", "description": "Attach Selected Text as Agent Context"},
-    {"name": "terminal:ask_ai_about_selection", "description": "Ask Warp AI about Selection"},
-    {"name": "terminal:ask_ai_assistant_last_block", "description": "Ask Warp AI about last block"},
-    {"name": "terminal:ask_ai", "description": "Ask Warp AI"},
-    {"name": "input:insert_command_correction", "description": "Insert Command Correction"},
-    {"name": "terminal:onboarding_flow", "description": "Setup Guide"},
-    {"name": "workspace:open_settings_import_page", "description": "Import External Settings"},
-    {"name": "terminal:share_current_session", "description": "Share current session"},
-    {"name": "terminal:stop_sharing_current_session", "description": "Stop sharing current session"},
-    {"name": "terminal:toggle_block_filter", "description": "Toggle block filter on selected or last block"},
-    {"name": "terminal:toggle_snackbar_in_active_pane", "description": "Toggle Sticky Command Header in Active Pane"},
-    {"name": "terminal:toggle_autoexecute_mode", "description": "Toggle Auto-execute Mode"},
-    {"name": "workspace:init_project_rules", "description": "Initiate project for warp"},
-    {"name": "terminal:toggle_code_review_pane", "description": "Toggle code review pane"},
-    {"name": "workspace:add_current_dir_as_project", "description": "Add current folder as project"},
-    {"name": "project_buttons:open_repository", "description": "Open repository"},
-    {"name": "project_buttons:create_new_project", "description": "Create new project"},
-    {"name": "terminal:set_input_mode_agent", "description": "Set Input Mode to Agent Mode"},
-    {"name": "terminal:set_input_mode_terminal", "description": "Set Input Mode to Terminal Mode"},
-    {"name": "terminal:toggle_hide_cli_responses", "description": "Toggle Hide CLI Responses"},
-    {"name": "workspace:show_theme_chooser", "description": "Open theme picker"},
-    {"name": "workspace:activate_first_tab", "description": "Switch to 1st tab"},
-    {"name": "workspace:activate_second_tab", "description": "Switch to 2nd tab"},
-    {"name": "workspace:activate_third_tab", "description": "Switch to 3rd tab"},
-    {"name": "workspace:activate_fourth_tab", "description": "Switch to 4th tab"},
-    {"name": "workspace:activate_fifth_tab", "description": "Switch to 5th tab"},
-    {"name": "workspace:activate_sixth_tab", "description": "Switch to 6th tab"},
-    {"name": "workspace:activate_seventh_tab", "description": "Switch to 7th tab"},
-    {"name": "workspace:activate_eighth_tab", "description": "Switch to 8th tab"},
-    {"name": "workspace:activate_last_tab", "description": "Switch to last tab"},
-    {"name": "workspace:activate_prev_tab", "description": "Activate previous tab"},
-    {"name": "workspace:activate_next_tab", "description": "Activate next tab"},
-    {"name": "pane_group:navigate_prev", "description": "Activate previous pane"},
-    {"name": "pane_group:navigate_next", "description": "Activate next pane"},
-    {"name": "workspace:toggle_mouse_reporting", "description": "Toggle Mouse Reporting"},
-    {"name": "workspace:create_team_notebook", "description": "Create a new team notebook"},
-    {"name": "workspace:create_personal_notebook", "description": "Create a new personal notebook"},
-    {"name": "workspace:create_team_workflow", "description": "Create a new team workflow"},
-    {"name": "workspace:create_personal_workflow", "description": "Create a new personal workflow"},
-    {"name": "workspace:create_team_folder", "description": "Create a new team folder"},
-    {"name": "workspace:create_personal_folder", "description": "Create a new personal folder"},
-    {"name": "workspace:new_tab", "description": "Create new tab"},
-    {"name": "workspace:new_terminal_tab", "description": "Create new terminal tab"},
-    {"name": "workspace:toggle_left_panel", "description": "Open Left Panel"},
-    {"name": "workspace:toggle_right_panel", "description": "Toggle code review"},
-    {"name": "workspace:left_panel_agent_conversations", "description": "Left Panel: Agent conversations"},
-    {"name": "workspace:left_panel_project_explorer", "description": "Left Panel: Project explorer"},
-    {"name": "workspace:left_panel_global_search", "description": "Left Panel: Global search"},
-    {"name": "workspace:left_panel_warp_drive", "description": "Left Panel: Warp Drive"},
-    {"name": "workspace:toggle_project_explorer", "description": "Toggle project explorer"},
-    {"name": "workspace:toggle_global_search", "description": "Toggle global search"},
-    {"name": "workspace:toggle_warp_drive", "description": "Toggle Warp Drive"},
-    {"name": "workspace:toggle_conversation_list_view", "description": "Toggle Agent conversation list view"},
-    {"name": "workspace:close_panel", "description": "Close focused panel"},
-    {"name": "workspace:toggle_command_palette", "description": "Toggle command palette"},
-    {"name": "workspace:move_tab_left", "description": "Move tab left"},
-    {"name": "workspace:rename_tab", "description": "Rename tab"},
-    {"name": "workspace:terminate_app", "description": "Quit Warp"},
-    {"name": "workspace:close_window", "description": "Close Window"},
-    {"name": "workspace:close_active_tab", "description": "Close the current tab"},
-    {"name": "workspace:close_other_tabs", "description": "Close other tabs"},
-    {"name": "workspace:close_tabs_right_active_tab", "description": "Close tabs to the right"},
-    {"name": "workspace:toggle_notifications_on", "description": "Turn notifications on"},
-    {"name": "workspace:toggle_notifications_off", "description": "Turn notifications off"},
-    {"name": "workspace:toggle_navigation_palette", "description": "Toggle navigation palette"},
-    {"name": "workspace:toggle_launch_config_palette", "description": "Launch configuration palette"},
-    {"name": "workspace:toggle_files_palette", "description": "Toggle Files Palette"},
-    {"name": "workspace:open_launch_config_save_modal", "description": "Save new launch configuration"},
-    {"name": "workspace:search_drive", "description": "Search Warp Drive"},
-    {"name": "workspace:update_and_relaunch", "description": "Install update and relaunch"},
-    {"name": "workspace:check_for_updates", "description": "Check for updates"},
-    {"name": "workspace:log_out", "description": "Log out"},
-    {"name": "workspace:toggle_resource_center", "description": "Toggle resource center"},
-    {"name": "workspace:export_all_warp_drive_objects", "description": "Export all Warp Drive objects"},
-    {"name": "workspace:install_cli", "description": "Install Oz CLI command"},
-    {"name": "workspace:uninstall_cli", "description": "Uninstall Oz CLI command"},
-    {"name": "workspace:view_changelog", "description": "View latest changelog"},
-    {"name": "workspace:toggle_ai_assistant", "description": "New agent pane"},
-    {"name": "workspace:toggle_warp_ai", "description": "Toggle Warp AI"},
-    {"name": "workspace:create_team_env_vars", "description": "Create new team environment variables"},
-    {"name": "workspace:create_personal_env_vars", "description": "Create new personal environment variables"},
-    {"name": "workspace:create_personal_ai_prompt", "description": "Create a new personal prompt"},
-    {"name": "workspace:create_team_ai_prompt", "description": "Create a new team prompt"},
-    {"name": "workspace:shift_focus_left", "description": "Switch Focus to Left Panel"},
-    {"name": "workspace:shift_focus_right", "description": "Switch Focus to Right Panel"},
-    {"name": "workspace:import_to_personal_drive", "description": "Import To Personal Drive"},
-    {"name": "workspace:import_to_team_drive", "description": "Import To Team Drive"},
-    {"name": "workspace:open_repository", "description": "Open repository"},
-    {"name": "workspace:open_ai_fact_collection", "description": "Open AI Rules"},
-    {"name": "workspace:open_mcp_servers", "description": "Open MCP Servers"},
-    {"name": "workspace:jump_to_latest_toast", "description": "Jump to latest agent task"},
-    {"name": "workspace:open_conversation_history", "description": "Open conversation history"},
-    {"name": "workspace:show_settings", "description": "Open Settings"},
-    {"name": "workspace:show_settings_account_page", "description": "Open Settings: Account"},
-    {"name": "workspace:show_settings_appearance_page", "description": "Open Settings: Appearance"},
-    {"name": "workspace:show_settings_features_page", "description": "Open Settings: Features"},
-    {"name": "workspace:show_settings_shared_blocks_page", "description": "Open Settings: Shared Blocks"},
-    {"name": "workspace:show_settings_keyboard_shortcuts_page", "description": "Open Settings: Keyboard Shortcuts"},
-    {"name": "workspace:show_settings_about_page", "description": "Open Settings: About"},
-    {"name": "workspace:show_settings_teams_page", "description": "Open Settings: Teams"},
-    {"name": "workspace:show_settings_privacy_page", "description": "Open Settings: Privacy"},
-    {"name": "workspace:show_settings_warpify_page", "description": "Open Settings: Warpify"},
-    {"name": "workspace:show_ai_settings_page", "description": "Open Settings: AI"},
-    {"name": "workspace:show_settings_billing_and_usage_page", "description": "Open Settings: Billing and usage"},
-    {"name": "workspace:show_settings_code_page", "description": "Open Settings: Code"},
-    {"name": "workspace:show_settings_referrals_page", "description": "Open Settings: Referrals"},
-    {"name": "workspace:show_settings_environments_page", "description": "Open Settings: Environments"},
-    {"name": "workspace:show_mcp_servers_settings_page", "description": "Open Settings: MCP Servers"},
-    {"name": "workspace:toggle_agent_management_view", "description": "Toggle the agent management view"},
-    {"name": "workspace:show_warp_network_log", "description": "Show Warp Network Log"},
-    {"name": "input:exit_vim_insert_mode", "description": "Exit Vim Insert Mode"},
-    {"name": "input:toggle_vim_keybindings", "description": "Enable Editing Commands With Vim Keybindings"},
-    {"name": "workspace:share_pane", "description": "Share Pane"}
+    {
+      "name": "terminal:alternate_terminal_paste",
+      "description": "Alternate terminal paste"
+    },
+    {
+      "name": "terminal:warpify_subshell",
+      "description": "Warpify subshell"
+    },
+    {
+      "name": "terminal:focus_input",
+      "description": "Focus terminal input"
+    },
+    {
+      "name": "terminal:paste",
+      "description": "Paste"
+    },
+    {
+      "name": "terminal:copy",
+      "description": "Copy"
+    },
+    {
+      "name": "terminal:reinput_commands",
+      "description": "Reinput selected commands"
+    },
+    {
+      "name": "terminal:reinput_commands_with_sudo",
+      "description": "Reinput selected commands as root"
+    },
+    {
+      "name": "terminal:find",
+      "description": "Find in Terminal"
+    },
+    {
+      "name": "terminal:select_bookmark_up",
+      "description": "Select the closest bookmark up"
+    },
+    {
+      "name": "terminal:select_bookmark_down",
+      "description": "Select the closest bookmark down"
+    },
+    {
+      "name": "terminal:jump_to_latest_agent_message",
+      "description": "Jump to latest agent message"
+    },
+    {
+      "name": "terminal:open_block_list_context_menu_via_keybinding",
+      "description": "Open block context menu"
+    },
+    {
+      "name": "terminal:toggle_teams_modal",
+      "description": "Toggle team workflows modal"
+    },
+    {
+      "name": "terminal:copy_git_branch",
+      "description": "Copy git branch"
+    },
+    {
+      "name": "terminal:clear_blocks",
+      "description": "Clear Blocks"
+    },
+    {
+      "name": "terminal:executing_command_move_cursor_word_left",
+      "description": "Move cursor one word to the left within an executing command"
+    },
+    {
+      "name": "terminal:executing_command_move_cursor_word_right",
+      "description": "Move cursor one word to the right within an executing command"
+    },
+    {
+      "name": "terminal:executing_command_move_cursor_home",
+      "description": "Move cursor home within an executing command"
+    },
+    {
+      "name": "terminal:executing_command_move_cursor_end",
+      "description": "Move cursor end within an executing command"
+    },
+    {
+      "name": "terminal:executing_command_delete_word_left",
+      "description": "Delete word left within an executing command"
+    },
+    {
+      "name": "terminal:executing_command_delete_line_start",
+      "description": "Delete to line start within an executing command"
+    },
+    {
+      "name": "terminal:executing_command_delete_line_end",
+      "description": "Delete to line end within an executing command"
+    },
+    {
+      "name": "terminal:backward_tabulation",
+      "description": "Backward tabulation within an executing command"
+    },
+    {
+      "name": "terminal:open_share_block_modal",
+      "description": "Share selected block"
+    },
+    {
+      "name": "terminal:bookmark_selected_block",
+      "description": "Bookmark selected block"
+    },
+    {
+      "name": "terminal:find",
+      "description": "Find within selected block"
+    },
+    {
+      "name": "terminal:copy",
+      "description": "Copy command and output"
+    },
+    {
+      "name": "terminal:copy_outputs",
+      "description": "Copy command output"
+    },
+    {
+      "name": "terminal:copy_commands",
+      "description": "Copy command"
+    },
+    {
+      "name": "terminal:scroll_up_one_line",
+      "description": "Scroll terminal output up one line"
+    },
+    {
+      "name": "terminal:scroll_down_one_line",
+      "description": "Scroll terminal output down one line"
+    },
+    {
+      "name": "terminal:scroll_up_one_page",
+      "description": "Scroll terminal output up one page"
+    },
+    {
+      "name": "terminal:scroll_down_one_page",
+      "description": "Scroll terminal output down one page"
+    },
+    {
+      "name": "terminal:scroll_to_top_of_selected_block",
+      "description": "Scroll to top of selected block"
+    },
+    {
+      "name": "terminal:scroll_to_bottom_of_selected_block",
+      "description": "Scroll to bottom of selected block"
+    },
+    {
+      "name": "terminal:select_all_blocks",
+      "description": "Select all blocks"
+    },
+    {
+      "name": "terminal:expand_block_selection_above",
+      "description": "Expand selected blocks above"
+    },
+    {
+      "name": "terminal:expand_block_selection_below",
+      "description": "Expand selected blocks below"
+    },
+    {
+      "name": "terminal:ask_ai_assistant",
+      "description": "Ask Warp AI about Selection"
+    },
+    {
+      "name": "terminal:ask_ai_assistant_last_block",
+      "description": "Ask Warp AI about last block"
+    },
+    {
+      "name": "terminal:ask_ai_assistant",
+      "description": "Ask Warp AI"
+    },
+    {
+      "name": "input:insert_command_correction",
+      "description": "Insert Command Correction"
+    },
+    {
+      "name": "workspace:open_settings_import_page",
+      "description": "Import External Settings"
+    },
+    {
+      "name": "terminal:share_current_session",
+      "description": "Share current session"
+    },
+    {
+      "name": "terminal:stop_sharing_current_session",
+      "description": "Stop sharing current session"
+    },
+    {
+      "name": "terminal:toggle_snackbar_in_active_pane",
+      "description": "Toggle Sticky Command Header in Active Pane"
+    },
+    {
+      "name": "terminal:load_agent_mode_conversation",
+      "description": "Load agent mode conversation (from debug link in clipboard)"
+    },
+    {
+      "name": "terminal:toggle_session_recording",
+      "description": "Toggle PTY Recording for Session"
+    },
+    {
+      "name": "terminal:toggle_conversation_details_panel",
+      "description": "Toggle Conversation Details Panel"
+    },
+    {
+      "name": "terminal:ask_ai_assistant",
+      "description": "Attach Selected Block as Agent Context"
+    },
+    {
+      "name": "terminal:ask_ai_assistant",
+      "description": "Attach Selected Text as Agent Context"
+    },
+    {
+      "name": "workspace:write_codebase_index",
+      "description": "Write current codebase index snapshot"
+    },
+    {
+      "name": "workspace:init_project_rules",
+      "description": "Initiate project for warp"
+    },
+    {
+      "name": "workspace:add_current_dir_as_project",
+      "description": "Add current folder as project"
+    },
+    {
+      "name": "workspace:panic",
+      "description": "Trigger a panic (for testing sentry-rust)"
+    },
+    {
+      "name": "workspace:open_view_tree_debug_view",
+      "description": "Open view tree debugger"
+    },
+    {
+      "name": "workspace:sample_process",
+      "description": "Sample Process"
+    },
+    {
+      "name": "workspace:dump_heap_profile",
+      "description": "Write heap profile to disk"
+    },
+    {
+      "name": "workspace:increase_zoom",
+      "description": "Increase zoom level"
+    },
+    {
+      "name": "workspace:decrease_zoom",
+      "description": "Decrease zoom level"
+    },
+    {
+      "name": "workspace:reset_zoom",
+      "description": "Reset zoom level to default"
+    },
+    {
+      "name": "workspace:increase_font_size",
+      "description": "Increase font size"
+    },
+    {
+      "name": "workspace:decrease_font_size",
+      "description": "Decrease font size"
+    },
+    {
+      "name": "workspace:reset_font_size",
+      "description": "Reset font size to default"
+    },
+    {
+      "name": "workspace:show_theme_chooser",
+      "description": "Open theme picker"
+    },
+    {
+      "name": "workspace:activate_first_tab",
+      "description": "Switch to 1st tab"
+    },
+    {
+      "name": "workspace:activate_second_tab",
+      "description": "Switch to 2nd tab"
+    },
+    {
+      "name": "workspace:activate_third_tab",
+      "description": "Switch to 3rd tab"
+    },
+    {
+      "name": "workspace:activate_fourth_tab",
+      "description": "Switch to 4th tab"
+    },
+    {
+      "name": "workspace:activate_fifth_tab",
+      "description": "Switch to 5th tab"
+    },
+    {
+      "name": "workspace:activate_sixth_tab",
+      "description": "Switch to 6th tab"
+    },
+    {
+      "name": "workspace:activate_seventh_tab",
+      "description": "Switch to 7th tab"
+    },
+    {
+      "name": "workspace:activate_eighth_tab",
+      "description": "Switch to 8th tab"
+    },
+    {
+      "name": "workspace:activate_last_tab",
+      "description": "Switch to last tab"
+    },
+    {
+      "name": "workspace:activate_prev_tab",
+      "description": "Activate previous tab"
+    },
+    {
+      "name": "workspace:activate_next_tab",
+      "description": "Activate next tab"
+    },
+    {
+      "name": "pane_group:navigate_prev",
+      "description": "Activate previous pane"
+    },
+    {
+      "name": "pane_group:navigate_next",
+      "description": "Activate next pane"
+    },
+    {
+      "name": "workspace:toggle_keybindings_page",
+      "description": "Toggle keyboard shortcuts"
+    },
+    {
+      "name": "workspace:show_keybinding_settings",
+      "description": "Open keybindings editor"
+    },
+    {
+      "name": "workspace:toggle_block_snackbar",
+      "description": "Toggle sticky command header"
+    },
+    {
+      "name": "workspace:set_a11y_concise_verbosity_level",
+      "description": "[a11y] Set concise accessibility announcements"
+    },
+    {
+      "name": "workspace:set_a11y_verbose_verbosity_level",
+      "description": "[a11y] Set verbose accessibility announcements"
+    },
+    {
+      "name": "workspace:rename_active_tab",
+      "description": "Rename the current tab"
+    },
+    {
+      "name": "workspace:rename_active_pane",
+      "description": "Rename the current pane"
+    },
+    {
+      "name": "workspace:new_tab_group",
+      "description": "Create new tab group"
+    },
+    {
+      "name": "workspace:new_tab_group_from_active_or_selected_tabs",
+      "description": "Create tab group from active or selected tab(s)"
+    },
+    {
+      "name": "workspace:remove_active_or_selected_tabs_from_group",
+      "description": "Remove active or selected tab(s) from group"
+    },
+    {
+      "name": "workspace:pin_active_tab",
+      "description": "Pin current tab"
+    },
+    {
+      "name": "workspace:unpin_active_tab",
+      "description": "Unpin current tab"
+    },
+    {
+      "name": "workspace:pin_active_tab_group",
+      "description": "Pin current tab group"
+    },
+    {
+      "name": "workspace:unpin_active_tab_group",
+      "description": "Unpin current tab group"
+    },
+    {
+      "name": "workspace:terminate_app",
+      "description": "Quit Warp"
+    },
+    {
+      "name": "workspace:close_active_tab",
+      "description": "Close the current tab"
+    },
+    {
+      "name": "workspace:close_other_tabs",
+      "description": "Close other tabs"
+    },
+    {
+      "name": "workspace:toggle_notifications_on",
+      "description": "Turn notifications on"
+    },
+    {
+      "name": "workspace:toggle_notifications_off",
+      "description": "Turn notifications off"
+    },
+    {
+      "name": "workspace:toggle_launch_config_palette",
+      "description": "Launch configuration palette"
+    },
+    {
+      "name": "workspace:toggle_files_palette",
+      "description": "Toggle Files Palette"
+    },
+    {
+      "name": "workspace:open_launch_config_save_modal",
+      "description": "Save new launch configuration"
+    },
+    {
+      "name": "workspace:update_and_relaunch",
+      "description": "Install update and relaunch"
+    },
+    {
+      "name": "workspace:check_for_updates",
+      "description": "Check for updates"
+    },
+    {
+      "name": "workspace:log_out",
+      "description": "Log out"
+    },
+    {
+      "name": "workspace:toggle_resource_center",
+      "description": "Toggle resource center"
+    },
+    {
+      "name": "workspace:export_all_warp_drive_objects",
+      "description": "Export all Warp Drive objects"
+    },
+    {
+      "name": "workspace:install_cli",
+      "description": "Install Oz CLI globally for use outside of Warp"
+    },
+    {
+      "name": "workspace:uninstall_cli",
+      "description": "Undo global Oz CLI installation (oz will still work within Warp)"
+    },
+    {
+      "name": "workspace:install_warpctrl",
+      "description": "Install Warp Control CLI globally for use outside of Warp"
+    },
+    {
+      "name": "workspace:uninstall_warpctrl",
+      "description": "Undo global Warp Control CLI installation (warpctrl will still work within Warp)"
+    },
+    {
+      "name": "workspace:view_changelog",
+      "description": "View latest changelog"
+    },
+    {
+      "name": "workspace:toggle_ai_assistant",
+      "description": "Toggle Warp AI"
+    },
+    {
+      "name": "workspace:shift_focus_left",
+      "description": "Switch Focus to Left Panel"
+    },
+    {
+      "name": "workspace:shift_focus_right",
+      "description": "Switch Focus to Right Panel"
+    },
+    {
+      "name": "workspace:import_to_personal_drive",
+      "description": "Import To Personal Drive"
+    },
+    {
+      "name": "workspace:import_to_team_drive",
+      "description": "Import To Team Drive"
+    },
+    {
+      "name": "workspace:copy_access_token_to_clipboard",
+      "description": "Copy access token to clipboard"
+    },
+    {
+      "name": "workspace:jump_to_latest_toast",
+      "description": "Jump to latest agent task"
+    },
+    {
+      "name": "workspace:toggle_agent_management_view",
+      "description": "Toggle the agent management view"
+    },
+    {
+      "name": "workspace:show_settings_account_page",
+      "description": "Open Settings: Account"
+    },
+    {
+      "name": "workspace:show_settings_features_page",
+      "description": "Open Settings: Features"
+    },
+    {
+      "name": "workspace:open_settings_file",
+      "description": "Open settings file"
+    },
+    {
+      "name": "workspace:show_invite_modal",
+      "description": "Invite People..."
+    },
+    {
+      "name": "workspace:link_to_slack",
+      "description": "Join our Slack community (opens external link)"
+    },
+    {
+      "name": "workspace:link_to_user_docs",
+      "description": "View user docs (opens external link)"
+    },
+    {
+      "name": "workspace:view_logs",
+      "description": "View Warp logs"
+    },
+    {
+      "name": "workspace:link_to_privacy_policy",
+      "description": "View privacy policy (opens external link)"
+    },
+    {
+      "name": "workspace:create_team_notebook",
+      "description": "Create a new team notebook"
+    },
+    {
+      "name": "workspace:create_personal_notebook",
+      "description": "Create a new personal notebook"
+    },
+    {
+      "name": "workspace:create_team_workflow",
+      "description": "Create a new team workflow"
+    },
+    {
+      "name": "workspace:create_personal_workflow",
+      "description": "Create a new personal workflow"
+    },
+    {
+      "name": "workspace:create_team_folder",
+      "description": "Create a new team folder"
+    },
+    {
+      "name": "workspace:create_personal_folder",
+      "description": "Create a new personal folder"
+    },
+    {
+      "name": "workspace:toggle_left_panel",
+      "description": "Open Left Panel"
+    },
+    {
+      "name": "file_tree:toggle_hidden_files",
+      "description": "Toggle hidden files in Project Explorer"
+    },
+    {
+      "name": "workspace:close_panel",
+      "description": "Close focused panel"
+    },
+    {
+      "name": "workspace:toggle_command_palette",
+      "description": "Toggle command palette"
+    },
+    {
+      "name": "workspace:move_tab_left",
+      "description": "Move tab left"
+    },
+    {
+      "name": "workspace:move_tab_right",
+      "description": "Move tab right"
+    },
+    {
+      "name": "workspace:close_window",
+      "description": "Close Window"
+    },
+    {
+      "name": "workspace:close_tabs_right_active_tab",
+      "description": "Close tabs to the right"
+    },
+    {
+      "name": "workspace:toggle_navigation_palette",
+      "description": "Toggle navigation palette"
+    },
+    {
+      "name": "workspace:create_team_env_vars",
+      "description": "Create new team environment variables"
+    },
+    {
+      "name": "workspace:create_personal_env_vars",
+      "description": "Create new personal environment variables"
+    },
+    {
+      "name": "workspace:create_personal_ai_prompt",
+      "description": "Create a new personal prompt"
+    },
+    {
+      "name": "workspace:create_team_ai_prompt",
+      "description": "Create a new team prompt"
+    },
+    {
+      "name": "workspace:copy_current_path",
+      "description": "Copy current path"
+    },
+    {
+      "name": "workspace:open_repository",
+      "description": "Open repository"
+    },
+    {
+      "name": "workspace:open_ai_fact_collection",
+      "description": "Open AI Rules"
+    },
+    {
+      "name": "workspace:open_mcp_servers",
+      "description": "Open MCP Servers"
+    },
+    {
+      "name": "workspace:show_settings",
+      "description": "Open Settings"
+    },
+    {
+      "name": "workspace:show_settings_appearance_page",
+      "description": "Open Settings: Appearance"
+    },
+    {
+      "name": "workspace:show_settings_shared_blocks_page",
+      "description": "Open Settings: Shared Blocks"
+    },
+    {
+      "name": "workspace:show_settings_keyboard_shortcuts_page",
+      "description": "Open Settings: Keyboard Shortcuts"
+    },
+    {
+      "name": "workspace:show_settings_about_page",
+      "description": "Open Settings: About"
+    },
+    {
+      "name": "workspace:show_settings_teams_page",
+      "description": "Open Settings: Teams"
+    },
+    {
+      "name": "workspace:show_settings_privacy_page",
+      "description": "Open Settings: Privacy"
+    },
+    {
+      "name": "workspace:show_settings_warpify_page",
+      "description": "Open Settings: Warpify"
+    },
+    {
+      "name": "workspace:show_ai_settings_page",
+      "description": "Open Settings: AI"
+    },
+    {
+      "name": "workspace:show_settings_billing_and_usage_page",
+      "description": "Open Settings: Billing and usage"
+    },
+    {
+      "name": "workspace:show_settings_code_page",
+      "description": "Open Settings: Code"
+    },
+    {
+      "name": "workspace:show_settings_referrals_page",
+      "description": "Open Settings: Referrals"
+    },
+    {
+      "name": "workspace:show_settings_environments_page",
+      "description": "Open Settings: Environments"
+    },
+    {
+      "name": "workspace:show_mcp_servers_settings_page",
+      "description": "Open Settings: MCP Servers"
+    },
+    {
+      "name": "workspace:send_feedback",
+      "description": "Send feedback (opens external link)"
+    }
   ],
-  "generated_at": "2026-04-23T23:55:00Z"
+  "generated_at": "2026-07-21T21:45:59.337152+00:00"
 }

--- a/.agents/skills/validate_ui_refs/validate_ui_refs.py
+++ b/.agents/skills/validate_ui_refs/validate_ui_refs.py
@@ -1360,10 +1360,14 @@ def _extract_settings_sections(warp_internal: Path) -> Dict[str, Any]:
         re.DOTALL,
     )
     if enum_match:
-        for variant in re.findall(r"(\w+)", enum_match.group(1)):
-            if variant in ("Copy", "Clone", "Debug", "Default", "PartialEq", "default"):
-                continue
-            display_map[variant] = variant  # default: use variant name
+        # Strip Rust line/doc comments before extracting variants. Without this,
+        # words from doc comments (e.g. "backing" from "/// Internal backing-page
+        # identifier") are incorrectly captured as settings section names.
+        enum_body = re.sub(r"//[^\n]*", "", enum_match.group(1))
+        # Only match CamelCase words (enum variants), not lowercase identifiers
+        # that appear in code or attribute tokens.
+        for variant in re.findall(r"^\s*([A-Z]\w+)\s*(?:,|$)", enum_body, re.MULTILINE):
+            display_map[variant] = variant  # default: use variant name as display name
 
     # Parse Display impl for overrides
     display_impl = re.search(
@@ -1391,6 +1395,8 @@ def _extract_settings_sections(warp_internal: Path) -> Dict[str, Any]:
         "Platform": "platform_page.rs",
         "Code": "code_page.rs",
         # Agents umbrella subpages (all render widgets defined in ai_page.rs).
+        # WarpAgent is the current name; Oz is the legacy name kept for compat.
+        "WarpAgent": "ai_page.rs",
         "Oz": "ai_page.rs",
         "AgentProfiles": "ai_page.rs",
         "Knowledge": "ai_page.rs",

--- a/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
+++ b/src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
@@ -14,7 +14,7 @@ BYOK provides greater flexibility in model access and ensures Warp **never consu
 
 <VideoEmbed url="https://youtu.be/jbSBnbPzQwY" title="How to BYOK to the Warp Agent" />
 
-For xAI's Grok models, you can also connect your SuperGrok subscription instead of entering an API key. In the Warp app, go to **Settings** > **AI** and choose to connect your SuperGrok subscription — Warp opens your browser to complete the connection.
+For xAI's Grok models, you can also connect your SuperGrok subscription instead of entering an API key. In the Warp app, go to **Settings** > **Agents** > **Oz** and choose to connect your SuperGrok subscription — Warp opens your browser to complete the connection.
 
 :::note
 BYOK is available on Free and all eligible paid plans for individual users and organizations with 10 or fewer employees, subject to Warp's [Terms of Service](https://www.warp.dev/legal/terms-of-service). Larger organizations need a Business or Enterprise plan. See [Warp pricing](https://www.warp.dev/pricing) for current availability.

--- a/src/content/docs/agent-platform/inference/model-choice.mdx
+++ b/src/content/docs/agent-platform/inference/model-choice.mdx
@@ -148,7 +148,7 @@ To change models, click the displayed model name (for example, _Claude Sonnet 5_
 
 Beyond the built-in Auto models, you can define your own custom routers that automatically route each task to a concrete model based on task complexity or rules you write. Custom routers appear in the model picker alongside Auto and individual models.
 
-Add and manage custom routers in **Settings** > **AI** > **Custom Routers**. See [Custom routers](/agent-platform/inference/custom-routers/) for details on creating one.
+Add and manage custom routers in **Settings** > **Agents** > **Oz** > **Custom Routers**. See [Custom routers](/agent-platform/inference/custom-routers/) for details on creating one.
 
 ### Model fallback
 

--- a/src/content/docs/guides/agent-workflows/how-to-edit-agent-code-in-warp.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-edit-agent-code-in-warp.mdx
@@ -53,7 +53,7 @@ Once you’re happy with a diff:
 * Click **Apply Changes** to accept it
 * Or **Fast-Forward** to let Warp automatically continue the rest of the fix sequence
 
-You can control this level of autonomy globally in **Settings** > **AI** > **Autonomy**.
+You can control this level of autonomy globally in **Settings** > **Agents** > **Oz** > **Autonomy**.
 
 ---
 

--- a/src/content/docs/guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-railway.mdx
+++ b/src/content/docs/guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-railway.mdx
@@ -127,7 +127,7 @@ The project: a **real-time chat application** built with **Python (FastAPI)** an
 
    Once Warp starts executing, you can let Warp run commands automatically:
 
-   1. Go to **Settings** > **AI** > **Agents**
+   1. Go to **Settings** > **Agents** > **Profiles**
    2. Change **“Always Ask”** → **“Always Allow”**
    3. Ensure restricted commands (e.g., `rm -rf`) remain blocked
 
@@ -169,7 +169,7 @@ The project: a **real-time chat application** built with **Python (FastAPI)** an
 
    Connect GitHub MCP:
 
-   1. Go to **Settings** > **AI** > **MCP Servers** > **Add**
+   1. Go to **Settings** > **Agents** > **MCP servers** > **Add**
    2. Add a JSON block for GitHub MCP:
 
    ```json

--- a/src/content/docs/guides/external-tools/sqlite-and-stripe-mcp-basic-queries-you-can-make-after-set-up.mdx
+++ b/src/content/docs/guides/external-tools/sqlite-and-stripe-mcp-basic-queries-you-can-make-after-set-up.mdx
@@ -25,7 +25,7 @@ This tutorial teaches you how to use **MCP servers** to connect Warp to **Stripe
 
    To set it up:
 
-   * Open **Settings** > **AI** > **MCP Servers** in Warp.
+   * Open **Settings** > **Agents** > **MCP servers** in Warp.
    * Click **Add Server**, and choose from a list of available MCP configurations.
    * Once added, Warp automatically connects and authorizes the agent to use those tools.
 

--- a/src/content/docs/guides/getting-started/how-to-customize-warps-appearance.mdx
+++ b/src/content/docs/guides/getting-started/how-to-customize-warps-appearance.mdx
@@ -44,7 +44,7 @@ Warp’s **input bar** can live in three different positions:
 
 ### 3. Managing AI & agent settings
 
-Open **Settings** > **AI** to control:
+Open **Settings** > **Agents** > **Oz** to control:
 
 * Which **model** Warp uses (e.g., Claude 3.5 for code generation, GPT-4o for planning).
 * How much **autonomy** agents have for:

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -268,7 +268,7 @@ Regardless of plan, Warp never allows OpenAI, Anthropic, Google, or other model 
 
 ### Can I bring my own API key?
 
-Yes. On Free, Build, Max, Business, and Enterprise plans, you can configure your own OpenAI, Anthropic, or Google API key in **Settings** > **AI** > **Manage models**. Requests routed through your own key don't consume Warp credits — you're billed directly by the model provider.
+Yes. On Free, Build, Max, Business, and Enterprise plans, you can configure your own OpenAI, Anthropic, or Google API key in **Settings** > **Agents** > **Oz** > **Manage models**. Requests routed through your own key don't consume Warp credits — you're billed directly by the model provider.
 
 See [Bring Your Own API Key](/agent-platform/inference/bring-your-own-api-key/) for setup steps, the list of supported providers and models, and the differences between BYOK, custom inference endpoints, and BYOLLM.
 
@@ -393,7 +393,7 @@ Unused add-on credits remain valid for 12 months from purchase, as long as you h
 
 #### Can I bring my own API key on the Free plan now?
 
-Yes. As of May 21, 2026, **Bring Your Own API Key (BYOK)** is available on all plans, including Free. Previously, BYOK required a Build, Business, or Enterprise subscription. You can configure your OpenAI, Anthropic, or Google key under **Settings** > **AI** > **Manage models**.
+Yes. As of May 21, 2026, **Bring Your Own API Key (BYOK)** is available on all plans, including Free. Previously, BYOK required a Build, Business, or Enterprise subscription. You can configure your OpenAI, Anthropic, or Google key under **Settings** > **Agents** > **Oz** > **Manage models**.
 
 See [Bring Your Own API Key](/agent-platform/inference/bring-your-own-api-key/) for the full list of supported providers and setup steps.
 

--- a/src/content/docs/terminal/input/universal-input.mdx
+++ b/src/content/docs/terminal/input/universal-input.mdx
@@ -90,7 +90,7 @@ The model Warp uses to detect natural language automatically is completely local
 
 By default, auto-detection is enabled. This means Warp decides whether to treat your input as a command or an Agent prompt.
 
-* **To turn off auto-detection**: go to **Settings** > **AI** > **Input** > **Natural Language Detection**
+* **To turn off auto-detection**: go to **Settings** > **Agents** > **Oz** > **Input** > **Natural Language Detection**
 * When disabled: You’ll explicitly be in either Terminal or Agent Mode. Use the following keyboard shortcuts to switch between modes:
   * `CMD+I` (macOS)
   * `CTRL+I` (Windows/Linux)
@@ -195,11 +195,11 @@ Warp can automatically detect when you’re writing in plain English and switch 
 
 #### Fixing false detections
 
-If certain shell commands are mistakenly detected as natural language, you can add them to the denylist: **Settings** > **AI** > **Input** > **Natural language denylist**
+If certain shell commands are mistakenly detected as natural language, you can add them to the denylist: **Settings** > **Agents** > **Oz** > **Input** > **Natural language denylist**
 
 #### Turning off auto-detection
 
-To disable natural language detection entirely, go to: **Settings** > **AI** > **Input Auto-detection**
+To disable natural language detection entirely, go to: **Settings** > **Agents** > **Oz** > **Input Auto-detection**
 
 When auto-detection is turned off, you’ll need to explicitly switch between Terminal Mode and Agent Mode using `CMD + I` (macOS) or `CTRL + I` (Windows/Linux).
 


### PR DESCRIPTION
Combines three things into one PR to supersede #358.

## 1. Extractor bug fix (`validate_ui_refs.py`)

The `SettingsSection` enum in the OSS warp repo contains Rust doc comments inside the enum body (e.g. `/// Internal backing-page identifier...`). The old extractor used `re.findall(r'(\w+)', enum_body)` which matched ALL words — including common words from comments like `backing`, `for`, `is`, `as`, `the`, single letters, etc.

Fix: strip `//` line comments first, then only match lines that contain CamelCase identifiers (actual enum variants). Also adds `WarpAgent` to the page file map (the current name for the Oz subpage in the OSS warp repo).

## 2. Refreshed `valid_paths.json`

Regenerated from the fixed extractor against `warpdotdev/warp`: 25 clean sections, 3 umbrellas, 4 deprecated sections, 164 command palette commands.

## 3. Doc path fixes (from #358)

14 stale `Settings > AI` paths corrected to current umbrella paths (`Settings > Agents > Oz`, `Settings > Agents > Profiles`, `Settings > Agents > MCP servers`, etc.) 14 stale `Settings > AI` paths corrected to c#358 (alt text space, `detail` back to backtick) were already correct on `main`.

Closes #358.

Co-Authored-By: Oz <oz-agent@warp.dev>