### PR TITLE
docs: missing_docs audit bookkeeping (surface map + snapshot)

### DIFF
--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -147,6 +147,12 @@ DragTabsToWindows -> src/content/docs/terminal/windows/tabs.mdx
 RevertDiffHunk -> src/content/docs/code/code-review.mdx
 SshRemoteServer -> src/content/docs/terminal/warpify/ssh.mdx
 
+# Computer use: session recording (VideoRecording gates the start/stop recording
+# tools) and window-targeted background capture (BackgroundComputerUse). Both are
+# GA and documented on the computer use capability page.
+VideoRecording -> src/content/docs/agent-platform/capabilities/computer-use.mdx
+BackgroundComputerUse -> src/content/docs/agent-platform/capabilities/computer-use.mdx
+
 # Feature flags whose only user-facing surface is a documented setting in the
 # all-settings reference (terminal/settings/all-settings.mdx).
 # - FullScreenZenMode: the "zen mode" tab-bar visibility knob appearance.tabs.workspace_decoration_visibility
@@ -360,8 +366,13 @@ GET /memory_stores/{uid}/memories/{memoryUid}/versions -> gated:AIMemories
 /view-logs -> internal
 /auto-approve -> internal
 /logout -> internal
-/enable-natural-language-detection -> internal
-/disable-natural-language-detection -> internal
+# The paired /enable- and /disable-natural-language-detection commands were
+# replaced by a single toggle, /natural-language-detection. Like the other Warp
+# Agent CLI-only commands above, it isn't in the GUI, so it stays internal.
+/natural-language-detection -> internal
+# TUI-only voice input and version commands (Warp Agent CLI surface).
+/voice -> internal
+/version -> internal
 
 ## Settings -> doc pages
 
@@ -378,6 +389,14 @@ warpify.ssh.ssh_tmux_deprecation_notice_pending -> internal
 # Warp Agent CLI). It isn't present in the GUI settings UI, so it isn't
 # documented in the all-settings reference.
 general.autoupdate_enabled -> internal
+
+# Warp Agent CLI-only (crates/warp_tui) zero-state animation knobs (surface: Warp
+# Agent CLI, SettingSurfaces::TUI). They tune the rotating object shown in the
+# empty Warp Agent CLI state and aren't present in the GUI settings UI, so they
+# aren't documented in the all-settings reference.
+appearance.zero_state.object -> internal
+appearance.zero_state.rotation_period_seconds -> internal
+appearance.zero_state.extrusion_depth -> internal
 
 ## Unlisted docs pages to ignore
 
@@ -453,6 +472,9 @@ OpenWarpLaunchModal
 OrchestrationLaunchModal
 GetStartedTab
 CreateProjectFlow
+# Account-first onboarding is an internal login/onboarding flow variant with no
+# distinct user-facing surface to document (like HOAOnboardingFlow below).
+AccountFirstOnboarding
 CodeLaunchModal
 ValidateAutosuggestions
 ClearAutosuggestionOnEscape

--- a/.agents/skills/missing_docs/references/surface_snapshot.json
+++ b/.agents/skills/missing_docs/references/surface_snapshot.json
@@ -11,6 +11,7 @@
     "AIRules": "ga",
     "APIKeyAuthentication": "ga",
     "APIKeyManagement": "ga",
+    "AccountFirstOnboarding": "ga",
     "ActiveConversationRequiresInteraction": "ga",
     "AgentDecidesCommandExecution": "ga",
     "AgentHarness": "ga",
@@ -45,7 +46,7 @@
     "Autoupdate": "ga",
     "AutoupdateUIRevamp": "ga",
     "AvatarInTabBar": "ga",
-    "BackgroundComputerUse": "dogfood",
+    "BackgroundComputerUse": "ga",
     "BillingAndUsagePageV2": "ga",
     "BlocklistMarkdownImages": "ga",
     "BlocklistMarkdownTableRendering": "ga",
@@ -271,7 +272,7 @@
     "ValidateAutosuggestions": "ga",
     "VerticalTabs": "ga",
     "VerticalTabsSummaryMode": "ga",
-    "VideoRecording": "dogfood",
+    "VideoRecording": "ga",
     "ViewingSharedSessions": "ga",
     "VimCodeEditor": "ga",
     "WaitForEventsParentRegistration": "dogfood",
@@ -425,6 +426,10 @@
     },
     {
       "command": "oz harness-support report-artifact",
+      "hidden": true
+    },
+    {
+      "command": "oz harness-support report-external-reference",
       "hidden": true
     },
     {
@@ -808,6 +813,7 @@
     "DELETE /api/v1/factory/automations/{id}/subscriptions/{subscription_id}",
     "DELETE /api/v1/factory/{uid}",
     "DELETE /api/v1/factory/{uid}/source",
+    "DELETE /api/v1/factory/{uid}/tasks/{task_uid}",
     "DELETE /api/v1/memory_stores/{uid}",
     "DELETE /api/v1/memory_stores/{uid}/memories/{memoryUid}",
     "GET /.well-known/openid-configuration",
@@ -842,6 +848,9 @@
     "GET /api/v1/factory/{uid}",
     "GET /api/v1/factory/{uid}/source",
     "GET /api/v1/factory/{uid}/syncs",
+    "GET /api/v1/factory/{uid}/task-by-conversation",
+    "GET /api/v1/factory/{uid}/tasks",
+    "GET /api/v1/factory/{uid}/tasks/{task_uid}",
     "GET /api/v1/harness-support/transcript",
     "GET /api/v1/memory_stores",
     "GET /api/v1/memory_stores/{uid}",
@@ -853,6 +862,7 @@
     "GET /api/v1/oauth/jwks.json",
     "PATCH /api/v1/agent/runs/{runId}/event-sequence",
     "PATCH /api/v1/factory/{uid}",
+    "PATCH /api/v1/factory/{uid}/tasks/{task_uid}",
     "POST /api/v1/agent/events/{run_id}",
     "POST /api/v1/agent/handoff/upload-snapshot",
     "POST /api/v1/agent/identities",
@@ -875,6 +885,7 @@
     "POST /api/v1/factory/avatar",
     "POST /api/v1/factory/{uid}/apply",
     "POST /api/v1/factory/{uid}/plan",
+    "POST /api/v1/factory/{uid}/tasks",
     "POST /api/v1/harness-support/block-snapshot",
     "POST /api/v1/harness-support/external-conversation",
     "POST /api/v1/harness-support/finish-task",
@@ -891,6 +902,7 @@
     "POST /api/v1/oauth/token",
     "PUT /api/v1/agent/identities/{uid}",
     "PUT /api/v1/agent/schedules/{id}",
+    "PUT /api/v1/factory/automations/{id}",
     "PUT /api/v1/factory/automations/{id}/subscriptions",
     "PUT /api/v1/factory/{uid}/source",
     "PUT /api/v1/memory_stores/{uid}",
@@ -911,9 +923,7 @@
     "/cost",
     "/create-environment",
     "/create-new-project",
-    "/disable-natural-language-detection",
     "/docker-sandbox",
-    "/enable-natural-language-detection",
     "/environment",
     "/exit",
     "/export-to-clipboard",
@@ -930,6 +940,7 @@
     "/logout",
     "/mcp",
     "/model",
+    "/natural-language-detection",
     "/new",
     "/open-code-review",
     "/open-file",
@@ -949,7 +960,9 @@
     "/set-tab-color",
     "/skills",
     "/usage",
-    "/view-logs"
+    "/version",
+    "/view-logs",
+    "/voice"
   ],
   "settings": {
     "accessibility.accessibility_verbosity": "always_on",
@@ -1059,6 +1072,9 @@
     "appearance.window.override_blur_texture": "always_on",
     "appearance.window.override_opacity": "always_on",
     "appearance.window.zoom_level": "always_on",
+    "appearance.zero_state.extrusion_depth": "always_on",
+    "appearance.zero_state.object": "always_on",
+    "appearance.zero_state.rotation_period_seconds": "always_on",
     "cloud_platform.third_party_api_keys.aws_bedrock_auth_refresh_command": "always_on",
     "cloud_platform.third_party_api_keys.aws_bedrock_auto_login": "always_on",
     "cloud_platform.third_party_api_keys.aws_bedrock_credentials_enabled": "always_on",
@@ -1233,6 +1249,8 @@
     "read_skill",
     "read_todos",
     "remove_todos",
+    "report_intent",
+    "report_outcome",
     "report_pr",
     "report_screenshot",
     "request_computer_use",
@@ -1247,7 +1265,6 @@
     "send_message_to_agent",
     "set_computer_use_target",
     "skip",
-    "start_agent",
     "start_recording",
     "stop_recording",
     "suggest_prompt",
@@ -1277,5 +1294,5 @@
     "verify-ui-change-in-cloud": "dogfood",
     "warpctrl": "bundled"
   },
-  "changelog_last_version": "2026.07.16"
+  "changelog_last_version": "2026.07.23"
 }


### PR DESCRIPTION
## Summary
Companion **audit-bookkeeping** change for the `missing_docs` drift-watch run. Collects all surface-map edits and the regenerated snapshot into one PR (per the skill's PR strategy), so the shared `feature_surface_map.md` and `surface_snapshot.json` don't conflict across the feature PRs.

### Surface map edits
- Map `VideoRecording` and `BackgroundComputerUse` -> Computer Use page (docs added in #374).
- Slash commands: replace the removed `/enable-natural-language-detection` and `/disable-natural-language-detection` entries with `/natural-language-detection`; map the new TUI-only `/voice` and `/version` -> `internal` (Warp Agent CLI surface, not in the GUI slash-commands page).
- Settings: map the new TUI-only `appearance.zero_state.object`, `appearance.zero_state.rotation_period_seconds`, and `appearance.zero_state.extrusion_depth` -> `internal` (`SettingSurfaces::TUI`, not in the GUI settings UI — consistent with `general.autoupdate_enabled`).
- Flags: add `AccountFirstOnboarding` to the internal ignore list (internal login/onboarding flow variant, no distinct user-facing surface).

### Snapshot
- Regenerated with `--update-snapshot` (absorbs the new factory/agent API routes, the `report_intent`/`report_outcome`/`start_agent` server-tool diffs, the new slash/settings surfaces, and advances the last-seen changelog version).

Companion feature PRs: **#373** (cloud runners) and **#374** (Computer Use recording).

## Related feature verified already documented (no change needed)
- Tab pinning, tab groups, and drag-a-tab-to-another-window (changelog 2026.07.23) are already fully documented in `terminal/windows/tabs.mdx`.

## Deferred findings (nothing silently dropped)
These remain open by design and were **not** documented in this run:

- **41 public API endpoints** (`/factory/*`, `/agent/artifacts/*`, `/agent/events*`, `/agent/messages*`, `/agent/schedules/{id}*`, `/agent/run-by-external-reference`). `warp-server` is a **private** repo and these are **not in the released OpenAPI spec**, so they must not be hand-documented. Route any that are publicly released through the **`sync-openapi-spec`** skill as a separate change; the rest stay deferred. Factory endpoints back the (preview) software-factory surface.
- **32 docs-staleness (terminology) findings** — LOW; pure wording/style is owned by the **`style_lint`** skill and is intentionally out of scope here. Several are also false positives in context (e.g. "warp terminal" when distinguishing from Oz, "ai credits" on billing pages).
- **Changelog items to verify** — the bulk are incremental Warp TUI (Warp Agent CLI) UX improvements and the `oh-my-pi (omp)` CLI-agent integration. TUI-only surfaces are treated as `internal` here (matching existing map policy); `omp` is deferred pending confirmation of public/GA status. The snapshot regen advances the last-seen changelog version so these don't re-fire as noise.

## Validation
- `missing_docs` audit re-run after all edits: `feature_flags`, `cli_commands`, `slash_commands`, and `settings` findings are all **0**; completeness accounting reports **no unaccounted items**. Remaining findings are only the deferred API (41) and staleness (32) buckets above.
- Both audit modes exited **0** (no `audits_skipped`, no extraction-guard failures).

_Conversation: https://staging.warp.dev/conversation/a962f7a4-4945-4f91-af46-26e65f71152d_
_Run: https://oz.staging.warp.dev/runs/019f9511-e5f7-78c7-8960-dc26fa67140d_

_This PR was generated with [Oz](https://warp.dev/oz)._
