### PR TITLE
docs(cli): context (rules, skills, MCP)

### DIFF
--- a/src/content/docs/cli/context.mdx
+++ b/src/content/docs/cli/context.mdx
@@ -6,22 +6,63 @@ description: >-
 ---
 import { VARS } from '@data/vars';
 
-{/* TODO(cli-context): draft per drafts/warp-cli-launch-plan.md — "cli/context.mdx" section. Feature-doc content type. */}
-
-The {VARS.WARP_CLI} documentation for this page is in progress.
+The {VARS.WARP_CLI} gives its agent the same layered context system as the Warp app: your working directory, project rules, skills, and MCP servers. All of it follows the directory you're working in, so the agent's knowledge stays scoped to the project at hand.
 
 ## Project context and rules
 
-{/* TODO(cli-context): AGENTS.md/rules pickup, working-directory context; cross-link agent-platform/capabilities/rules. */}
+Every conversation includes the session's current working directory as context. The {VARS.WARP_CLI} starts in the directory where you ran `warp`, and when you `cd` inside the session, project rules and skills re-scope to the new directory automatically.
+
+Within a project, the {VARS.WARP_CLI} picks up the same rule files as the Warp app:
+
+* **Project rules** - `AGENTS.md` (or `WARP.md`) files in your repository apply automatically, starting from the repository root and your current directory. See [Rules](/agent-platform/capabilities/rules/) for the file format, nested rules in subdirectories, and precedence.
+* **Global rules** - A rule file at `~/.agents/AGENTS.md` applies across all projects on your machine.
+
+Because rules and skills are discovered from these shared file locations, a repository that's already set up for agents in the Warp app (or other agent tools that read `AGENTS.md`) works in the {VARS.WARP_CLI} with no extra setup.
 
 ## Skills
 
-{/* TODO(cli-context): /skills invocation and skills menu; cross-link agent-platform/capabilities/skills. */}
+[Skills](/agent-platform/capabilities/skills/) are reusable instruction sets the agent can invoke to perform specific tasks. The {VARS.WARP_CLI} discovers the same skills as the Warp app: project skills from your repository's skill directories (such as `.agents/skills/`) and personal skills from your home directory (such as `~/.agents/skills/`), scoped to your current working directory.
+
+To browse and invoke skills:
+
+1. Type `/skills` and press `Enter` to open the skills menu. The menu lists every skill in scope with its description; type to filter the list.
+2. Use `↑` and `↓` to select a skill, then press `Enter`. The {VARS.WARP_CLI} inserts `/skill-name ` into the input so you can add extra instructions before running it.
+3. Press `Enter` to invoke the skill. Any text after the skill name is passed along, either as [skill arguments](/agent-platform/capabilities/skills/#skill-arguments) or as additional context for the agent.
+
+You can also invoke a skill directly by typing `/` followed by its name, for example `/deploy push the latest changes to staging`. Matching skills appear in the slash command menu as you type.
 
 ## Bundled skills
 
-{/* TODO(cli-context): built-in skills (updating settings, migrating from the Warp app). */}
+The {VARS.WARP_CLI} ships with built-in skills that appear in the skills menu alongside your own:
+
+* **`/modify-settings`** - Updates {VARS.WARP_CLI} settings for you. Describe the change you want (for example, "switch to a dark theme"), and the agent looks up the setting in the bundled settings schema and edits your settings file. Changes apply immediately. See [Configuration](/cli/configuration/) for the settings file details.
+* **`/tui-migrate-setup`** - Sets up the {VARS.WARP_CLI} from an existing Warp app installation. The agent copies compatible settings and global MCP server definitions from the desktop app, and asks for your approval before changing anything. Credentials and OAuth state are never copied, so MCP servers that require authentication prompt you to re-authenticate. Rules and skills don't need migration because both surfaces discover them from the same locations.
 
 ## MCP servers
 
-{/* TODO(cli-context): /mcp management view, configuring servers; cross-link agent-platform/capabilities/mcp. */}
+[MCP servers](/agent-platform/capabilities/mcp/) extend the agent with external tools and data sources. The {VARS.WARP_CLI} keeps its own MCP server configuration, separate from the Warp app's, so each can run its own set of servers.
+
+Servers are defined in a JSON config file using the same `mcpServers` format as [file-based MCP servers](/agent-platform/capabilities/mcp/#file-based-mcp-servers) in the Warp app (on macOS, the file is `~/.warp_cli/.mcp.json`). Edit the file to add or remove servers; the {VARS.WARP_CLI} picks up changes automatically. Configured servers start automatically once you're logged in.
+
+:::note
+The {VARS.WARP_CLI} reads MCP servers from its global config file only. Project-scoped MCP config files in repositories are not detected. To copy global server definitions from the Warp app, use the `/tui-migrate-setup` bundled skill.
+:::
+
+### Managing servers with /mcp
+
+Type `/mcp` to open the MCP management view. The header shows the path to the config file the {VARS.WARP_CLI} is reading.
+
+Each configured server is listed with its transport (`stdio` or `HTTP/SSE`) and current status, including the number of tools a running server exposes. Select a server with `↑` and `↓`, then press `Enter` to act on it:
+
+* **Offline servers** - Pressing `Enter` starts the server.
+* **Running servers** - Pressing `Enter` stops the server.
+* **Failed servers** - The row shows the failure message. Pressing `Enter` retries the server.
+* **Servers awaiting authentication** - Pressing `Enter` reopens the OAuth authorization page in your browser. Servers with saved credentials show a **Log out** row that removes the stored OAuth credentials.
+
+## Related pages
+
+* [Rules](/agent-platform/capabilities/rules/) - Full guide to project and global rules
+* [Skills](/agent-platform/capabilities/skills/) - Authoring skills, skill arguments, and skill locations
+* [MCP servers](/agent-platform/capabilities/mcp/) - Config format, server examples, and authentication
+* [Codebase Context](/agent-platform/capabilities/codebase-context/) - Codebase indexing in the Warp app
+* [Configuration](/cli/configuration/) - The {VARS.WARP_CLI} settings file

--- a/src/content/docs/cli/context.mdx
+++ b/src/content/docs/cli/context.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Agent context in the {{WARP_CLI}}: rules, skills, and MCP"
+title: "Agent context in the Warp CLI: rules, skills, and MCP"
 description: >-
-  Give the {{WARP_CLI}} agent context with project rules (AGENTS.md), skills,
+  Give the Warp CLI agent context with project rules (AGENTS.md), skills,
   and MCP servers.
 ---
 import { VARS } from '@data/vars';


### PR DESCRIPTION
## Pages changed
- `src/content/docs/cli/context.mdx` — agent context in the Warp CLI (feature-doc type)

## Features covered
- **Project context pickup** — working-directory context; `cd` re-scopes rules and skills to the session's working directory; `AGENTS.md`/`WARP.md` project rules; global `~/.agents/AGENTS.md` rules; cross-links agent-platform/capabilities/rules
- **Skills** — `/skills` menu (search, select, insert `/skill-name ` for extra instructions), direct `/skill-name` invocation with arguments, skills matching in the slash menu; cross-links agent-platform/capabilities/skills
- **Bundled skills** — `/modify-settings` (schema-guided settings edits) and `/tui-migrate-setup` (migrate compatible settings + global MCP definitions from the Warp app; no credentials copied)
- **MCP** — `/mcp` management view (transport, status, tool counts; start/stop/retry; OAuth reopen + log out), CLI-specific global `.mcp.json` config (same `mcpServers` format, auto-reloaded, servers auto-start after login); cross-links agent-platform/capabilities/mcp

## Dropped/unconfirmed
- **Project-scoped MCP servers** — not shipped in the CLI: TUI-mode MCP discovery is explicitly limited to the CLI's global Warp config (project + third-party provider discovery is deferred "to a later phase" in code). The page instead carries a note that only the global config file is read.
- **MCP import/discovery from other tools** — fast follow, not landed; excluded per plan.

## Validation
- `npm run build` passes (363 pages, no errors)

Suggested reviewer(s): Kevin, moira

Co-Authored-By: Oz <oz-agent@warp.dev>