### PR TITLE
docs(cli): shell commands

### DIFF
--- a/src/content/docs/cli/shell-commands.mdx
+++ b/src/content/docs/cli/shell-commands.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Running shell commands in the {{WARP_CLI}}"
+title: "Running shell commands in the Warp CLI"
 description: >-
-  Run shell commands directly in the {{WARP_CLI}}, including interactive and
+  Run shell commands directly in the Warp CLI, including interactive and
   long-running commands, full-screen apps, and natural language detection.
 ---
 import { VARS } from '@data/vars';

--- a/src/content/docs/cli/shell-commands.mdx
+++ b/src/content/docs/cli/shell-commands.mdx
@@ -6,30 +6,76 @@ description: >-
 ---
 import { VARS } from '@data/vars';
 
-{/* TODO(cli-shell-commands): draft per drafts/warp-cli-launch-plan.md — "cli/shell-commands.mdx" section. Feature-doc content type. */}
-
-The {VARS.WARP_CLI} documentation for this page is in progress.
+The {VARS.WARP_CLI} is a full terminal as well as an agent. Every session runs a real shell, so you can run commands in the same place you prompt the agent. Commands and their output appear in the transcript alongside the conversation, and interactive, long-running, and full-screen commands behave the way they do in a plain terminal.
 
 ## Shell mode
 
-{/* TODO(cli-shell-commands): entering shell commands vs agent prompts; command row styling. */}
+The input is agent-first: by default, pressing `Enter` sends your text to the agent as a prompt. Use shell mode to run a command instead:
+
+1. Press `!` at the start of the input. The prompt marker changes from `>` to `!`, and the statusline below the input shows **Shell mode**.
+2. Type a command and press `Enter`. The command runs in the session's shell, and the input returns to agent mode.
+
+To leave shell mode without running a command, press `Esc`, or press `Backspace` at the start of the input. Any text you typed stays in the input.
+
+In the transcript, each command you run is marked with a `!` prefix and a highlighted row background, so shell commands stay visually distinct from prompts and agent responses. Output streams in below the command as it's produced.
+
+In shell mode, press `Tab` to complete commands and paths. For more on completions and menus, see [Input and editing](/cli/input-and-editing/).
+
+:::note
+Running a shell command cancels the agent's in-progress response, if there is one.
+:::
 
 ## Natural language detection
 
-{/* TODO(cli-shell-commands): opt-in NLD, /natural-language-detection toggle. */}
+Out of the box, the {VARS.WARP_CLI} never guesses what your input is: everything goes to the agent unless you enter shell mode. To type commands directly without the `!` prefix, turn on natural language detection:
+
+- **Toggle detection** - Run `/natural-language-detection` to turn detection on or off. The statusline confirms the change, and the setting persists across sessions.
+- **Automatic classification** - With detection on, the {VARS.WARP_CLI} classifies your input as you type. When the input looks like a shell command (for example, `git status`), the input switches to shell mode, and `Enter` runs it as a command. Everything else is sent to the agent.
+- **Biased toward the agent** - Short or ambiguous input stays in agent mode, and a single word switches to shell mode only when it matches a command available in your shell.
+
+The prompt marker and statusline always show the current mode before you press `Enter`. If detection classifies input differently than you intended, press `Esc` to switch back to agent mode, or press `!` at the start of the input to force shell mode.
 
 ## Command history
 
-{/* TODO(cli-shell-commands): shell commands in the up-arrow history menu. */}
+Press `↑` with the cursor on the first line of the input to open the history menu. The menu combines your previous prompts and shell commands in one list, with commands marked by a `!` prefix.
+
+- **Filter** - Keep typing to filter the list.
+- **Preview** - Moving the selection previews each entry in the input and switches the input to the matching mode: recalled commands run as shell commands, and recalled prompts go to the agent.
+- **Submit** - Press `Enter` to run the selected command or send the selected prompt.
+- **Dismiss** - Press `Esc` to close the menu and restore what you had typed.
+
+In shell mode, the history menu shows shell commands only. Commands you run in the {VARS.WARP_CLI} are added to your command history.
 
 ## Long-running and interactive commands
 
-{/* TODO(cli-shell-commands): interactive input passthrough, typed-character carryover, hints during execution. */}
+When a command keeps running, such as a dev server, a package install, or an interactive prompt, the {VARS.WARP_CLI} hands input over to it:
+
+- **Input passthrough** - Keystrokes and pasted text are forwarded to the running process, so password requests, confirmation prompts, and other interactive programs work as they do in a plain terminal.
+- **Interrupt hint** - While the command owns input, a dimmed `ctrl-c to interrupt` hint replaces the input. Press `Ctrl+C` to stop the command.
+- **Type ahead** - If you start typing your next command before the current one finishes, the typed characters are carried into the input when the command completes, with the cursor at the end. This matches type-ahead behavior in shells like zsh and bash.
+
+One command runs in the session at a time. If the terminal is already busy, for example while the agent is running a command of its own, submitting a shell command shows a notice in the statusline and keeps your text in the input.
 
 ## Full-screen terminal apps
 
-{/* TODO(cli-shell-commands): alt-screen apps (editors, pagers, TUIs) support. */}
+Commands that switch the terminal to the alternate screen, such as `vim`, `htop`, or `less`, take over the whole {VARS.WARP_CLI} view:
+
+- The app renders full-screen and receives keyboard, paste, scroll, and mouse input, so editors and other terminal UIs are fully usable inside the {VARS.WARP_CLI}.
+- When the app exits, the transcript returns with your conversation intact.
 
 ## Stopping commands and exiting
 
-{/* TODO(cli-shell-commands): Ctrl+C to stop, double Ctrl+C to exit. */}
+`Ctrl+C` performs one contextual action per press:
+
+- **While a command is running** - `Ctrl+C` interrupts the running command, as in a plain terminal. It doesn't exit the {VARS.WARP_CLI}.
+- **While the agent is responding** - `Ctrl+C` cancels the in-progress response. Text in the input is preserved.
+- **At an idle prompt** - `Ctrl+C` clears the input if it has text.
+
+After a press at the prompt, the statusline shows `ctrl-c again to exit` for about one second. Press `Ctrl+C` a second time within that window to exit the {VARS.WARP_CLI}. This works even while the agent is responding; while a shell command is running, `Ctrl+C` keeps interrupting the command instead.
+
+There are two other ways to exit:
+
+- **`Ctrl+D`** - Exits immediately when the input is empty.
+- **`/exit`** - Exits from the slash command menu.
+
+When you exit, the {VARS.WARP_CLI} prints a command you can use to pick the conversation back up later. See [Managing conversations](/cli/conversations/) for resuming and switching conversations.


### PR DESCRIPTION
## Pages changed
- `src/content/docs/cli/shell-commands.mdx` (full draft, replaces stub)

## Features covered
- Shell mode: agent-first input, `!` prefix to enter, `Esc`/`Backspace` to exit, `>` vs `!` prompt marker, **Shell mode** statusline label, `!`-prefixed highlighted command rows in the transcript, note that running a command cancels an in-progress agent response
- Natural language detection: off by default (opt-in), `/natural-language-detection` toggle persists across sessions, agent-biased classification (single tokens switch only with command evidence)
- Command history: up-arrow history menu combining prompts + shell commands, `!` prefix on command rows, filter/preview/submit/dismiss, commands-only list in shell mode
- Long-running/interactive commands: input passthrough to the running process, dimmed "ctrl-c to interrupt" hint replacing the input, typed-character carryover into the input on completion (shell type-ahead), one-command-at-a-time notice
- Full-screen (alt-screen) apps: full-area rendering, keyboard/paste/scroll/mouse forwarding, transcript restored on exit
- Ctrl+C semantics: interrupt running command (never exits), cancel streaming response, clear input, "ctrl-c again to exit" 1s window for double-press exit; `Ctrl+D` on empty input and `/exit`; pointer to conversations page for resume

## Dropped/unconfirmed
- Manual attach (CODE-1915): no commits on master or any branch reference this ticket; not shipped, so it is not documented.
- Command row color: documented as a `!` marker + highlighted row background without naming a color (plan mentioned yellow rows; current master uses a theme-blended tint).

Suggested reviewer(s): Kevin (moira for manual attach)

Co-Authored-By: Oz <oz-agent@warp.dev>
