### PR TITLE
docs(cli): permissions and profiles

### DIFF
--- a/src/content/docs/cli/permissions-and-profiles.mdx
+++ b/src/content/docs/cli/permissions-and-profiles.mdx
@@ -70,8 +70,11 @@ execute_commands = "agent_decides"
 apply_code_diffs = "agent_decides"
 read_files = "agent_decides"
 command_allowlist = ['cargo (build|check|test)(\s.*)?']
-command_denylist = ['rm(\s.*)?', 'curl(\s.*)?']
 ```
+
+:::caution
+Setting `command_denylist` replaces the built-in default denylist, which covers `rm`, `curl`, `wget`, `eval`, `ssh`, shells, and other risky command patterns. Omitting the field keeps the defaults. To deny additional commands, extend the generated list in your settings file rather than writing a short list from scratch.
+:::
 
 Edit the file directly, or ask the agent to change its own permissions and it will update the settings file for you. The {VARS.WARP_CLI} picks up saved changes automatically.
 

--- a/src/content/docs/cli/permissions-and-profiles.mdx
+++ b/src/content/docs/cli/permissions-and-profiles.mdx
@@ -6,15 +6,15 @@ description: >-
 ---
 import { VARS } from '@data/vars';
 
-The {VARS.WARP_CLI} uses the same permission model as the Warp app: you decide, action type by action type, whether the agent needs your approval before it acts. This page covers how to set those permissions in the CLI, what happens when the agent asks, and how to hand it full autonomy with auto-approve. For the full permission model, including team-wide controls, see [Profiles & Permissions](/agent-platform/capabilities/agent-profiles-permissions/).
+The {VARS.WARP_CLI} uses the same permission model as the Warp app: you choose how much approval each type of action needs, from reviewing every command to letting the agent run unattended. This page covers how to set those permissions in the CLI, what happens when the agent asks for approval, and how to hand over full autonomy with auto-approve. For the full permission model, including team-wide controls, see [Profiles & Permissions](/agent-platform/capabilities/agent-profiles-permissions/).
 
 ## How permissions work
 
-Every action the agent proposes, such as running a shell command, editing files, or calling an MCP tool, is checked against your active execution profile before it runs. Each action type is set independently: `always_ask` to approve every action of that type, `always_allow` to let them all run, or `agent_decides` to let the agent act when it's confident and ask when it isn't.
+Every action the agent proposes, such as running a shell command, editing files, or calling an MCP tool, is checked against your active execution profile before it runs. Each action type is set independently to [`always_ask`, `always_allow`, or `agent_decides`](#permission-values), so you can review every command while letting file reads through, or allow everything for an agent that never stops to ask.
 
-Out of the box the CLI uses `agent_decides` for shell commands, file edits, file reads, and MCP tool calls, and asks before typing into a running command or launching child agents. For file edits, `agent_decides` still prompts every time, so you review a diff before it's applied. A built-in command denylist sits on top: commands matching a denylist pattern, such as `rm`, `curl`, or `ssh`, require approval even when `execute_commands` is `always_allow`.
+Out of the box the CLI uses `agent_decides` for shell commands, file edits, file reads, and MCP tool calls, and asks before typing into a running command or launching child agents. For file edits, `agent_decides` still prompts every time, so you always review a diff before it's applied. A command denylist sits on top of these values: matching commands require approval even when `execute_commands` is `always_allow`.
 
-Set every action type to `always_ask` to review everything, or to `always_allow` for an agent that never stops to ask. Both are done by [editing your execution profile](#execution-profiles).
+Change any of this by [editing your execution profile](#execution-profiles).
 
 ## Approving agent actions
 
@@ -26,12 +26,13 @@ When an action needs your approval, the agent pauses and shows a permission card
 
 ## Auto-approve
 
-Auto-approve gives the agent full autonomy for the current conversation: proposed actions run immediately, without permission cards, until the task finishes or you turn it off. Toggle it with `/auto-approve` or `Ctrl+Shift+I`, or launch with `warp --auto-approve` to start every new conversation in that session with auto-approve already on.
+Auto-approve gives the agent full autonomy: proposed actions run immediately, without permission cards, until the task finishes or you turn it off. Toggle it with `/auto-approve` or `Ctrl+Shift+I`.
 
-Auto-approve applies per conversation, and new conversations start with it off unless you launched with `--auto-approve`. To see its state at a glance, add the **Auto-approve indicator** to the statusline with `/statusline`. If your profile sets `ask_user_question = "ask_except_in_auto_approve"`, the agent also skips clarifying questions while auto-approve is on.
+Auto-approve is scoped to a single conversation, and new conversations start with it off. To start every new conversation in a session with auto-approve already on, launch with `warp --auto-approve`. To see the current state at a glance, add the **Auto-approve indicator** to the statusline with `/statusline`. If your profile sets `ask_user_question = "ask_except_in_auto_approve"`, the agent also skips clarifying questions while auto-approve is on.
 
 :::danger
-With auto-approve on, the agent runs commands and applies file edits without review, and by default it also runs commands that match your own command denylist. Press `Ctrl+C` to stop the agent if it starts doing something you didn't intend.
+With auto-approve on, the agent runs commands and applies file edits without review, including commands that match your own command denylist. Press `Ctrl+C` to stop the agent if it starts doing something you didn't intend.
+:::
 
 To keep your denylist in force while auto-approve is on, turn off the bypass in your settings file:
 
@@ -41,7 +42,6 @@ auto_approve_bypasses_command_denylist = false
 ```
 
 Denylist rules enforced by your team in the [Admin Panel](/enterprise/team-management/admin-panel/) always require approval and are never bypassed, regardless of this setting.
-:::
 
 ## Execution profiles
 

--- a/src/content/docs/cli/permissions-and-profiles.mdx
+++ b/src/content/docs/cli/permissions-and-profiles.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Permissions and profiles in the {{WARP_CLI}}"
+title: "Permissions and profiles in the Warp CLI"
 description: >-
-  Control what the agent can do in the {{WARP_CLI}}: permission request cards,
+  Control what the agent can do in the Warp CLI: permission request cards,
   auto-approve, and execution profiles in the settings file.
 ---
 import { VARS } from '@data/vars';

--- a/src/content/docs/cli/permissions-and-profiles.mdx
+++ b/src/content/docs/cli/permissions-and-profiles.mdx
@@ -21,25 +21,15 @@ You can change these defaults by [editing your execution profile](#execution-pro
 
 ## Approving agent actions
 
-When an action needs your approval, the CLI pauses the conversation and shows a permission card in the transcript: what the agent wants to do, the details (the exact command, the file diffs, or the tool call), and a **yes**/**no** selector. Select **Other** to type a reply instead; the agent receives your guidance in place of the proposed action, which is useful when you want it to take a different approach.
+When an action needs your approval, the agent pauses and shows a permission card with the proposed command or file edits. Beyond approving or rejecting it, you can:
 
-### Reviewing commands
-
-When the agent asks "Is it OK if I run this command and read the output?", the card shows the proposed command in an editable field. Press `E` to edit the command before it runs; approving then runs your edited version. While editing, `Enter` or `Esc` returns to the options without cancelling the request.
-
-### Reviewing file edits
-
-When the agent asks "Is it OK if I make these file edits?", the card shows the proposed diffs inline, one section per file. Press `E` to expand or collapse all diffs at once.
+* Select **Other** to reply with guidance instead of running the action; the agent adjusts its approach based on what you type.
+* Press `E` on a command card to edit the proposed command; approving then runs your edited version. While editing, `Esc` exits the editor without rejecting the request.
+* Press `E` on a file-edits card to expand or collapse all diffs.
 
 ## Auto-approve
 
-Auto-approve gives the agent full autonomy for the current conversation: proposed actions run immediately, without permission cards, until the task finishes or you turn it off.
-
-Toggle auto-approve in any of these ways:
-
-* Run `/auto-approve`.
-* Press `Ctrl+Shift+I`.
-* Click the **Auto approve** control (`▶▶`) at the right edge of the progress row while the agent is working.
+Auto-approve gives the agent full autonomy for the current conversation: proposed actions run immediately, without permission cards, until the task finishes or you turn it off. Toggle it with `/auto-approve` or `Ctrl+Shift+I`.
 
 Auto-approve applies per conversation, and new conversations start with it off. To see its state at a glance, add the **Auto-approve indicator** to the statusline with `/statusline`. If your profile sets `ask_user_question = "ask_except_in_auto_approve"`, the agent also skips clarifying questions while auto-approve is on.
 

--- a/src/content/docs/cli/permissions-and-profiles.mdx
+++ b/src/content/docs/cli/permissions-and-profiles.mdx
@@ -6,22 +6,22 @@ description: >-
 ---
 import { VARS } from '@data/vars';
 
-The {VARS.WARP_CLI} uses the same permission model as the Warp app: the agent acts on its own when it's confident an action is safe, and asks for your approval when it isn't. This page covers how permission requests appear in the {VARS.WARP_CLI} and how to tune the agent's autonomy with auto-approve and execution profiles. For the full permission model, including autonomy levels and organization-wide controls, see [Profiles & Permissions](/agent-platform/capabilities/agent-profiles-permissions/).
+The {VARS.WARP_CLI} uses the same permission model as the Warp app: the agent acts on its own when it's confident an action is safe, and asks for your approval when it isn't. This page covers how permission requests appear in the CLI and how to tune the agent's autonomy with auto-approve and execution profiles. For the full permission model, including autonomy levels and organization-wide controls, see [Profiles & Permissions](/agent-platform/capabilities/agent-profiles-permissions/).
 
 ## How permissions work
 
-Every action the agent proposes, such as running a shell command, editing files, or calling an MCP tool, is checked against your active execution profile before it runs. By default, the {VARS.WARP_CLI} behaves as follows:
+Every action the agent proposes, such as running a shell command, editing files, or calling an MCP tool, is checked against your active execution profile before it runs. By default, the CLI behaves as follows:
 
 * **Shell commands** - The agent decides. It runs commands it judges safe, such as read-only commands and commands on your allowlist, and asks before anything else.
 * **File edits** - The agent shows a diff and asks for approval before applying edits.
 * **Reading files** - The agent decides, reading files without prompting in most cases.
 * **Denylisted commands** - Commands matching your command denylist (for example `rm`, `curl`, or `ssh`) always require approval. The denylist takes precedence over every other setting, including auto-approve.
 
-You can change these defaults by editing your execution profile. See [Execution profiles](#execution-profiles) below.
+You can change these defaults by [editing your execution profile](#execution-profiles).
 
 ## Approving agent actions
 
-When an action needs your approval, the {VARS.WARP_CLI} pauses the conversation and shows a permission card in the transcript. The card states what the agent wants to do, shows the details (the exact command, the file diffs, or the tool call), and moves focus to a **yes**/**no** selector.
+When an action needs your approval, the CLI pauses the conversation and shows a permission card in the transcript. The card states what the agent wants to do, shows the details (the exact command, the file diffs, or the tool call), and moves focus to a **yes**/**no** selector.
 
 * Press `Enter` to confirm the highlighted option. **yes** approves and runs the action.
 * Press `Esc` (or select **no**) to reject the request. The agent continues without running the action.
@@ -61,7 +61,7 @@ With auto-approve on, the agent executes commands and applies file edits without
 
 ## Execution profiles
 
-The {VARS.WARP_CLI} reads its permissions from execution profiles stored in the [{VARS.WARP_CLI} settings file](/cli/configuration/). Profiles live under the `agents.execution_profiles` table, and the {VARS.WARP_CLI} always runs with the profile under the reserved `default` key:
+The CLI reads its permissions from execution profiles stored in its [settings file](/cli/configuration/). Profiles live under the `agents.execution_profiles` table, and the CLI always runs with the profile under the reserved `default` key:
 
 ```toml title="settings.toml"
 [agents.execution_profiles.default]
@@ -76,9 +76,9 @@ command_allowlist = ['cargo (build|check|test)(\s.*)?']
 Setting `command_denylist` replaces the built-in default denylist, which covers `rm`, `curl`, `wget`, `eval`, `ssh`, shells, and other risky command patterns. Omitting the field keeps the defaults. To deny additional commands, extend the generated list in your settings file rather than writing a short list from scratch.
 :::
 
-Edit the file directly, or ask the agent to change its own permissions and it will update the settings file for you. The {VARS.WARP_CLI} picks up saved changes automatically.
+Edit the file directly, or ask the agent to change its own permissions and it will update the settings file for you. The CLI picks up saved changes automatically.
 
-Profiles in the {VARS.WARP_CLI} are local to your machine: they never sync to the cloud, and they are separate from the Agent Profiles you configure in the Warp app. You can define additional profiles in the file, but the {VARS.WARP_CLI} currently always runs with `default`.
+Profiles in the {VARS.WARP_CLI} are local to your machine: they never sync to the cloud, and they are separate from the Agent Profiles you configure in the Warp app. You can define additional profiles in the file, but the CLI currently always runs with `default`.
 
 ### Permission values
 
@@ -101,10 +101,10 @@ Most permission fields accept one of three values:
 * **`command_denylist`** - Regular expressions for commands that always require approval, regardless of other settings.
 * **`directory_allowlist`** - Directories the agent may read without approval.
 
-Profiles also hold per-profile model overrides such as `base_model`. See [Models and usage in the {VARS.WARP_CLI}](/cli/models-and-usage/) for how the {VARS.WARP_CLI} resolves models.
+Profiles also hold model overrides such as `base_model`, covered in [Models and usage in the {VARS.WARP_CLI}](/cli/models-and-usage/).
 
 :::note
-The profile collection is validated as a whole. If any profile contains an invalid value, the {VARS.WARP_CLI} keeps the last valid configuration while it's running and falls back to the built-in default profile on the next launch, until the file is fixed.
+The profile collection is validated as a whole. If any profile contains an invalid value, the CLI keeps the last valid configuration while it's running and falls back to the built-in default profile on the next launch, until the file is fixed.
 :::
 
 ## Related pages

--- a/src/content/docs/cli/permissions-and-profiles.mdx
+++ b/src/content/docs/cli/permissions-and-profiles.mdx
@@ -1,35 +1,111 @@
 ---
 title: "Permissions and profiles in the {{WARP_CLI}}"
 description: >-
-  Control what the agent can do in the {{WARP_CLI}}: permission requests,
-  auto-approve, fast-forward mode, and execution profiles.
+  Control what the agent can do in the {{WARP_CLI}}: permission request cards,
+  auto-approve, and execution profiles in the settings file.
 ---
 import { VARS } from '@data/vars';
 
-{/* TODO(cli-permissions): draft per drafts/warp-cli-launch-plan.md — "cli/permissions-and-profiles.mdx" section. Feature-doc content type. */}
-
-The {VARS.WARP_CLI} documentation for this page is in progress.
+The {VARS.WARP_CLI} uses the same permission model as the Warp app: the agent acts on its own when it's confident an action is safe, and asks for your approval when it isn't. This page covers how permission requests appear in the {VARS.WARP_CLI} and how to tune the agent's autonomy with auto-approve and execution profiles. For the full permission model, including autonomy levels and organization-wide controls, see [Profiles & Permissions](/agent-platform/capabilities/agent-profiles-permissions/).
 
 ## How permissions work
 
-{/* TODO(cli-permissions): permission model summary; default behavior; cross-link agent-platform/capabilities/agent-profiles-permissions. */}
+Every action the agent proposes, such as running a shell command, editing files, or calling an MCP tool, is checked against your active execution profile before it runs. By default, the {VARS.WARP_CLI} behaves as follows:
+
+* **Shell commands** - The agent decides. It runs commands it judges safe, such as read-only commands and commands on your allowlist, and asks before anything else.
+* **File edits** - The agent shows a diff and asks for approval before applying edits.
+* **Reading files** - The agent decides, reading files without prompting in most cases.
+* **Denylisted commands** - Commands matching your command denylist (for example `rm`, `curl`, or `ssh`) always require approval. The denylist takes precedence over every other setting, including auto-approve.
+
+You can change these defaults by editing your execution profile. See [Execution profiles](#execution-profiles) below.
 
 ## Approving agent actions
 
-{/* TODO(cli-permissions): permission request cards, command edit/escape behavior, diff approval. */}
+When an action needs your approval, the {VARS.WARP_CLI} pauses the conversation and shows a permission card in the transcript. The card states what the agent wants to do, shows the details (the exact command, the file diffs, or the tool call), and moves focus to a **yes**/**no** selector.
+
+* Press `Enter` to confirm the highlighted option. **yes** approves and runs the action.
+* Press `Esc` (or select **no**) to reject the request. The agent continues without running the action.
+* Select **Other** to type a reply instead. The agent receives your guidance in place of the proposed action, which is useful when you want it to take a different approach.
+
+### Reviewing commands
+
+When the agent asks "Is it OK if I run this command and read the output?", the card shows the proposed command in an editable field:
+
+* Press `E` to edit the command before it runs.
+* While editing, press `Enter` or `Esc` to finish. Finishing returns focus to the **yes**/**no** options without cancelling the request. Press `Esc` again to reject it.
+* Approve with **yes** to run the command, including any edits you made. Output streams into the transcript, and commands that keep running expand automatically so you can follow along.
+
+### Reviewing file edits
+
+When the agent asks "Is it OK if I make these file edits?", the card shows the proposed diffs inline, with one section per file:
+
+* Each file header shows the change type, the file name, and added/removed line counts. Multi-file edits are grouped under a summary header, and all diffs start expanded while the request is pending.
+* Press `E` to expand or collapse all diffs at once, or click a file header to toggle a single file.
+* Approve with **yes** to apply the edits, or reject with **no** or `Esc` to discard them.
 
 ## Auto-approve
 
-{/* TODO(cli-permissions): /auto-approve toggle and when to use it. */}
+Auto-approve gives the agent full autonomy for the current conversation: proposed actions run immediately, without permission cards, until the task finishes or you turn it off.
 
-## Fast-forward mode
+Toggle auto-approve in any of these ways:
 
-{/* TODO(cli-permissions): fast-forward mode and /fast-forward toggle. */}
+* Run `/auto-approve`. The slash command menu shows whether it's currently on or off.
+* Press `Ctrl+Shift+I`.
+* Click the **Auto approve** control (`▶▶`) at the right edge of the progress row while the agent is working.
+
+Auto-approve applies per conversation, and new conversations start with it off. To see its state at a glance, add the **Auto-approve indicator** to the statusline with `/statusline`. If your profile sets `ask_user_question = "ask_except_in_auto_approve"`, the agent also skips clarifying questions while auto-approve is on.
+
+:::caution
+With auto-approve on, the agent executes commands and applies file edits without review. Commands matching your command denylist still require approval, but everything else runs immediately. Press `Ctrl+C` to stop the agent if it starts doing something you didn't intend.
+:::
 
 ## Execution profiles
 
-{/* TODO(cli-permissions): settings-file-based execution profiles and defaults. */}
+The {VARS.WARP_CLI} reads its permissions from execution profiles stored in the [{VARS.WARP_CLI} settings file](/cli/configuration/). Profiles live under the `agents.execution_profiles` table, and the {VARS.WARP_CLI} always runs with the profile under the reserved `default` key:
 
-## Unattended use
+```toml title="settings.toml"
+[agents.execution_profiles.default]
+name = "Default"
+execute_commands = "agent_decides"
+apply_code_diffs = "agent_decides"
+read_files = "agent_decides"
+command_allowlist = ['cargo (build|check|test)(\s.*)?']
+command_denylist = ['rm(\s.*)?', 'curl(\s.*)?']
+```
 
-{/* TODO(cli-permissions): flags for skipping permissions — confirm shipped before merge; include safety caution. */}
+Edit the file directly, or ask the agent to change its own permissions and it will update the settings file for you. The {VARS.WARP_CLI} picks up saved changes automatically.
+
+Profiles in the {VARS.WARP_CLI} are local to your machine: they never sync to the cloud, and they are separate from the Agent Profiles you configure in the Warp app. You can define additional profiles in the file, but the {VARS.WARP_CLI} currently always runs with `default`.
+
+### Permission values
+
+Most permission fields accept one of three values:
+
+* **`agent_decides`** - The agent acts on its own when it's confident and asks when it's uncertain.
+* **`always_ask`** - Every action of this type requires approval.
+* **`always_allow`** - Actions of this type run without prompting.
+
+### Profile fields
+
+* **`execute_commands`** - Permission to run shell commands.
+* **`apply_code_diffs`** - Permission to apply file edits.
+* **`read_files`** - Permission to read files.
+* **`mcp_permissions`** - Permission to call MCP servers.
+* **`write_to_pty`** - Permission to type into running interactive commands. Also accepts `ask_on_first_write`.
+* **`ask_user_question`** - Whether the agent may pause to ask clarifying questions: `always_ask`, `ask_except_in_auto_approve`, or `never`.
+* **`run_agents`** - Permission to launch child agents: `always_ask`, `always_allow`, or `never_allow`.
+* **`command_allowlist`** - Regular expressions for commands that run without approval.
+* **`command_denylist`** - Regular expressions for commands that always require approval, regardless of other settings.
+* **`directory_allowlist`** - Directories the agent may read without approval.
+
+Profiles also hold per-profile model overrides such as `base_model`. See [Models and usage in the {VARS.WARP_CLI}](/cli/models-and-usage/) for how the {VARS.WARP_CLI} resolves models.
+
+:::note
+The profile collection is validated as a whole. If any profile contains an invalid value, the {VARS.WARP_CLI} keeps the last valid configuration while it's running and falls back to the built-in default profile on the next launch, until the file is fixed.
+:::
+
+## Related pages
+
+* [Profiles & Permissions](/agent-platform/capabilities/agent-profiles-permissions/) - The full permission model, autonomy levels, and allowlist/denylist behavior.
+* [Configuring the {VARS.WARP_CLI}](/cli/configuration/) - The settings file, themes, statusline, and keybindings.
+* [Agent conversations in the {VARS.WARP_CLI}](/cli/agent-conversations/) - How tool calls, diffs, and agent questions render in the transcript.

--- a/src/content/docs/cli/permissions-and-profiles.mdx
+++ b/src/content/docs/cli/permissions-and-profiles.mdx
@@ -21,27 +21,15 @@ You can change these defaults by [editing your execution profile](#execution-pro
 
 ## Approving agent actions
 
-When an action needs your approval, the CLI pauses the conversation and shows a permission card in the transcript. The card states what the agent wants to do, shows the details (the exact command, the file diffs, or the tool call), and moves focus to a **yes**/**no** selector.
-
-* Press `Enter` to confirm the highlighted option. **yes** approves and runs the action.
-* Press `Esc` (or select **no**) to reject the request. The agent continues without running the action.
-* Select **Other** to type a reply instead. The agent receives your guidance in place of the proposed action, which is useful when you want it to take a different approach.
+When an action needs your approval, the CLI pauses the conversation and shows a permission card in the transcript: what the agent wants to do, the details (the exact command, the file diffs, or the tool call), and a **yes**/**no** selector. Select **Other** to type a reply instead; the agent receives your guidance in place of the proposed action, which is useful when you want it to take a different approach.
 
 ### Reviewing commands
 
-When the agent asks "Is it OK if I run this command and read the output?", the card shows the proposed command in an editable field:
-
-* Press `E` to edit the command before it runs.
-* While editing, press `Enter` or `Esc` to finish. Finishing returns focus to the **yes**/**no** options without cancelling the request. Press `Esc` again to reject it.
-* Approve with **yes** to run the command, including any edits you made. Output streams into the transcript, and commands that keep running expand automatically so you can follow along.
+When the agent asks "Is it OK if I run this command and read the output?", the card shows the proposed command in an editable field. Press `E` to edit the command before it runs; approving then runs your edited version. While editing, `Enter` or `Esc` returns to the options without cancelling the request.
 
 ### Reviewing file edits
 
-When the agent asks "Is it OK if I make these file edits?", the card shows the proposed diffs inline, with one section per file:
-
-* Each file header shows the change type, the file name, and added/removed line counts. Multi-file edits are grouped under a summary header, and all diffs start expanded while the request is pending.
-* Press `E` to expand or collapse all diffs at once, or click a file header to toggle a single file.
-* Approve with **yes** to apply the edits, or reject with **no** or `Esc` to discard them.
+When the agent asks "Is it OK if I make these file edits?", the card shows the proposed diffs inline, one section per file. Press `E` to expand or collapse all diffs at once.
 
 ## Auto-approve
 
@@ -49,7 +37,7 @@ Auto-approve gives the agent full autonomy for the current conversation: propose
 
 Toggle auto-approve in any of these ways:
 
-* Run `/auto-approve`. The slash command menu shows whether it's currently on or off.
+* Run `/auto-approve`.
 * Press `Ctrl+Shift+I`.
 * Click the **Auto approve** control (`▶▶`) at the right edge of the progress row while the agent is working.
 

--- a/src/content/docs/cli/permissions-and-profiles.mdx
+++ b/src/content/docs/cli/permissions-and-profiles.mdx
@@ -6,18 +6,15 @@ description: >-
 ---
 import { VARS } from '@data/vars';
 
-The {VARS.WARP_CLI} uses the same permission model as the Warp app: the agent acts on its own when it's confident an action is safe, and asks for your approval when it isn't. This page covers how permission requests appear in the CLI and how to tune the agent's autonomy with auto-approve and execution profiles. For the full permission model, including autonomy levels and organization-wide controls, see [Profiles & Permissions](/agent-platform/capabilities/agent-profiles-permissions/).
+The {VARS.WARP_CLI} uses the same permission model as the Warp app: you decide, action type by action type, whether the agent needs your approval before it acts. This page covers how to set those permissions in the CLI, what happens when the agent asks, and how to hand it full autonomy with auto-approve. For the full permission model, including team-wide controls, see [Profiles & Permissions](/agent-platform/capabilities/agent-profiles-permissions/).
 
 ## How permissions work
 
-Every action the agent proposes, such as running a shell command, editing files, or calling an MCP tool, is checked against your active execution profile before it runs. By default, the CLI behaves as follows:
+Every action the agent proposes, such as running a shell command, editing files, or calling an MCP tool, is checked against your active execution profile before it runs. Each action type is set independently: `always_ask` to approve every action of that type, `always_allow` to let them all run, or `agent_decides` to let the agent act when it's confident and ask when it isn't.
 
-* **Shell commands** - The agent decides. It runs commands it judges safe, such as read-only commands and commands on your allowlist, and asks before anything else.
-* **File edits** - The agent shows a diff and asks for approval before applying edits.
-* **Reading files** - The agent decides, reading files without prompting in most cases.
-* **Denylisted commands** - Commands matching your command denylist (for example `rm`, `curl`, or `ssh`) always require approval. The denylist takes precedence over every other setting, including auto-approve.
+Out of the box the CLI uses `agent_decides` for shell commands, file edits, file reads, and MCP tool calls, and asks before typing into a running command or launching child agents. For file edits, `agent_decides` still prompts every time, so you review a diff before it's applied. A built-in command denylist sits on top: commands matching a denylist pattern, such as `rm`, `curl`, or `ssh`, require approval even when `execute_commands` is `always_allow`.
 
-You can change these defaults by [editing your execution profile](#execution-profiles).
+Set every action type to `always_ask` to review everything, or to `always_allow` for an agent that never stops to ask. Both are done by [editing your execution profile](#execution-profiles).
 
 ## Approving agent actions
 
@@ -29,12 +26,21 @@ When an action needs your approval, the agent pauses and shows a permission card
 
 ## Auto-approve
 
-Auto-approve gives the agent full autonomy for the current conversation: proposed actions run immediately, without permission cards, until the task finishes or you turn it off. Toggle it with `/auto-approve` or `Ctrl+Shift+I`.
+Auto-approve gives the agent full autonomy for the current conversation: proposed actions run immediately, without permission cards, until the task finishes or you turn it off. Toggle it with `/auto-approve` or `Ctrl+Shift+I`, or launch with `warp --auto-approve` to start every new conversation in that session with auto-approve already on.
 
-Auto-approve applies per conversation, and new conversations start with it off. To see its state at a glance, add the **Auto-approve indicator** to the statusline with `/statusline`. If your profile sets `ask_user_question = "ask_except_in_auto_approve"`, the agent also skips clarifying questions while auto-approve is on.
+Auto-approve applies per conversation, and new conversations start with it off unless you launched with `--auto-approve`. To see its state at a glance, add the **Auto-approve indicator** to the statusline with `/statusline`. If your profile sets `ask_user_question = "ask_except_in_auto_approve"`, the agent also skips clarifying questions while auto-approve is on.
 
-:::caution
-With auto-approve on, the agent executes commands and applies file edits without review. Commands matching your command denylist still require approval, but everything else runs immediately. Press `Ctrl+C` to stop the agent if it starts doing something you didn't intend.
+:::danger
+With auto-approve on, the agent runs commands and applies file edits without review, and by default it also runs commands that match your own command denylist. Press `Ctrl+C` to stop the agent if it starts doing something you didn't intend.
+
+To keep your denylist in force while auto-approve is on, turn off the bypass in your settings file:
+
+```toml title="settings.toml"
+[agents.warp_agent.other]
+auto_approve_bypasses_command_denylist = false
+```
+
+Denylist rules enforced by your team in the [Admin Panel](/enterprise/team-management/admin-panel/) always require approval and are never bypassed, regardless of this setting.
 :::
 
 ## Execution profiles
@@ -76,7 +82,7 @@ Most permission fields accept one of three values:
 * **`ask_user_question`** - Whether the agent may pause to ask clarifying questions: `always_ask`, `ask_except_in_auto_approve`, or `never`.
 * **`run_agents`** - Permission to launch child agents: `always_ask`, `always_allow`, or `never_allow`.
 * **`command_allowlist`** - Regular expressions for commands that run without approval.
-* **`command_denylist`** - Regular expressions for commands that always require approval, regardless of other settings.
+* **`command_denylist`** - Regular expressions for commands that require approval regardless of the other permission values. [Auto-approve bypasses this list by default](#auto-approve).
 * **`directory_allowlist`** - Directories the agent may read without approval.
 
 Profiles also hold model overrides such as `base_model`, covered in [Models and usage in the {VARS.WARP_CLI}](/cli/models-and-usage/).

--- a/src/content/docs/cli/permissions-and-profiles.mdx
+++ b/src/content/docs/cli/permissions-and-profiles.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Permissions and profiles in the Warp CLI"
+title: "Permissions and profiles in the Warp Agent CLI"
 description: >-
-  Control what the agent can do in the Warp CLI: permission request cards,
-  auto-approve, and execution profiles in the settings file.
+  Control what the agent can do in the Warp Agent CLI: permission request
+  cards, auto-approve, and execution profiles in the settings file.
 ---
 import { VARS } from '@data/vars';
 


### PR DESCRIPTION
## Pages changed
- `src/content/docs/cli/permissions-and-profiles.mdx` (stub replaced with full draft)

## Features covered
- Permission model: per-action-type configuration (`always_ask` / `always_allow` / `agent_decides`), CLI defaults (`agent_decides` for commands/edits/reads/MCP, `always_ask` for `write_to_pty` and `run_agents`, verified in `default_profile_for_tui`), and the command denylist layered on top
- Permission cards: **Other** for replacement guidance, `E` to edit a proposed command (approving runs the edited version; `Esc` exits the editor without cancelling), `E` to expand/collapse all diffs
- Auto-approve: `/auto-approve` slash command, `Ctrl+Shift+I` binding, `warp --auto-approve` launch flag, opt-in statusline indicator via `/statusline`, per-conversation scope, question-skipping interplay, denylist-bypass safety callout
- Settings-file execution profiles: `agents.execution_profiles` TOML table, reserved `default` key (the CLI always runs with `default`), field and value reference (snake_case values), allowlist/denylist regexes, whole-collection validation and fallback behavior, local-only (no cloud sync, separate from Warp app Agent Profiles)
- Cross-links to the canonical Profiles & Permissions page, cli/configuration, cli/models-and-usage, and cli/agent-conversations

## Dropped/unconfirmed
- `/fast-forward` slash command: no such command exists in `static_commands/commands.rs`; the "▶▶" progress-row control is labeled "Auto approve" and the whole surface is documented under Auto-approve instead
- `computer_use` profile field: intentionally omitted from the field list because I could not confirm the computer-use tool is reachable from the CLI; happy to add if eng confirms

## Review round 2 (@harryalbert)
- **Permission model framing** — reframed the intro and "How permissions work" around per-action-type configuration instead of implying the agent always self-judges safety. The CLI defaults are now presented as defaults, with an explicit note that you can set everything to `always_ask` or `always_allow`.
- **Launch flag** — documented `warp --auto-approve` (warpdotdev/warp#14483). Note the merged flag is `--auto-approve`, not `--fast-forward`; see `TuiArgs::auto_approve` in `crates/warp_tui/src/session.rs`. Also corrected the follow-on sentence: new conversations start with auto-approve off *unless* launched with the flag.
- **Denylist under auto-approve** — corrected. `auto_approve_bypasses_command_denylist` defaults to `true`, so auto-approve runs denylisted commands; the page now shows how to set it to `false` and notes that team-enforced Admin Panel denylist rules are never bypassed. The `command_denylist` field bullet was updated to match.
- `--auto-approve` still needs to land in the flags table on `cli/reference.mdx`, which is a stub owned by a separate PR on this stack.

## Notes for review
- Follow-up needed on the GUI page `agent-platform/capabilities/agent-profiles-permissions.mdx`: with the new bypass default, the caution at line 39 and the note at line 60 ("any denylist rules will still override these settings") are now stale, while line 144 ("Run until completion ignores the denylist entirely") is accurate. Happy to fix in a separate PR or fold it in here.
- Pre-existing integration-branch issue (not introduced here, affects all cli/ stubs): `{{WARP_CLI}}` frontmatter tokens render literally in built page titles/descriptions. The `vars-transform` Vite plugin is registered, but Astro's content layer parses frontmatter outside Vite, so only body-prose `{VARS.WARP_CLI}` substitutes. Needs a fix on `hyc/launch-cli` (e.g. a remark plugin or frontmatter preprocessing).

Validation: `npm run build` passes (363 pages); `style_lint --changed` reports 0 issues.

Suggested reviewer(s): harry

Co-Authored-By: Oz <oz-agent@warp.dev>
