### PR TITLE
Fix Vite 8 (Rolldown/OXC) transform error in CopyPageButton script

### DIFF
--- a/src/components/CopyPageButton.astro
+++ b/src/components/CopyPageButton.astro
@@ -148,8 +148,12 @@ const claudeUrl = `https://claude.ai/new?q=${prompt}`;
     const copyPromptBtn = document.getElementById('copy-agent-prompt');
     const viewMdBtn = document.getElementById('view-as-markdown');
     const exportBtn = document.getElementById('export-as-pdf');
-    const mdTemplate = document.getElementById('page-markdown-content') as HTMLTemplateElement | null;
-    const promptTemplate = document.getElementById('agent-prompt-content') as HTMLTemplateElement | null;
+    const mdTemplate = /** @type {HTMLTemplateElement | null} */ (
+      document.getElementById('page-markdown-content')
+    );
+    const promptTemplate = /** @type {HTMLTemplateElement | null} */ (
+      document.getElementById('agent-prompt-content')
+    );
 
     if (!wrapper || !trigger || !panel) return;
 
@@ -163,8 +167,9 @@ const claudeUrl = `https://claude.ai/new?q=${prompt}`;
       }
     });
 
-    function closeOnOutsideClick(e: MouseEvent) {
-      if (!wrapper?.contains(e.target as Node)) {
+    /** @param {MouseEvent} e */
+    function closeOnOutsideClick(e) {
+      if (!wrapper?.contains(/** @type {Node} */ (e.target))) {
         panel?.classList.remove('open');
         trigger?.classList.remove('active');
         document.removeEventListener('click', closeOnOutsideClick);


### PR DESCRIPTION
## Problem
Running the docs dev server fails for anyone on a fresh install with a Vite transform error:

```
[ERROR] [vite] Internal server error: Transform failed with 3 errors:
[PARSE_ERROR] Type assertion expressions can only be used in TypeScript files.
[ src/components/CopyPageButton.astro?astro&type=script&index=0&lang.ts ]
Plugin: vite:oxc
```

## Root cause
Astro compiles client `<script>` blocks into virtual modules tagged `?astro&type=script&index=0&lang.ts` and relies on the transformer to strip TypeScript. `astro@7.1.3` now pulls in **Vite 8** (Rolldown-powered, using the **OXC** transformer instead of esbuild — note `Plugin: vite:oxc`). OXC infers the language from the real `.astro` file extension rather than the `lang.ts` query suffix, so it parses the script as plain JS and rejects the TS-only syntax in `CopyPageButton.astro`.

This is why it hits "someone else" and not everyone: devs with older `node_modules` still have Vite 7 (esbuild), which handled `lang.ts` correctly. A clean install (`npm ci`) lands on Vite 8.1.5 + Rolldown/OXC and breaks.

## Fix
`CopyPageButton.astro` is the only processed (bundled) `<script>` in the repo containing TS-only syntax — every other script is `is:inline` (untransformed) or already plain JS. Convert its three bits of TS syntax to JSDoc casts, which are valid JS that OXC accepts while preserving the type info for `astro check`:

- `as HTMLTemplateElement | null` → `/** @type {HTMLTemplateElement | null} */ (...)`
- `(e: MouseEvent)` → `/** @param {MouseEvent} e */`
- `e.target as Node` → `/** @type {Node} */ (e.target)`

Runtime behavior is unchanged.

## Verification
On the exact reproducing stack (**Vite 8.1.5 + Rolldown 1.1.5 + Astro 7.1.3**):
- `npm run dev -- --force` starts cleanly with no `vite:oxc` / `[PARSE_ERROR]`.
- `npm run build` completes with exit 0 (full OXC transform of all client scripts), no parse/transform errors.

_Conversation: https://staging.warp.dev/conversation/d5fabfce-7be4-4574-b96b-0faa9a8ea1ec_
_Run: https://oz.staging.warp.dev/runs/019faacc-1953-76c9-8392-d925b72c068d_

_This PR was generated with [Oz](https://warp.dev/oz)._
