### PR TITLE
Update Computer Use docs: enabled by default

### DIFF
--- a/developers/agent-api-openapi.yaml
+++ b/developers/agent-api-openapi.yaml
@@ -2382,7 +2382,8 @@ components:
           type: boolean
           description: |
             Controls whether computer use is enabled for this agent.
-            If not set, defaults to true.
+            If not set, defaults to true for runs on Warp's built-in harness
+            and false for third-party harnesses.
         idle_timeout_minutes:
           type: integer
           format: int32

--- a/developers/agent-api-openapi.yaml
+++ b/developers/agent-api-openapi.yaml
@@ -2382,7 +2382,7 @@ components:
           type: boolean
           description: |
             Controls whether computer use is enabled for this agent.
-            If not set, defaults to false.
+            If not set, defaults to true.
         idle_timeout_minutes:
           type: integer
           format: int32

--- a/src/content/docs/agent-platform/capabilities/computer-use/artifacts-in-prs.mdx
+++ b/src/content/docs/agent-platform/capabilities/computer-use/artifacts-in-prs.mdx
@@ -53,7 +53,7 @@ Pull requests aren't the only place captures end up:
 
 ## Related pages
 
-* [Computer Use](/agent-platform/capabilities/computer-use/) - Enable Computer Use and understand security considerations.
+* [Computer Use](/agent-platform/capabilities/computer-use/) - Control Computer Use and understand security considerations.
 * [Testing and recordings](/agent-platform/capabilities/computer-use/testing-and-recordings/) - How the recording pipeline works and what finished videos contain.
 * [Admin Panel for teams](/enterprise/team-management/admin-panel/) - The full reference for team settings, including the Platform section.
 * [Viewing cloud agent runs](/platform/viewing-cloud-agent-runs/) - Open and inspect cloud agent run transcripts.

--- a/src/content/docs/agent-platform/capabilities/computer-use/browser-use.mdx
+++ b/src/content/docs/agent-platform/capabilities/computer-use/browser-use.mdx
@@ -50,6 +50,6 @@ Browsing the open internet is where Computer Use risks are highest. Prefer non-r
 
 ## Related pages
 
-* [Computer Use](/agent-platform/capabilities/computer-use/) - Enable Computer Use and understand how the sandbox works.
+* [Computer Use](/agent-platform/capabilities/computer-use/) - Control Computer Use and understand how the sandbox works.
 * [Testing and recordings](/agent-platform/capabilities/computer-use/testing-and-recordings/) - Record browser sessions as annotated videos for review.
 * [Environments](/platform/environments/) - Configure the cloud environment your agents run in.

--- a/src/content/docs/agent-platform/capabilities/computer-use/index.mdx
+++ b/src/content/docs/agent-platform/capabilities/computer-use/index.mdx
@@ -36,7 +36,7 @@ Computer Use is only available in Warp's sandboxed cloud environments, not in lo
 
 ## Enabling Computer Use
 
-Computer Use is **enabled by default** for cloud agent runs. When a run's configuration doesn't specify a Computer Use setting, the agent runs with Computer Use available. You can turn it off per run or per configuration through several entry points:
+Computer Use is **enabled by default** for cloud agent runs on Warp's built-in harness. When a run's configuration doesn't specify a Computer Use setting, the agent runs with Computer Use available. Runs on third-party harnesses (Claude Code, Gemini, Codex) default to Computer Use disabled because third-party harnesses don't integrate with Warp's Computer Use tooling. You can turn Computer Use off per run or per configuration through several entry points:
 
 ### Warp app settings
 
@@ -53,7 +53,7 @@ oz agent run-cloud --no-computer-use --prompt "<task>"
 
 ### Oz API
 
-When creating a cloud agent run with the [Oz API](/reference/api-and-sdk/), the optional `computer_use_enabled` field controls Computer Use. It defaults to `true` when omitted; set it to `false` to disable Computer Use for the run:
+When creating a cloud agent run with the [Oz API](/reference/api-and-sdk/), the optional `computer_use_enabled` field controls Computer Use. When omitted, it defaults to `true` for runs on Warp's built-in harness and `false` for runs on third-party harnesses. Set it to `false` to disable Computer Use for the run:
 
 ```json
 {

--- a/src/content/docs/agent-platform/capabilities/computer-use/index.mdx
+++ b/src/content/docs/agent-platform/capabilities/computer-use/index.mdx
@@ -36,11 +36,11 @@ Computer Use is only available in Warp's sandboxed cloud environments, not in lo
 
 ## Enabling Computer Use
 
-Computer Use is **opt-in** and disabled by default. You can enable it through several entry points:
+Computer Use is **enabled by default** for cloud agent runs. When a run's configuration doesn't specify a Computer Use setting, the agent runs with Computer Use available. You can turn it off per run or per configuration through several entry points:
 
 ### Warp app settings
 
-To enable Computer Use for [Cloud Agents](/platform/), navigate to **Settings** > **Agents** > **Warp Agent** > **Experimental** > **Computer use in Cloud Agents** and toggle to enable.
+To control Computer Use for [Cloud Agents](/platform/) started from the Warp app, navigate to **Settings** > **Agents** > **Warp Agent** > **Experimental** > **Computer use in Cloud Agents**.
 
 ### Oz CLI
 
@@ -53,12 +53,12 @@ oz agent run-cloud --no-computer-use --prompt "<task>"
 
 ### Oz API
 
-When creating a cloud agent run with the [Oz API](/reference/api-and-sdk/), include the `computer_use_enabled` field in your request:
+When creating a cloud agent run with the [Oz API](/reference/api-and-sdk/), the optional `computer_use_enabled` field controls Computer Use. It defaults to `true` when omitted; set it to `false` to disable Computer Use for the run:
 
 ```json
 {
   "prompt": "Build a button component that matches this design, then test it in the browser",
-  "computer_use_enabled": true,
+  "computer_use_enabled": false,
   "environment_id": "optional-environment-id"
 }
 ```

--- a/src/content/docs/agent-platform/capabilities/computer-use/index.mdx
+++ b/src/content/docs/agent-platform/capabilities/computer-use/index.mdx
@@ -36,11 +36,11 @@ Computer Use is only available in Warp's sandboxed cloud environments, not in lo
 
 ## Enabling Computer Use
 
-Computer Use is **enabled by default** for cloud agent runs on Warp's built-in harness. When a run's configuration doesn't specify a Computer Use setting, the agent runs with Computer Use available. Runs on third-party harnesses (Claude Code, Gemini, Codex) default to Computer Use disabled because third-party harnesses don't integrate with Warp's Computer Use tooling. You can turn Computer Use off per run or per configuration through several entry points:
+Computer Use is **enabled by default** for cloud agent runs on Warp's built-in harness: when a run's configuration doesn't specify a Computer Use setting, the agent runs with Computer Use available. Runs on third-party harnesses (Claude Code, Gemini, Codex) default to Computer Use disabled because third-party harnesses don't integrate with Warp's Computer Use tooling. You can control Computer Use per run or per configuration through several entry points:
 
 ### Warp app settings
 
-To control Computer Use for [Cloud Agents](/platform/) started from the Warp app, navigate to **Settings** > **Agents** > **Warp Agent** > **Experimental** > **Computer use in Cloud Agents**.
+Runs started from the Warp app don't use the server default: they always follow the app's **Computer use in Cloud Agents** setting ([`cloud_agent_computer_use_enabled`](/terminal/settings/all-settings/)), which is off by default. To control Computer Use for [Cloud Agents](/platform/) started from the Warp app, navigate to **Settings** > **Agents** > **Warp Agent** > **Experimental** > **Computer use in Cloud Agents**.
 
 ### Oz CLI
 
@@ -53,13 +53,15 @@ oz agent run-cloud --no-computer-use --prompt "<task>"
 
 ### Oz API
 
-When creating a cloud agent run with the [Oz API](/reference/api-and-sdk/), the optional `computer_use_enabled` field controls Computer Use. When omitted, it defaults to `true` for runs on Warp's built-in harness and `false` for runs on third-party harnesses. Set it to `false` to disable Computer Use for the run:
+When creating a cloud agent run with the [Oz API](/reference/api-and-sdk/), the optional `config.computer_use_enabled` field controls Computer Use. When omitted, it defaults to `true` for runs on Warp's built-in harness and `false` for runs on third-party harnesses. Set it to `false` to disable Computer Use for the run:
 
 ```json
 {
   "prompt": "Build a button component that matches this design, then test it in the browser",
-  "computer_use_enabled": false,
-  "environment_id": "optional-environment-id"
+  "config": {
+    "computer_use_enabled": false,
+    "environment_id": "optional-environment-id"
+  }
 }
 ```
 

--- a/src/content/docs/agent-platform/capabilities/computer-use/testing-and-recordings.mdx
+++ b/src/content/docs/agent-platform/capabilities/computer-use/testing-and-recordings.mdx
@@ -31,7 +31,7 @@ You don't need to ask the agent to record explicitly. Prompts like "test this ch
 
 ## How it works
 
-1. **Confirm Computer Use is enabled.** Computer Use is enabled by default for cloud agent runs, so no setup is needed unless it was turned off for your run. See the [Computer Use](/agent-platform/capabilities/computer-use/#enabling-computer-use) page for how to control it via the Warp app, the {VARS.WARP_AGENT_CLI}, or the Oz API.
+1. **Confirm Computer Use is enabled.** Computer Use is enabled by default for cloud agent runs on Warp's built-in harness, so no setup is needed unless it was turned off for your run. See the [Computer Use](/agent-platform/capabilities/computer-use/#enabling-computer-use) page for how to control it via the Warp app, the {VARS.WARP_AGENT_CLI}, or the Oz API.
 2. **Agent starts recording.** Once Computer Use is active, the agent begins a screen capture inside the sandbox. The recording is gated by your session's Computer Use approval. If you've already approved Computer Use for the run, recording starts automatically without a separate prompt.
 3. **Agent exercises the UI.** The agent takes screenshots, clicks, types, scrolls, and drives the interface. Each successful interaction is tracked: when it started, when it finished, what actions it contained, and where the cursor moved.
 4. **Agent stops and processes.** When the task is complete (or when the recording's configured time or size limit is reached), the agent stops capture. Before upload, the recording is post-processed: idle and thinking gaps are cut, leaving only the windows where real interaction happened, and action overlays are burned in so the video is annotated.

--- a/src/content/docs/agent-platform/capabilities/computer-use/testing-and-recordings.mdx
+++ b/src/content/docs/agent-platform/capabilities/computer-use/testing-and-recordings.mdx
@@ -31,7 +31,7 @@ You don't need to ask the agent to record explicitly. Prompts like "test this ch
 
 ## How it works
 
-1. **Enable Computer Use.** The agent needs Computer Use enabled for its run. See the [Computer Use](/agent-platform/capabilities/computer-use/#enabling-computer-use) page for how to enable it via the Warp app, the {VARS.WARP_AGENT_CLI}, or the Oz API.
+1. **Confirm Computer Use is enabled.** Computer Use is enabled by default for cloud agent runs, so no setup is needed unless it was turned off for your run. See the [Computer Use](/agent-platform/capabilities/computer-use/#enabling-computer-use) page for how to control it via the Warp app, the {VARS.WARP_AGENT_CLI}, or the Oz API.
 2. **Agent starts recording.** Once Computer Use is active, the agent begins a screen capture inside the sandbox. The recording is gated by your session's Computer Use approval. If you've already approved Computer Use for the run, recording starts automatically without a separate prompt.
 3. **Agent exercises the UI.** The agent takes screenshots, clicks, types, scrolls, and drives the interface. Each successful interaction is tracked: when it started, when it finished, what actions it contained, and where the cursor moved.
 4. **Agent stops and processes.** When the task is complete (or when the recording's configured time or size limit is reached), the agent stops capture. Before upload, the recording is post-processed: idle and thinking gaps are cut, leaving only the windows where real interaction happened, and action overlays are burned in so the video is annotated.


### PR DESCRIPTION
## Summary
Computer use for cloud agents is no longer experimental and now **defaults to enabled for runs on Warp's built-in harness** (see warpdotdev/warp-server#13465 and warpdotdev/oz-agent-worker#119); third-party harness runs (Claude Code, Gemini, Codex) default to disabled since they don't integrate with Warp's Computer Use tooling. This updates the docs to match:

- **Computer Use page**: the "Enabling Computer Use" section now states the harness-conditional default and frames the entry points (Warp app settings, Oz CLI, Oz API, Oz web app) as ways to control or opt out. The API example shows disabling via `computer_use_enabled: false`, since enabling is now the default on the built-in harness.
- **Testing and recordings**: step 1 no longer instructs readers to enable Computer Use first; it's on by default for built-in-harness runs.
- **Related-page link descriptions** on Browser use and Screenshots/videos in PRs updated from "Enable" to "Control".
- **Agent API OpenAPI spec** (`developers/agent-api-openapi.yaml`): `computer_use_enabled` documented as defaulting to true on the built-in harness and false for third-party harnesses, mirroring the warp-server spec change.

`npm run build` passes (352 pages).

[Conversation](https://staging.warp.dev/conversation/4c268425-a4c3-44c7-bb8c-619055cc6eae)

Co-Authored-By: Oz <oz-agent@warp.dev>