### PR TITLE
docs: credential strategy for agent runs (REMOTE-1815) [auto-draft]

### DIFF
--- a/src/content/docs/platform/credential-strategy.mdx
+++ b/src/content/docs/platform/credential-strategy.mdx
@@ -1,0 +1,127 @@
+---
+title: Credential strategy
+description: >-
+  Choose which principal's credentials a cloud agent run uses for Git and GitLab
+  operations with the per-run credential_strategy field — EXECUTOR or CREATOR.
+sidebar:
+  label: "Credential strategy"
+---
+
+The `credential_strategy` field lets you control which principal's credentials a [cloud agent](/platform/agents/) run uses when Warp mints tokens for Git and GitLab operations. Set it per run to decide whether operations authenticate as the run's execution principal or as its creator — without changing who executes the run.
+
+:::note
+`credential_strategy` is an optional, per-run setting. When you omit it, runs behave exactly as they do today, so existing automations need no changes.
+:::
+
+## Key features
+
+* **Per-run control** - Choose the credential source for each run independently of who executes it.
+* **Two explicit strategies** - Select `EXECUTOR` to use the execution principal's credentials or `CREATOR` to always use the run creator's credentials.
+* **Backward compatible default** - Omitting the field preserves today's behavior, which is identical to `EXECUTOR`.
+* **GitHub and GitLab support** - The same field governs credential selection for both GitHub and GitLab environments.
+* **Fast-fail validation** - When set explicitly, the platform verifies the required credential exists at task creation time, before any compute is spent.
+
+## How it works
+
+A cloud agent run has two associated principals:
+
+* **Execution principal** - The identity that executes the run. This can be a user or a [service account](/platform/agents/#service-accounts) (cloud agent).
+* **Creator** - The identity that created the run. This can also be a user or a service account.
+
+The `credential_strategy` field determines which of these principals supplies credentials when Warp mints user- or team-scoped tokens for the run. The credential *type* is always derived from the selected principal's type:
+
+* A **user** principal produces the user's personal OAuth token for the relevant code forge.
+* A **service account** principal produces a GitHub App installation token (or the equivalent team-level credential).
+
+`credential_strategy` accepts one of two explicit values, or it can be left unset:
+
+* **`EXECUTOR`** - Credentials come from the run's execution principal. This is the explicit form of the default behavior.
+* **`CREATOR`** - Credentials always come from the run creator, regardless of the execution principal.
+* **(unset)** - Behaves identically to `EXECUTOR`.
+
+The strategy is set at run creation time and snapshotted onto the run record alongside the `creator` and `execution_principal`. It cannot be changed after the run is created, so the effective credential behavior is always recoverable from the run record.
+
+:::note
+`credential_strategy` is not specific to Git. Any Warp subsystem that mints user- or team-scoped tokens for a run is intended to respect the same field rather than introducing a separate setting.
+:::
+
+{/* [TODO: docs reviewer — screenshot needed] Run detail view showing the effective credential strategy. [UNVERIFIED] whether the effective strategy is surfaced in the Oz web app UI. */}
+
+## GitHub behavior
+
+The credential minted for GitHub operations depends on the strategy and the selected principal's type:
+
+* **`EXECUTOR` with a service account execution principal** - A GitHub App installation token scoped to the environment's repos is minted for the team that owns the service account. If no installation covers the repos, the run fails at task creation time.
+* **`EXECUTOR` with a user execution principal** - The execution principal's personal GitHub OAuth token is used. If they have no connected GitHub account, the run fails at task creation time.
+* **`CREATOR` with a user creator** - The run creator's personal GitHub OAuth token is used. If the creator has no connected GitHub account, the run fails at task creation time.
+* **`CREATOR` with a service account creator** - A GitHub App installation token scoped to the environment's repos is minted for the team that owns the creator service account. If no installation covers the repos, the run fails at task creation time.
+
+When the field is unset, behavior is identical to `EXECUTOR`.
+
+## GitLab behavior
+
+GitLab environments follow the same model, with an interim limitation for service accounts:
+
+* **`EXECUTOR` with a user execution principal** - The execution principal's personal GitLab OAuth token is used. If they have no connected GitLab account, the run fails at task creation time.
+* **`EXECUTOR` with a service account execution principal** - GitLab team-level credentials (the equivalent of GitHub App tokens) are not yet supported. In the interim, the run falls back to the creator's GitLab OAuth connection when available; if the creator has no connected GitLab account, task creation is rejected.
+* **`CREATOR` with a user creator** - The run creator's personal GitLab OAuth token is used.
+* **`CREATOR` with a service account creator** - GitLab team-level credentials for service accounts do not yet exist, so task creation is rejected until they become available.
+
+When the field is unset, behavior is unchanged from today.
+
+:::caution
+GitLab team-level credentials for service accounts are not yet available. Once they are, `EXECUTOR` and `CREATOR` with a service account will use them, matching the GitHub behavior above.
+:::
+
+## Setting the credential strategy
+
+Set `credential_strategy` in the `config` block of the run creation request. See the [Oz API & SDK reference](/reference/api-and-sdk/) for the full request schema and the [Agents API Reference](/api) for endpoint details.
+
+### Accepted values
+
+* **`EXECUTOR`** - Source credentials from the execution principal.
+* **`CREATOR`** - Source credentials from the run creator.
+
+The field is optional. Omitting it defaults to `EXECUTOR` behavior. Any other non-empty value is rejected with a `400` validation error before the run is created.
+
+### Create a run with a credential strategy
+
+1. Build the run creation request with a `config` block.
+2. Add `credential_strategy` to the `config` block, set to `EXECUTOR` or `CREATOR`.
+3. Submit the request. The platform validates that the required credential is available before the sandbox spawns, and rejects the request with a descriptive error if it is not.
+
+```bash
+curl -X POST https://app.warp.dev/api/v1/agent/run \
+  -H "Authorization: Bearer $WARP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Open a PR with the dependency updates.",
+    "config": {
+      "environment_id": "<ENV_ID>",
+      "credential_strategy": "CREATOR"
+    }
+  }'
+```
+
+{/* [TODO: engineer to verify — the create-run endpoint is documented as `POST /agent/run`; PRODUCT.md §15 references `POST /api/v1/agent/runs`. Confirm the exact endpoint and that `credential_strategy` lives in the `config` block. */}
+
+{/* [TODO: engineer to verify — confirm `credential_strategy` is returned in run GET responses (PRODUCT.md §15) and is present in the public OpenAPI spec that powers the /api reference. It is not yet in the docs repo's synced openapi spec. */}
+
+### Validation
+
+When `credential_strategy` is set explicitly, the platform validates the required credential at task creation time, before the sandbox spawns:
+
+* **For `CREATOR`** - The creator principal's type determines the check. User creators must have a connected OAuth account for the relevant code forge; service account creators must have a GitHub App installation covering the environment's repos (or, for GitLab, task creation is rejected in the interim).
+* **For `EXECUTOR`** - The same checks apply to the execution principal.
+
+If validation fails, the run creation request is rejected with a descriptive error. This fast-fail prevents wasted compute and surfaces misconfigurations immediately.
+
+When `credential_strategy` is unset, no additional pre-flight check runs beyond today's existing behavior.
+
+## Related pages
+
+* [Cloud agents](/platform/agents/) - How runs execute as users or service accounts.
+* [Environments](/platform/environments/) - The runtime context and repos a run uses.
+* [GitLab integration](/platform/integrations/gitlab/) - Connect cloud agents to GitLab repositories.
+* [Oz API & SDK](/reference/api-and-sdk/) - Programmatic access to the run creation API.
+* [API keys](/reference/cli/api-keys/) - Personal and agent API keys.

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -392,6 +392,8 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 						{ slug: 'platform/managing-cloud-agents', label: 'Managing cloud agents' },
 						{ slug: 'platform/agents', label: 'Agents' },
 						{ slug: 'platform/viewing-cloud-agent-runs', label: 'Viewing cloud agent runs' },
+						// [TODO: docs reviewer — confirm placement]
+						{ slug: 'platform/credential-strategy', label: 'Credential strategy' },
 						{ slug: 'platform/oz-web-app', label: 'Oz web app' },
 					],
 				},


### PR DESCRIPTION
## Summary

Auto-drafted documentation for **Configurable credential strategy for agent runs**.

- **Feature:** Credential strategy (`credential_strategy`) for cloud agent runs
- **Spec ID:** REMOTE-1815
- **Spec PR:** https://github.com/warpdotdev/warp-server/pull/12156

This adds a per-run `credential_strategy` field (`EXECUTOR` vs `CREATOR`, default `EXECUTOR`) that controls which principal's credentials Warp mints for Git/GitLab operations in a cloud agent run. New page: `src/content/docs/platform/credential-strategy.mdx`, plus a placeholder sidebar entry in `src/sidebar.ts`.

This draft was generated in **ambient mode** (triggered by `scan-new-specs`). Content is derived only from `PRODUCT.md` and codebase-verified facts — no `TECH.md`-derived content was included.

## Docs outline (auto-generated)

The following outline was generated from the spec. **@captainsafia: please review and check off each item, or leave a comment with corrections.**

### Content structure
- H1: `Credential strategy`
- Opening paragraph describes: what `credential_strategy` controls (which principal's credentials are used for Git/GitLab operations, set per run)
- Key features section covers: per-run control, two explicit strategies, backward-compatible default, GitHub + GitLab support, fast-fail validation
- How it works section covers: execution principal vs creator, how principal type maps to credential type, `EXECUTOR`/`CREATOR`/unset semantics, snapshotting onto the run record
- `## GitHub behavior`: per-strategy behavior for user vs service account principals
- `## GitLab behavior`: per-strategy behavior including the service-account interim limitation
- `## Setting the credential strategy` with steps: build request → add `credential_strategy` to `config` block → submit; plus accepted values, curl example, and validation subsection
- Related pages: Cloud agents, Environments, GitLab integration, Oz API & SDK, API keys

### Items needing engineer verification ⚠️
- [ ] **Endpoint path** — The public docs document run creation as `POST /agent/run`; PRODUCT.md §15 references `POST /api/v1/agent/runs`. Confirm the exact endpoint and that `credential_strategy` lives in the request's `config` block.
- [ ] **GET response** — Confirm `credential_strategy` is returned in run GET responses (PRODUCT.md §15) and is present in the public OpenAPI spec that powers the `/api` reference. It is **not** yet in the docs repo's synced `developers/agent-api-openapi.yaml`, so the Scalar `/api` reference will not show it until `sync-openapi-spec` runs.
- [ ] **Release/availability** — Confirm whether this field is generally available or gated behind a feature flag / plan, so the page can note any gating.
- [ ] **UI surface / screenshot** — Confirm whether the effective credential strategy is surfaced anywhere in the Oz web app (e.g. run detail). A `[TODO: docs reviewer — screenshot needed]` placeholder is left in the page; computer use was unavailable, so no screenshot was captured.
- [ ] **Sidebar placement** — Placed under **Oz → Managing agents** in `src/sidebar.ts` with a `// [TODO: docs reviewer — confirm placement]` note. Confirm this is the right home (vs. Reference → API & SDK).

### Verified from codebase ✅
- Field name `config.credential_strategy` — confirmed via the validation error string in `router/handlers/public_api/agent_webhooks.go` (`config.credential_strategy %q is not valid; accepted values are %q and %q`).
- Accepted values `CREATOR` and `EXECUTOR` — confirmed in `model/types/enums/credential_strategy.go` and related code.
- `400` validation for any other non-empty value — consistent with the webhook validation error and PRODUCT.md §16.
- Pre-flight validation at task creation time (before sandbox spawn) — confirmed in `logic/ai/ambient_agents/credential_strategy_validation.go`.
- Git token resolution respects the strategy — confirmed in `logic/ai/ambient_agents/git_credentials.go`.

## Full list of `[UNVERIFIED]` / `[TODO]` items in the draft
- `credential-strategy.mdx` (How it works): `[TODO: docs reviewer — screenshot needed]` + `[UNVERIFIED]` whether effective strategy shows in the Oz web app UI.
- `credential-strategy.mdx` (Setting the credential strategy): `[TODO: engineer to verify]` exact endpoint (`POST /agent/run` vs `POST /api/v1/agent/runs`) and `config` block placement.
- `credential-strategy.mdx` (Setting the credential strategy): `[TODO: engineer to verify]` `credential_strategy` returned in GET responses and present in the public OpenAPI spec.
- `src/sidebar.ts`: `// [TODO: docs reviewer — confirm placement]`.

/cc @captainsafia

Requesting review from @rachaelrenk and @hongyi-chen.

_Conversation: https://app.warp.dev/conversation/e8fd611f-bdd4-40ea-af4f-0efa6ccfb970_
_Run: https://oz.warp.dev/runs/019fae9f-b516-7887-b592-fa53ff7a5e95_

_This PR was generated with [Oz](https://warp.dev/oz)._
