### PR TITLE
docs: correct denylist behavior under Run until completion

### DIFF
--- a/src/content/docs/agent-platform/capabilities/agent-profiles-permissions.mdx
+++ b/src/content/docs/agent-platform/capabilities/agent-profiles-permissions.mdx
@@ -36,7 +36,7 @@ Agent Profiles let you configure how your Agent behaves in different situations.
 Agent Permissions let you define how your Agent in a specific Profile operates — control its autonomy, choose what tools or MCP servers it can access, and set when it should act independently or ask for approval.
 
 :::caution
-**Still getting approval prompts?** If the Agent keeps asking for permission to run certain commands (like `curl`, `rm`, or `wget`) even though you've set permissions to "Always allow," check your **Command denylist** in **Settings** > **Agents** > **Profiles**. The denylist always takes precedence over other permission settings. Remove commands from the denylist to allow them to auto-execute, or use [Run until completion](#run-until-completion) to bypass the denylist for the current task.
+**Still getting approval prompts?** If the Agent keeps asking for permission to run certain commands (like `curl`, `rm`, or `wget`) even though you've set permissions to "Always allow," check your **Command denylist** in **Settings** > **Agents** > **Profiles**. The denylist takes precedence over your other permission settings. Remove commands from the denylist to allow them to auto-execute, or use [Run until completion](#run-until-completion) to bypass the denylist for the current task.
 :::
 
 You can control how much autonomy the Agent has when performing different types of actions under **Settings** > **Agents** > **Profiles** > **Permissions** . Agent permission types:
@@ -98,7 +98,7 @@ For safety, the Agent always prompts for confirmation before executing potential
 * `rm(\s.*)?` - File deletion
 * `eval(\s.*)?` - Shell code execution
 
-The denylist takes precedence over both the allowlist and `Agent decides`. If a command matches the denylist, user permission will always be required, regardless of other settings. You can add your own regular expressions to this list in **Settings** > **Agents** > **Profiles** > **Command denylist**.
+The denylist takes precedence over both the allowlist and `Agent decides`: if a command matches the denylist, the Agent asks for permission even when that action type is set to **Always allow**. Add your own regular expressions to this list in **Settings** > **Agents** > **Profiles** > **Command denylist**. The one exception is [Run until completion](#run-until-completion), which bypasses your denylist by default.
 
 ### MCP permissions
 
@@ -140,8 +140,10 @@ During an Agent interaction, you can give the Agent full autonomy for the curren
 <figcaption>Auto-approve and take-over controls.</figcaption>
 </figure>
 
-:::note
-_Run until completion_ ignores the denylist entirely. It's the purest form of “YOLO” mode and essentially a fully "autonomous mode" where the Agent proceeds without asking for confirmation.
+:::caution
+_Run until completion_ is the purest form of “YOLO” mode: the Agent proceeds without asking for confirmation, and by default it also runs commands that match your command denylist.
+
+To keep your denylist in force during _Run until completion_, turn off **Allow auto-approve to bypass command denylist** in **Settings** > **Agents** > **Oz** > **Input**. Denylist rules your team enforces through the [Admin Panel](/enterprise/team-management/admin-panel/) always require approval and are never bypassed.
 :::
 
 ---


### PR DESCRIPTION
## Problem
`auto_approve_bypasses_command_denylist` (added in warpdotdev/warp#14489, **defaults to `true`**) changed how the command denylist interacts with auto-approve / Run until completion. Two statements on `agent-profiles-permissions.mdx` predate it and are now inaccurate in opposite directions:

- **Command denylist** said permission is *"always required, regardless of other settings."* Not true once Run until completion is on.
- **Run until completion** said it *"ignores the denylist entirely."* Overstated — the bypass is configurable, and org-enforced rules are never bypassed.

## Actual behavior
Verified against `can_autoexecute_command` in `app/src/ai/blocklist/permissions.rs`:

```rust
let bypass_user_denylist = auto_approve_enabled
    && !AppExecutionMode::as_ref(ctx).is_sandboxed()
    && *AISettings::as_ref(ctx).auto_approve_bypasses_command_denylist;
```

- Auto-approve off → full merged denylist (org + user) enforced, takes precedence over `Always allow`.
- Auto-approve on, setting `true` (default) → user denylist bypassed; `get_org_execute_commands_denylist` still enforced.
- Auto-approve on, setting `false` → full denylist enforced.

## Changes
- Reworded the **Command denylist** precedence sentence and noted Run until completion as the exception.
- Rewrote the Run until completion callout (`note` → `caution`, since it's a safety caveat) to state the default bypass, point to the GUI toggle, and clarify that team-enforced rules can't be bypassed.
- Dropped "always" from the "Still getting approval prompts?" caution for consistency.

GUI toggle documented as **Settings** > **Agents** > **Oz** > **Input** > **Allow auto-approve to bypass command denylist** (`AutoApproveBypassesCommandDenylist` in `app/src/settings_view/ai_page.rs`).

## Not changed
The note at line 60 — *"When all Agent permissions are set to **Always allow** ... any denylist rules will still override these settings"* — is **still correct**. `Always allow` is a profile permission value and does not enable auto-approve, so the denylist genuinely does still apply there. Left as-is.

## Validation
`npm run build` passes (352 pages). `style_lint --changed` reports 8 findings on this file: 6 screenshot-width and 1 unrecognized-term (line 13) are pre-existing and outside this diff; the line 146 `**Input**` "unrecognized term" is a menu-path segment, consistent with the existing convention on `terminal/input/universal-input.mdx`.

## Context
Follow-up to warpdotdev/docs#404, which documented this behavior for the Warp Agent CLI and surfaced the inconsistency on this page. That PR targeted the `hyc/launch-cli` integration branch; this one targets `main` since it's app behavior and shouldn't be gated behind the CLI launch.

_Conversation: https://staging.warp.dev/conversation/dfef0154-c007-40dd-a8f5-0e72b7ea7d34_
_Run: https://oz.staging.warp.dev/runs/019fb436-e2ee-7290-9f83-d94c6afce961_

_This PR was generated with [Oz](https://warp.dev/oz)._
