### PR TITLE
Automated SEO fixes: resolve 2 short titles and trim 4 long descriptions

### DIFF
--- a/src/content/docs/agent-platform/capabilities/computer-use/browser-use.mdx
+++ b/src/content/docs/agent-platform/capabilities/computer-use/browser-use.mdx
@@ -1,5 +1,5 @@
 ---
-title: Browser use
+title: Browser use for agents
 sidebar:
   label: "Browser use"
 description: >-

--- a/src/content/docs/enterprise/enterprise-features/team-managed-keys-and-endpoints.mdx
+++ b/src/content/docs/enterprise/enterprise-features/team-managed-keys-and-endpoints.mdx
@@ -1,8 +1,8 @@
 ---
 title: Team-managed LLM API keys and endpoints
 description: >-
-  Configure shared LLM provider API keys and custom inference endpoints for your whole team
-  from the Admin Panel, available in both interactive sessions and cloud agents.
+  Configure shared LLM provider API keys and custom inference endpoints for your
+  whole team from the Admin Panel, for interactive sessions and cloud agents.
 ---
 import VideoEmbed from '@components/VideoEmbed.astro';
 

--- a/src/content/docs/guides/agent-workflows/build-a-self-improving-agent.mdx
+++ b/src/content/docs/guides/agent-workflows/build-a-self-improving-agent.mdx
@@ -1,7 +1,8 @@
 ---
 title: Build a self-improving agent
 description: >-
-  Build an outer improvement loop where a scheduled agent reviews past runs, learns from team corrections, and proposes skill file updates — so your factory gets better over time.
+  Build an outer loop where a scheduled agent reviews past runs, learns from team
+  corrections, and proposes skill file updates for human review.
 sidebar:
   label: "Build a self-improving agent"
 tags:

--- a/src/content/docs/guides/agent-workflows/run-a-software-factory-in-the-cloud.mdx
+++ b/src/content/docs/guides/agent-workflows/run-a-software-factory-in-the-cloud.mdx
@@ -1,7 +1,8 @@
 ---
 title: Run a software factory in the cloud
 description: >-
-  Set up the Oz-native production path for your software factory: dedicated cloud environments, team-scoped secrets, native event triggers, and full audit trails for every agent run.
+  Run your software factory on Oz with dedicated cloud environments, team-scoped
+  secrets, native event triggers, and audit trails for every agent run.
 sidebar:
   label: "Run a software factory in the cloud"
 tags:

--- a/src/content/docs/platform/agents.mdx
+++ b/src/content/docs/platform/agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud agents
+title: Cloud agents and service accounts
 description: >-
   Cloud agents are how Warp runs scheduled jobs, integration triggers, CI/CD
   automation, and API-driven tasks against your team's environments.

--- a/src/content/docs/platform/runners.mdx
+++ b/src/content/docs/platform/runners.mdx
@@ -3,9 +3,8 @@ title: Cloud agent runners
 sidebar:
   label: "Runners"
 description: >-
-  Runners define the compute a cloud agent runs on—operating system, CPU
-  architecture, instance size, and sandbox image. Learn when to use runners and
-  how to manage them with the Oz CLI.
+  Runners define the compute a cloud agent runs on: operating system, CPU
+  architecture, instance size, and sandbox image. Manage them with the Oz CLI.
 ---
 
 Runners define the compute a [cloud agent](/platform/) runs on: the operating system, CPU architecture, instance size, and sandbox image used to execute a run.


### PR DESCRIPTION
## Summary
Ran the `docs-seo-audit` skill against the live sitemap: **352 pages scanned, 12 issues found** (0 errors, 8 warnings, 4 info). This PR fixes the 6 actionable issues. The other 6 are on the skill's intentional-exceptions allowlist.

## Title fixes (`title_too_short`)
| Page | Before | After |
| --- | --- | --- |
| `src/content/docs/platform/agents.mdx` | `Cloud agents` (19 chars with ` \| Warp`) | `Cloud agents and service accounts` |
| `src/content/docs/agent-platform/capabilities/computer-use/browser-use.mdx` | `Browser use` (18 chars) | `Browser use for agents` |

Notes:
- `platform/agents.mdx` also had near-duplicate framing with `Cloud agents overview` (`platform/index.mdx`). The new title reflects what the page actually covers — cloud agents as team-level identities, agent API keys, and their service-account representation in the CLI and API — and removes the keyword overlap.
- Only the frontmatter `title` changed on both pages. Sidebar labels (`Agents`, `Browser use`) and URLs are unchanged, so navigation and breadcrumbs stay as-is. Starlight derives the H1 from `title`, so headings stay in sync automatically.

## Description fixes (`description_too_long`, max 160 chars)
| Page | Before | After |
| --- | --- | --- |
| `src/content/docs/platform/runners.mdx` | 184 chars | 148 chars |
| `src/content/docs/guides/agent-workflows/run-a-software-factory-in-the-cloud.mdx` | 180 chars | 148 chars |
| `src/content/docs/guides/agent-workflows/build-a-self-improving-agent.mdx` | 177 chars | 142 chars |
| `src/content/docs/enterprise/enterprise-features/team-managed-keys-and-endpoints.mdx` | 168 chars | 154 chars |

All rewrites are grounded in the page content, keep the primary keyword, and follow `AGENTS.md` voice and terminology. The runners description also drops an em dash in favor of a colon.

## Not changed (intentional exceptions)
These 6 `title_too_short` warnings match the allowlist in the skill and were left alone: `changelog/index.mdx`, `guides/index.mdx`, `reference/cli/artifacts.mdx`, `terminal/windows/tabs.mdx`, `terminal/windows/tab-configs.mdx`, `terminal/windows/split-panes.mdx`.

## Validation
- `npm run build` succeeds (353 pages).
- Verified the rendered `<title>` and `<meta name="description">` tags in `dist/` for all six pages.
- Re-checked every frontmatter title across the docs: no duplicates introduced.

_Conversation: https://app.warp.dev/conversation/9ed250ab-c31f-4ee8-b037-beb7675ede81_
_Run: https://oz.warp.dev/runs/019fb6f9-241b-7c28-bfe4-1b3f7772d1f9_

_This PR was generated with [Oz](https://warp.dev/oz)._
