### PR TITLE
docs: Improve Manage billing access and Pricing FAQ accuracy

### DIFF
--- a/src/content/docs/knowledge-and-collaboration/teams.mdx
+++ b/src/content/docs/knowledge-and-collaboration/teams.mdx
@@ -107,4 +107,4 @@ If you're a Team admin, and you choose to [delete your Warp](/support-and-commun
 | Leave a team | | ✓ |
 | Delete a team | ✓ | |
 | Transfer admin | ✓ | |
-| [Manage billing](/support-and-community/plans-and-billing/plans-pricing-refunds/) | ✓ | |
+| [Manage billing](/support-and-community/plans-and-billing/pricing-faqs/#how-do-i-manage-my-billing) | ✓ | |

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -107,7 +107,7 @@ You can downgrade at any point throughout your subscription through the billing 
 
 You can cancel at any point throughout your subscription through the billing portal. See [How do I manage my billing?](#how-do-i-manage-my-billing).
 
-Cancelled subscriptions remain active until the **end of your billing cycle**, monthly or yearly. **You can continue to use your Warp paid plan features until the cycle end date**. Any additional team members added to your team will be invoiced at the end of your billing cycle.
+Cancelled subscriptions remain active until the **end of your billing cycle**, monthly or yearly. **You can continue to use your Warp paid plan features until the cycle end date**. New team members added before the cycle ends are still billed immediately on a prorated basis for the remaining time in the cycle. See [What counts as a team member and how does billing work for members?](#what-counts-as-a-team-member-and-how-does-billing-work-for-members).
 
 ### What happens if I upgrade from monthly to annual billing?
 

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -121,9 +121,9 @@ Unused credits do not rollover to the next cycle and can't be transferred to oth
 
 ### What happens if my payment fails?
 
-If a payment fails, you will receive an email from Stripe and your Warp Team Settings will show a past-due alert. Certain paid plan features and the ability to invite new members will be locked down while your Team is in a past-due state. Paying the most recent invoice through the billing portal will fully re-enable your paid plan features. See [How do I manage my billing?](#how-do-i-manage-my-billing).
+If a payment fails, you will receive an email from Stripe and your Warp Team Settings will show a past-due alert. Certain paid plan features and the ability to invite new members will be locked down while your Team is in a past-due state. Paying all unpaid invoices through the billing portal will fully re-enable your paid plan features. See [How do I manage my billing?](#how-do-i-manage-my-billing).
 
-If there are multiple unpaid invoices, your account will remain in a past-due state. Contact [billing@warp.dev](mailto:billing@warp.dev) for assistance.
+If there are multiple unpaid invoices and you need help resolving them, contact [billing@warp.dev](mailto:billing@warp.dev) for assistance.
 
 ### What counts as a credit?
 

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -86,25 +86,34 @@ When you use the account to sign into Warp on different devices, for example Lin
 
 You can use your Warp account on multiple personal computers. Warp is designed to provide a consistent experience across devices. When you log in with the same account on different computers, your settings and preferences can be synced through the [Settings Sync](/terminal/more-features/settings-sync/) feature.
 
+### How do I manage my billing?
+
+Open the billing portal to update your payment method, change billing details, view invoices, downgrade, cancel, or switch between monthly and annual billing.
+
+You can open **Manage billing** from the Warp app or the web:
+
+* **In the Warp app** - Go to **Settings** > **Billing and usage**, then click **Manage billing**.
+* **On the web** - Open the [Warp Admin Panel](https://app.warp.dev/admin/) or the [Warp upgrade page](https://app.warp.dev/upgrade), click your profile in the top-right corner, then click **Manage billing**. You don't need the Warp app installed.
+
 ### What happens when I downgrade during a billing cycle?
 
 Downgrades take effect immediately. Warp issues an account balance for the prorated difference based on the time remaining in your billing cycle, not on unused monthly AI credits. You can apply that balance toward future subscription payments or AI credit purchases. The account balance amount is visible in the billing portal invoice history.
 
 Any AI credits you've already used in the current cycle count against the lower plan's monthly limit. If your usage has already exceeded that limit, you won't receive more AI credits until your next billing cycle.
 
-You can downgrade at any point throughout your subscription through the billing portal by going to **Settings** > **Billing and usage** > **Manage billing**.
+You can downgrade at any point throughout your subscription through the billing portal. See [How do I manage my billing?](#how-do-i-manage-my-billing).
 
-### What happens when I cancel during a billing cycle?
+### How do I cancel my subscription?
 
-You can cancel at any point throughout your subscription through the billing portal by going to **Settings** > **Billing and usage** > **Manage billing**. The subscription will be canceled at the **end of your billing cycle**, monthly or yearly.
+You can cancel at any point throughout your subscription through the billing portal. See [How do I manage my billing?](#how-do-i-manage-my-billing).
 
-**You can continue to use your Warp paid plan features until the cycle end date**. Any additional team members added to your team will be invoiced at the end of your billing cycle.
+Cancelled subscriptions remain active until the **end of your billing cycle**, monthly or yearly. **You can continue to use your Warp paid plan features until the cycle end date**. Any additional team members added to your team will be invoiced at the end of your billing cycle.
 
 ### What happens if I upgrade from monthly to annual billing?
 
 When upgrading from a monthly to annual billing cycle the billing is prorated, meaning you only pay for the annual portion of the year you haven't paid for yet. You will be billed for the remaining part of the billing year with the discounted rate.
 
-You can upgrade at any point throughout your subscription through the billing portal by going to **Settings** > **Billing and usage** > **Manage billing**.
+You can upgrade at any point throughout your subscription on the [Warp upgrade page](https://app.warp.dev/upgrade). You can also open **Manage billing** from your profile menu on that page. See [How do I manage my billing?](#how-do-i-manage-my-billing).
 
 ### What happens to unused credits?
 
@@ -112,7 +121,9 @@ Unused credits do not rollover to the next cycle and can't be transferred to oth
 
 ### What happens if my payment fails?
 
-If a payment fails, you will receive an email from Stripe and your Warp Team Settings will show a past-due alert. Certain paid plan features and the ability to invite new members will be locked down while your Team is in a past-due state. Paying the most recent invoice through the billing portal by going to **Settings** > **Billing and usage** > **Manage billing** will fully re-enable your paid plan features.
+If a payment fails, you will receive an email from Stripe and your Warp Team Settings will show a past-due alert. Certain paid plan features and the ability to invite new members will be locked down while your Team is in a past-due state. Paying the most recent invoice through the billing portal will fully re-enable your paid plan features. See [How do I manage my billing?](#how-do-i-manage-my-billing).
+
+If there are multiple unpaid invoices, your account will remain in a past-due state. Contact [billing@warp.dev](mailto:billing@warp.dev) for assistance.
 
 ### What counts as a credit?
 
@@ -312,12 +323,6 @@ We don't support ACH, checks, PayPal, cryptocurrency, or other alternative payme
 To checkout with Apple Pay, use the Safari browser on an Apple device.\
 To checkout with Google Pay, use Chrome, make sure you're logged into your Google Wallet account in the browser, and that "Save and fill payment methods" is enabled in the browser settings.
 :::
-
-### How do I cancel my subscription?
-
-You can cancel at any point throughout your subscription through the billing portal by going to **Settings** > **Billing and usage** > **Manage billing**.
-
-Cancelled subscriptions will remain active until the end of the billing cycle.
 
 ### How do I get a refund?
 


### PR DESCRIPTION
## Summary
Updates Pricing FAQ billing guidance: document app and web paths to **Manage billing**, consolidate cancel FAQs, correct mid-cancel seat billing, and clean up related upgrade and past-due copy.

## Changes

### `src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx`
- Added **How do I manage my billing?** with app and web access paths (Admin Panel and upgrade page profile menus)
- Consolidated the two cancel FAQs into a single **How do I cancel my subscription?** higher in the page
- Corrected cancel-period teammate billing: new seats are billed immediately on a prorated basis, not at cycle end
- Pointed monthly-to-annual upgrades at the Warp upgrade page
- Clarified past-due behavior when multiple invoices are unpaid

### `src/content/docs/knowledge-and-collaboration/teams.mdx`
- Updated the Manage billing permissions table link to the new FAQ anchor

## Notes
- Preview this PR's Vercel deployment to verify the new FAQ anchors and links.

Co-Authored-By: Oz <oz-agent@warp.dev>
