### PR TITLE
docs: document Vim indent and dedent operators in the code editor

### DIFF
--- a/src/content/docs/code/code-editor/code-editor-vim-keybindings.mdx
+++ b/src/content/docs/code/code-editor/code-editor-vim-keybindings.mdx
@@ -79,8 +79,27 @@ See [Vim docs: motion](https://vimdoc.sourceforge.net/htmldoc/motion.html) for m
 | `.`        | repeat last edit                                            |
 | `gcc`      | toggle comments on current line                             |
 | `gc`       | toggle comments on visual selection                         |
+| `>`, `<`   | indent or dedent a range or object                          |
+| `>>`, `<<` | indent or dedent the current line                           |
 
 See [Vim docs: editing](https://vimdoc.sourceforge.net/htmldoc/editing.html) for more information.
+
+#### Indenting and dedenting
+
+`>` and `<` are operators, so they combine with any supported motion or text object the same way `d` and `y` do:
+
+| Command   | Description                                              |
+| --------- | -------------------------------------------------------- |
+| `>>`      | indent the current line                                  |
+| `<<`      | dedent the current line                                  |
+| `>j`      | indent the current line and the line below               |
+| `>ap`     | indent the current paragraph                             |
+| `3>>`     | indent the current line and the two below it             |
+| `>` / `<` | indent or dedent the selection in visual or visual line mode |
+
+In visual mode, `>` and `<` shift the selected lines and return to Normal mode.
+
+See [Vim docs: shifting text](https://vimdoc.sourceforge.net/htmldoc/change.html#%3E) for more information.
 
 #### Text objects
 


### PR DESCRIPTION
## Summary

Warp's code editor supports the Vim `>` and `<` indent and dedent operators, but the Vim keybindings reference didn't list them. That page is meant to be an exhaustive list of implemented Vim functionality, so a missing operator reads as "not supported."

Found by the `missing_docs` drift-watch audit (changelog item [#14268](https://github.com/warpdotdev/warp/pull/14268)) and verified against `crates/vim/src/vim.rs`.

## Changes

### `src/content/docs/code/code-editor/code-editor-vim-keybindings.mdx`
- Added `>`, `<`, `>>`, and `<<` to the **Editing** table.
- Added an **Indenting and dedenting** subsection showing that `>` and `<` are operators that compose with motions, text objects, and counts, plus their visual-mode behavior.

## Source verification

All behavior in the new subsection maps to `crates/vim/src/vim.rs`:

- `VimOperator::Indent` / `Dedent` are constructed from `>` / `<` in `PendingAction::from` and `VimOperator::from`.
- `>>` and `<<` resolve to `VimOperand::Line` in `handle_normal_pending_operation`.
- The same function routes `i`/`a` to text objects and `j`/`k` to linewise motions for any operator, so `>ap` and `>j` work.
- Digits accumulate into `pending_action_count` before the operator, so `3>>` applies a count.
- `handle_visual_nothing_pending` handles `<` / `>` via `create_visual_operator` and then returns to Normal mode.

## Verification

- `npm run build` passes.
- Internal link check passes (0 broken links).

## Deferred findings from this audit run

None specific to this page. Run-wide deferrals are listed in the companion audit-bookkeeping PR.

_Conversation: https://staging.warp.dev/conversation/53c4f3f8-39bb-46c1-a5c0-66b467db0439_
_Run: https://oz.staging.warp.dev/runs/019fb91e-74a0-73f4-ac72-f2d88c32fab5_

_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
