### PR TITLE
docs: document auto_approve_bypasses_command_denylist in the settings reference

### DIFF
--- a/src/content/docs/terminal/settings/all-settings.mdx
+++ b/src/content/docs/terminal/settings/all-settings.mdx
@@ -323,6 +323,7 @@ Settings for Warp's agents, including model behavior, permissions, knowledge, MC
 
 * `thinking_display_mode` — Controls how agent thinking traces are displayed after streaming. Type: string. Default: `"show_and_collapse"`. Options: `"show_and_collapse"`, `"always_show"`, `"never_show"`.
 * `open_conversation_layout_preference` — Whether to open agent conversations in a new tab or a split pane. Type: string. Default: `"new_tab"`. Options: `"new_tab"`, `"split_pane"`.
+* `auto_approve_bypasses_command_denylist` — Whether auto-approve and [Run until completion](/agent-platform/capabilities/agent-profiles-permissions/#run-until-completion) run commands that match your command denylist without asking for confirmation. Denylist rules your team enforces through the [Admin Panel](/enterprise/team-management/admin-panel/) are never bypassed. Type: boolean. Default: `true`.
 * `show_conversation_history` — Whether conversation history appears in the tools panel. Type: boolean. Default: `true`.
 * `show_agent_notifications` — Whether agent notifications are shown. Type: boolean. Default: `true`.
 * `should_show_oz_updates_in_zero_state` — Whether the "What's new" section is shown in the agent view. Type: boolean. Default: `true`.


### PR DESCRIPTION
## Summary

`agents.warp_agent.other.auto_approve_bypasses_command_denylist` is a user-facing, GA setting with a toggle in **Settings** > **Agents**, but it was missing from the all-settings reference.

Found by the `missing_docs` drift-watch audit (new setting detected by the snapshot diff) and verified against `app/src/settings/ai.rs`.

## Changes

### `src/content/docs/terminal/settings/all-settings.mdx`
- Added `auto_approve_bypasses_command_denylist` to the `[agents.warp_agent.other]` section, with its type and default, and cross-links to the Run until completion and command denylist sections of the agent profiles page.
- Noted that Admin Panel-enforced denylist rules are never bypassed, since that's the part most likely to be misread as a security hole.

## Relationship to #424

PR #424 corrected the prose about this behavior on `agent-profiles-permissions.mdx`. It didn't add the setting to the all-settings reference, which is what the audit checks and what this PR fixes. The two pages now agree.

## Source verification

`app/src/settings/ai.rs`:
- `toml_path: "agents.warp_agent.other.auto_approve_bypasses_command_denylist"`, `type: bool`, `default: true`, `private: false`, `surface: SettingSurfaces::ALL`.
- No `feature_flag`, and the toggle is pushed unconditionally in `AIInputWidget::render` (`app/src/settings_view/ai_page.rs`), so this is GA.

`app/src/ai/blocklist/permissions.rs` (`can_autoexecute_command`) confirms the Admin Panel caveat: `bypass_user_denylist` additionally requires `!AppExecutionMode::is_sandboxed()`, and when the bypass applies the code still enforces `get_org_execute_commands_denylist(ctx)`.

## Verification

- `npm run build` passes.
- Internal link check passes (0 broken links); both new anchors resolve to real headings.

## Deferred findings from this audit run

The same audit flagged `agents.voice.voice_input_hold_key` as undocumented. It is `SettingSurfaces::TUI` (Warp Agent CLI only) and has no desktop-app UI, so it follows the existing convention for CLI-only settings and is mapped `internal` in the companion audit-bookkeeping PR rather than documented here. Other run-wide deferrals are listed in that PR.

_Conversation: https://staging.warp.dev/conversation/53c4f3f8-39bb-46c1-a5c0-66b467db0439_
_Run: https://oz.staging.warp.dev/runs/019fb91e-74a0-73f4-ac72-f2d88c32fab5_

_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
