### PR TITLE
docs: missing_docs audit bookkeeping and OpenAPI path-parsing fix

### DIFF
--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -201,9 +201,6 @@ NamedAgents -> src/content/docs/platform/agents.mdx
 
 # Inference: BYOK and custom endpoints
 SoloUserByok -> src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
-# Gemini Enterprise (Vertex AI) BYOLLM routing. Promoted dogfood -> GA; the
-# feature has a dedicated Enterprise page.
-GeminiEnterprise -> src/content/docs/enterprise/enterprise-features/byollm-gemini-enterprise.mdx
 # CustomInferenceEndpoints flag was removed after the feature stabilized (GA);
 # the feature remains documented at inference/custom-inference-endpoint.mdx.
 # Connect a SuperGrok subscription instead of pasting an xAI API key.
@@ -444,16 +441,12 @@ GET /memory_stores/{uid}/memories/{memoryUid}/versions -> gated:AIMemories
 # - /status: show session and account status
 # - /clear: clear the transcript and start a new conversation
 # - /statusline: configure the Warp Agent CLI statusline (agents.statusline, internal)
-# - /reset-statusline: restore the statusline default items and ordering
-# - /api-keys: view and manage model-provider API keys. Replaces the removed
-#   /add-api-key and /clear-provider-api-key pair, whose entries were pruned.
-# - /vim-mode: toggle Vim mode in the Warp Agent CLI input
+# - /add-api-key, /clear-provider-api-key: store/remove a model-provider API key
 /status -> internal
 /clear -> internal
 /statusline -> internal
-/reset-statusline -> internal
-/api-keys -> internal
-/vim-mode -> internal
+/add-api-key -> internal
+/clear-provider-api-key -> internal
 # TUI-only color-theme picker (Warp Agent CLI surface, SlashCommandSurfaces::TuiOnly
 # in static_commands/commands.rs). It sets the Warp Agent CLI theme
 # (appearance.theme, mapped internal below) and isn't present in the GUI, so it
@@ -498,13 +491,6 @@ appearance.theme -> internal
 appearance.zero_state.object -> internal
 appearance.zero_state.rotation_period_seconds -> internal
 appearance.zero_state.extrusion_depth -> internal
-
-# Warp Agent CLI-only (crates/warp_tui) push-to-talk modifier for voice input
-# (surface: SettingSurfaces::TUI in app/src/settings/tui_voice.rs). The GUI knob
-# is the separate agents.voice.voice_input_toggle_key, which is documented in the
-# all-settings reference. Paired with the /voice Warp Agent CLI slash command
-# mapped internal above.
-agents.voice.voice_input_hold_key -> internal
 
 ## Unlisted docs pages to ignore
 

--- a/.agents/skills/missing_docs/references/feature_surface_map.md
+++ b/.agents/skills/missing_docs/references/feature_surface_map.md
@@ -201,6 +201,9 @@ NamedAgents -> src/content/docs/platform/agents.mdx
 
 # Inference: BYOK and custom endpoints
 SoloUserByok -> src/content/docs/agent-platform/inference/bring-your-own-api-key.mdx
+# Gemini Enterprise (Vertex AI) BYOLLM routing. Promoted dogfood -> GA; the
+# feature has a dedicated Enterprise page.
+GeminiEnterprise -> src/content/docs/enterprise/enterprise-features/byollm-gemini-enterprise.mdx
 # CustomInferenceEndpoints flag was removed after the feature stabilized (GA);
 # the feature remains documented at inference/custom-inference-endpoint.mdx.
 # Connect a SuperGrok subscription instead of pasting an xAI API key.
@@ -379,6 +382,24 @@ GET /factory/scorers -> internal
 POST /factory/scorers -> internal
 GET /factory/scorers/{scorer_id}/results -> internal
 
+# Orchestration messaging and lifecycle-event endpoints. These are marked
+# `x-internal: true` in warp-server's canonical spec (public_api/openapi.yaml),
+# so the publish filter deliberately strips them from the public docs copy.
+# They back the agent-to-agent messaging tools and the documented
+# `oz run message` CLI, but the REST surface itself is not part of the released
+# public Oz Agent API. Revisit if warp-server drops the x-internal marker.
+POST /agent/messages -> internal
+GET /agent/messages/{run_id} -> internal
+POST /agent/messages/{id}/read -> internal
+POST /agent/messages/{id}/delivered -> internal
+GET /agent/events -> internal
+POST /agent/events/{run_id} -> internal
+
+# SSE lifecycle-event stream consumed by the Warp client and the Oz web app.
+# Absent from warp-server's canonical public spec entirely, and registered only
+# on the RTC host, so it is not a released public API operation.
+GET /agent/events/stream -> internal
+
 # Agent Memory REST API — research preview (gating flag AIMemories is non-GA),
 # deferred via `gated:` and auto-surfaces when AIMemories goes GA. See
 # "Public vs. private surfaces" in SKILL.md.
@@ -423,12 +444,16 @@ GET /memory_stores/{uid}/memories/{memoryUid}/versions -> gated:AIMemories
 # - /status: show session and account status
 # - /clear: clear the transcript and start a new conversation
 # - /statusline: configure the Warp Agent CLI statusline (agents.statusline, internal)
-# - /add-api-key, /clear-provider-api-key: store/remove a model-provider API key
+# - /reset-statusline: restore the statusline default items and ordering
+# - /api-keys: view and manage model-provider API keys. Replaces the removed
+#   /add-api-key and /clear-provider-api-key pair, whose entries were pruned.
+# - /vim-mode: toggle Vim mode in the Warp Agent CLI input
 /status -> internal
 /clear -> internal
 /statusline -> internal
-/add-api-key -> internal
-/clear-provider-api-key -> internal
+/reset-statusline -> internal
+/api-keys -> internal
+/vim-mode -> internal
 # TUI-only color-theme picker (Warp Agent CLI surface, SlashCommandSurfaces::TuiOnly
 # in static_commands/commands.rs). It sets the Warp Agent CLI theme
 # (appearance.theme, mapped internal below) and isn't present in the GUI, so it
@@ -473,6 +498,13 @@ appearance.theme -> internal
 appearance.zero_state.object -> internal
 appearance.zero_state.rotation_period_seconds -> internal
 appearance.zero_state.extrusion_depth -> internal
+
+# Warp Agent CLI-only (crates/warp_tui) push-to-talk modifier for voice input
+# (surface: SettingSurfaces::TUI in app/src/settings/tui_voice.rs). The GUI knob
+# is the separate agents.voice.voice_input_toggle_key, which is documented in the
+# all-settings reference. Paired with the /voice Warp Agent CLI slash command
+# mapped internal above.
+agents.voice.voice_input_hold_key -> internal
 
 ## Unlisted docs pages to ignore
 

--- a/.agents/skills/missing_docs/references/surface_snapshot.json
+++ b/.agents/skills/missing_docs/references/surface_snapshot.json
@@ -127,7 +127,7 @@
     "FullScreenZenMode": "ga",
     "FullSourceCodeEmbedding": "dogfood",
     "GPTConfigurableContextWindow": "dogfood",
-    "GeminiEnterprise": "dogfood",
+    "GeminiEnterprise": "ga",
     "GeminiNotifications": "dogfood",
     "GetStartedTab": "ga",
     "GitCredentialRefresh": "ga",
@@ -917,20 +917,20 @@
     "PUT /api/v1/memory_stores/{uid}/memories/{memoryUid}"
   ],
   "slash_commands": [
-    "/add-api-key",
     "/add-mcp",
     "/add-prompt",
     "/add-rule",
     "/agent",
+    "/api-keys",
     "/auto-approve",
     "/changelog",
     "/clear",
-    "/clear-provider-api-key",
     "/cloud-agent",
     "/compact",
     "/compact-and",
     "/continue-locally",
     "/conversations",
+    "/copy-debugging-id",
     "/cost",
     "/create-environment",
     "/create-new-project",
@@ -967,6 +967,7 @@
     "/remote-control",
     "/rename-conversation",
     "/rename-tab",
+    "/reset-statusline",
     "/rewind",
     "/set-tab-color",
     "/skills",
@@ -975,6 +976,7 @@
     "/theme",
     "/usage",
     "/view-logs",
+    "/vim-mode",
     "/voice"
   ],
   "settings": {
@@ -1000,6 +1002,7 @@
     "agents.third_party.submit_on_ctrl_enter": "always_on",
     "agents.usage_display_mode": "always_on",
     "agents.voice.voice_input_enabled": "always_on",
+    "agents.voice.voice_input_hold_key": "always_on",
     "agents.voice.voice_input_language": "always_on",
     "agents.voice.voice_input_toggle_key": "always_on",
     "agents.warp_agent.active_ai.agent_mode_query_suggestions_enabled": "always_on",
@@ -1019,6 +1022,7 @@
     "agents.warp_agent.input.show_model_selectors_in_prompt": "always_on",
     "agents.warp_agent.is_any_ai_enabled": "always_on",
     "agents.warp_agent.other.agent_attribution_enabled": "always_on",
+    "agents.warp_agent.other.auto_approve_bypasses_command_denylist": "always_on",
     "agents.warp_agent.other.auto_handoff_on_sleep_enabled": "always_on",
     "agents.warp_agent.other.cloud_agent_computer_use_enabled": "always_on",
     "agents.warp_agent.other.default_prompt_submission_mode": "ga",
@@ -1266,6 +1270,7 @@
     "read_skill",
     "read_todos",
     "remove_todos",
+    "report_external_reference",
     "report_intent",
     "report_outcome",
     "report_pr",
@@ -1311,5 +1316,5 @@
     "verify-ui-change-in-cloud": "dogfood",
     "warpctrl": "bundled"
   },
-  "changelog_last_version": "2026.07.23"
+  "changelog_last_version": "2026.07.31"
 }

--- a/.agents/skills/missing_docs/scripts/audit_docs.py
+++ b/.agents/skills/missing_docs/scripts/audit_docs.py
@@ -939,10 +939,17 @@ def _normalize_path_params(path: str) -> str:
 
 
 def parse_openapi_paths(openapi_text: str) -> set[str]:
-    """Extract normalized path keys from the OpenAPI YAML text."""
+    """Extract normalized path keys from the OpenAPI YAML text.
+
+    Path keys containing `{param}` are usually emitted quoted (YAML treats a
+    leading `{` as a flow mapping), so both `  /agent/runs:` and
+    `  '/agent/runs/{runId}':` must be recognized. Missing the quoted form made
+    every parameterized endpoint look absent from the spec.
+    """
     paths = set()
-    for match in re.finditer(r"(?m)^\s{2}(/[^\s:]+):", openapi_text):
-        paths.add(_normalize_path_params(match.group(1)))
+    for match in re.finditer(r"""(?m)^\s{2}(?:'(/[^']+)'|"(/[^"]+)"|(/[^\s:'"]+)):""", openapi_text):
+        path = match.group(1) or match.group(2) or match.group(3)
+        paths.add(_normalize_path_params(path))
     return paths
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Companion bookkeeping PR for a `missing_docs` drift-watch run: an audit-script bug fix, the API surface-map entries, and the regenerated snapshot.

Both audits exited 0 with no skipped audits and `unaccounted: none`.

## Scope note: overlap with #430

This PR originally also mapped `GeminiEnterprise`, the three new TUI-only slash commands, and `agents.voice.voice_input_hold_key`. **#430 already covers all three**, so those hunks have been removed to avoid conflicting edits to the same regions of `feature_surface_map.md`. What's left here is disjoint from #430, so the two can merge in either order.

Consequence while both are open: running the audit on this branch alone still reports 1 feature, 4 slash command, and 2 setting findings. Those are #430's to close. The standing coverage audit keeps flagging them until it merges, so nothing is lost if this PR lands first.

One thing worth checking on #430: it maps `GeminiEnterprise -> bring-your-own-llm.mdx`, but #407 has since merged a dedicated `byollm-gemini-enterprise.mdx` page. That may be the better target now.

## Audit-script bug: quoted OpenAPI path keys

`parse_openapi_paths()` matched `^\s{2}(/[^\s:]+):`, which only recognizes unquoted YAML path keys. Any path containing a `{param}` is emitted quoted, because YAML reads a leading `{` as a flow mapping:

```yaml
  /agent/runs:                      # matched
  '/agent/runs/{runId}':            # NOT matched
```

Every parameterized endpoint therefore looked absent from the spec. The substring fallback didn't save it either, since it compares the handler's param name against the spec's (`{id}` vs `{scheduleId}`).

That produced **6 false-positive findings** in this run: `GET /agent/artifacts/{uid}` plus all five `/agent/schedules/{id}` operations. All six are, and were, in the released spec.

The regex now accepts single-quoted, double-quoted, and bare keys. Effect on the accounting: `api_routes` `spec_covered` went 9 → 22, and API findings went 15 → 2.

## Surface map: API endpoints

Mapped `internal` with rationale, each verified against `x-internal: true` in warp-server's `public_api/openapi.yaml`:

- `POST /agent/messages`, `GET /agent/messages/{run_id}`, `POST /agent/messages/{id}/read`, `POST /agent/messages/{id}/delivered`, `GET /agent/events`, `POST /agent/events/{run_id}` — marked internal upstream, so warp-server's publish filter strips them. They back the agent messaging tools and the documented `oz run message` CLI, but the REST surface itself isn't released.
- `GET /agent/events/stream` — absent from the canonical spec entirely and registered only on the RTC host.

## Snapshot

Regenerated with `--update-snapshot`. Diff mode reports 0 surface changes and 0 changelog items to verify.

## Deferred findings

Nothing from this run was silently dropped. What remains open, and why:

**2 API endpoints awaiting the release sync (medium)**
`GET /agent/artifacts/{artifactUid}/download` and `GET /agent/run-by-external-reference` are public upstream (no `x-internal` marker) but missing from `developers/agent-api-openapi.yaml`. They are deliberately **not** mapped `internal` — the finding should keep firing until the spec actually contains them. warp-server's release-gated `sync_public_openapi_to_docs` workflow is the authoritative publisher and will bring them in; #445 makes the docs-side fallback safe if it's needed sooner.

**32 terminology findings (low)**
Owned by the `style_lint` skill, which `missing_docs` explicitly defers to for pure wording issues. They cluster into four families: "warp ai", "ai credits", "agent-mode", and "warp terminal", spread across 32 files with several different owners. Fixing them here would produce a wide, low-signal diff; they belong in a dedicated `style_lint` sweep.

**1 new server-side agent tool (low)**
`report_external_reference` (changelog [#14072](https://github.com/warpdotdev/warp/pull/14072)) records an external resource such as a Linear issue as an `EXTERNAL_REFERENCE` artifact. Verified no docs change is needed: Warp doesn't document individual server-side agent tools — `report_pr`, `notify_user`, `finish_task`, and `wait_for_events` all have no public pages either. Tracked by the snapshot.

**11 changelog items verified as already covered or not doc-worthy**
Of 13 flagged items, 5 became sibling PRs (#438, #439, #440, #441, #442). The rest:
- *Agent execution profiles configurable from settings files* — `FileBackedExecutionProfiles` is an internal persistence-backend detail already on the ignore list; `agents.execution_profiles` is documented.
- *Computer-use recording overlay timing*, *MCP tool confirmation labels*, *Oz armadillo icon → Warp "W" logo*, *logout also signs out of Warp web*, *code-block file references open in your configured editor* — UI/behavior polish with no distinct doc surface.
- *Third-party harnesses report non-PR work products* — the `report_external_reference` item above.

_Conversation: https://staging.warp.dev/conversation/53c4f3f8-39bb-46c1-a5c0-66b467db0439_
_Run: https://oz.staging.warp.dev/runs/019fb91e-74a0-73f4-ac72-f2d88c32fab5_

_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
