### PR TITLE
fix: update llms.txt top-level description

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -163,7 +163,7 @@ export default defineConfig({
 				// extends it to llms-full.txt and custom sets as well.
 				exclude: ['support-and-community/community/open-source-licenses'],
 					description:
-						'Documentation for Warp, the agentic development environment, and Oz, Warp\'s programmable agent for running and coordinating agents at scale.',
+						'Documentation for Warp, the agentic development environment. Covers Warp Terminal, Warp Agents, and the Oz platform for cloud agents and orchestration at scale.',
 					customSets: [
 						{ label: 'Terminal', description: 'Warp Terminal features and configuration.', paths: ['terminal/**'] },
 						{ label: 'Agent Platform', description: 'Warp\'s Agent Platform: capabilities, local agents, and CLI agents.', paths: ['agent-platform/**'] },


### PR DESCRIPTION
## Summary

Updates the top-level description in the `starlight-llms-txt` config, which is rendered at the top of `docs.warp.dev/llms.txt`.

## Why

The previous wording — *"and Oz, Warp's programmable agent for running and coordinating agents at scale"* — framed Oz as the singular programmable agent in a way that conflated Oz with the broader agent concept. HYC flagged this as needing a fix separate from the slug rename (PR #420).

## Changes

- **`astro.config.mjs`**: Updated the `description` field in `starlightLlmsTxt()` to accurately position Oz as the platform for cloud agents and orchestration, and to name the three major documentation areas (Terminal, Agents, Oz platform).

**Before:**
> Documentation for Warp, the agentic development environment, and Oz, Warp's programmable agent for running and coordinating agents at scale.

**After:**
> Documentation for Warp, the agentic development environment. Covers Warp Terminal, Warp Agents, and the Oz platform for cloud agents and orchestration at scale.

## Notes

- All labels (`Oz Platform`, `Agent Platform`, `Oz Agent API`) are intentionally unchanged — a broader terminology update will follow the Aug 18 rename.
- This PR does not conflict with PR #420 (slug rename); they touch different lines in `astro.config.mjs`.

---

Co-Authored-By: Oz <oz-agent@warp.dev>
