### PR TITLE
docs: document the context window usage breakdown

### DIFF
--- a/src/content/docs/agents/local-agents/interacting-with-agents/index.mdx
+++ b/src/content/docs/agents/local-agents/interacting-with-agents/index.mdx
@@ -140,6 +140,21 @@ The context window usage indicator is available in agent conversation views.
 If you switch models during a conversation, the context usage indicator updates only after you send your next message.
 :::
 
+### Context window usage breakdown
+
+Expand the context window entry in the conversation's usage summary to see which parts of the request are consuming the window. Warp lists each segment with the share of the context window it accounts for, sorted from largest to smallest:
+
+* **System prompt** - Warp's base instructions for the agent, including your active [rules](/agents/capabilities/rules/) and profile configuration.
+* **Tool definitions** - The schemas for the tools available to the agent, including any [MCP servers](/agents/capabilities/mcp/) you've connected.
+* **Conversation history** - Previous prompts, responses, and tool results in the thread.
+* **Latest input** - Your most recent prompt and any context attached to it.
+* **Images** - Any [images you attached as context](/agents/local-agents/agent-context/images-as-context/).
+* **Other** - Remaining request context and temporary instructions Warp adds to help the agent respond.
+
+Segment percentages are shares of the full context window, so together they add up to the total usage the indicator shows. Segments that round to zero are omitted.
+
+Use the breakdown to decide how to reclaim space: a large **Tool definitions** share points at disconnecting unused MCP servers, while a large **Conversation history** share points at running `/compact` or [forking the conversation](/agents/local-agents/interacting-with-agents/conversation-forking/).
+
 ## Conversation segmentation
 
 Warp automatically detects when your query has shifted to a new topic. When this happens, it suggests starting a new conversation instead of continuing in the same context.


### PR DESCRIPTION
## What

Documents the per-segment context window breakdown under **Context window management** in
`agents/local-agents/interacting-with-agents/index.mdx`.

## Why

Found by the `missing_docs` drift-watch audit: `ContextWindowUsageBreakdown` was promoted
**dogfood → GA**, and the breakdown it adds to the usage summary was undocumented.

## Source of truth

- `app/src/ai/blocklist/usage/conversation_usage_view.rs` — `append_context_window_segment_rows`
  and `context_window_segment_display_rows` (percentages are shares of total context window usage;
  rows sort descending with `Other` last; zero rows are dropped), plus the `Other` tooltip copy.
- `crates/persistence/src/model.rs` — the `ContextWindowSegmentType` variants that produce the
  segment labels.

## Deferred findings from this run

Nothing from the audit was silently dropped. The full deferral list lives in the companion
bookkeeping PR (`docs/missing-docs-audit-bookkeeping`); in summary:

- **15 warp-server public API routes missing from the OpenAPI spec** — routed to the
  `sync-openapi-spec` skill rather than hand-written, per the skill's public/private guardrail.
- **32 terminology/staleness findings** — owned by the `style_lint` skill.
- **1 new server-side agent tool (`report_external_reference`)** — reached only through the hidden
  `oz harness-support` CLI, so no public surface to document yet.

---

_Conversation: https://staging.warp.dev/conversation/c45bb2ea-d33b-4723-8249-478547f81a47_
_Run: https://oz.staging.warp.dev/runs/019fc891-7c04-779b-b006-328169d8a0d7_

_This PR was generated with [Oz](https://warp.dev/oz)._
