### PR TITLE
docs: document Vim indent and dedent operators in the code editor

### DIFF
--- a/src/content/docs/code/code-editor/code-editor-vim-keybindings.mdx
+++ b/src/content/docs/code/code-editor/code-editor-vim-keybindings.mdx
@@ -78,6 +78,8 @@ See [Vim docs: motion](https://vimdoc.sourceforge.net/htmldoc/motion.html) for m
 | `J`        | join current and following lines                            |
 | `.`        | repeat last edit                                            |
 | `gcc`      | toggle comments on current line                             |
+| `>`, `<`   | indent or dedent a range or object (for example, `>j`, `>ap`) |
+| `>>`, `<<` | indent or dedent the current line                           |
 | `gc`       | toggle comments on visual selection                         |
 
 See [Vim docs: editing](https://vimdoc.sourceforge.net/htmldoc/editing.html) for more information.


### PR DESCRIPTION
## What

Adds `>` / `<` and `>>` / `<<` rows to the editing keybindings table in
`code/code-editor/code-editor-vim-keybindings.mdx`.

## Why

Flagged by the `missing_docs` changelog cross-check (2026.07.31: "Added Vim `<` and `>` indent and
dedent operators to the code editor"). The keybindings table is the page readers scan to see what
is supported, and it did not list them.

## Source of truth

- `crates/vim/src/vim.rs` — `VimOperator::Indent` / `Dedent`, the `>` and `<` key mapping, and the
  doubled `>>` / `<<` line forms.
- `app/src/code/editor/view/vim_handler.rs` — the operator implementation in the code editor.

## Deferred findings from this run

Nothing from the audit was silently dropped. The full deferral list lives in the companion
bookkeeping PR (`docs/missing-docs-audit-bookkeeping`); in summary:

- **15 warp-server public API routes missing from the OpenAPI spec** — routed to the
  `sync-openapi-spec` skill rather than hand-written, per the skill's public/private guardrail.
- **32 terminology/staleness findings** — owned by the `style_lint` skill.
- **1 new server-side agent tool (`report_external_reference`)** — reached only through the hidden
  `oz harness-support` CLI, so no public surface to document yet.

---

_Conversation: https://staging.warp.dev/conversation/c45bb2ea-d33b-4723-8249-478547f81a47_
_Run: https://oz.staging.warp.dev/runs/019fc891-7c04-779b-b006-328169d8a0d7_

_This PR was generated with [Oz](https://warp.dev/oz)._
