### PR TITLE
docs: update stale Settings > Agents > Oz menu paths

### DIFF
--- a/src/content/docs/agents/capabilities/agent-profiles-permissions.mdx
+++ b/src/content/docs/agents/capabilities/agent-profiles-permissions.mdx
@@ -143,7 +143,7 @@ During an Agent interaction, you can give the Agent full autonomy for the curren
 :::caution
 _Run until completion_ is the purest form of “YOLO” mode: the Agent proceeds without asking for confirmation, and by default it also runs commands that match your command denylist.
 
-To keep your denylist in force during _Run until completion_, turn off **Allow auto-approve to bypass command denylist** in **Settings** > **Agents** > **Oz** > **Input**. Denylist rules your team enforces through the [Admin Panel](/enterprise/team-management/admin-panel/) always require approval and are never bypassed.
+To keep your denylist in force during _Run until completion_, turn off **Allow auto-approve to bypass command denylist** in **Settings** > **Agents** > **Warp Agent** > **Input**. Denylist rules your team enforces through the [Admin Panel](/enterprise/team-management/admin-panel/) always require approval and are never bypassed.
 :::
 
 ---

--- a/src/content/docs/agents/inference/bring-your-own-api-key.mdx
+++ b/src/content/docs/agents/inference/bring-your-own-api-key.mdx
@@ -14,7 +14,7 @@ BYOK provides greater flexibility in model access and ensures Warp **never consu
 
 <VideoEmbed url="https://youtu.be/jbSBnbPzQwY" title="How to BYOK to the Warp Agent" />
 
-For xAI's Grok models, you can also connect your SuperGrok subscription instead of entering an API key. In the Warp app, go to **Settings** > **Agents** > **Oz** and choose to connect your SuperGrok subscription — Warp opens your browser to complete the connection.
+For xAI's Grok models, you can also connect your SuperGrok subscription instead of entering an API key. In the Warp app, go to **Settings** > **Agents** > **Warp Agent** and choose to connect your SuperGrok subscription — Warp opens your browser to complete the connection.
 
 :::note
 BYOK is available on Free and all eligible paid plans for individual users and organizations with 10 or fewer employees, subject to Warp's [Terms of Service](https://www.warp.dev/legal/terms-of-service). Larger organizations need a Business or Enterprise plan. See [Warp pricing](https://www.warp.dev/pricing) for current availability.

--- a/src/content/docs/agents/inference/model-choice.mdx
+++ b/src/content/docs/agents/inference/model-choice.mdx
@@ -160,7 +160,7 @@ To change models, click the displayed model name (for example, _Claude Sonnet 5_
 
 Beyond the built-in Auto models, you can define your own custom routers that automatically route each task to a concrete model based on task complexity or rules you write. Custom routers appear in the model picker alongside Auto and individual models.
 
-Add and manage custom routers in **Settings** > **Agents** > **Oz** > **Custom Routers**. See [Custom routers](/agents/inference/custom-routers/) for details on creating one.
+Add and manage custom routers in **Settings** > **Agents** > **Warp Agent** > **Custom Routers**. See [Custom routers](/agents/inference/custom-routers/) for details on creating one.
 
 ### Model fallback
 

--- a/src/content/docs/guides/getting-started/how-to-customize-warps-appearance.mdx
+++ b/src/content/docs/guides/getting-started/how-to-customize-warps-appearance.mdx
@@ -44,7 +44,7 @@ Warp’s **input bar** can live in three different positions:
 
 ### 3. Managing AI & agent settings
 
-Open **Settings** > **Agents** > **Oz** to control:
+Open **Settings** > **Agents** > **Warp Agent** to control:
 
 * Which **model** Warp uses (e.g., Claude 3.5 for code generation, GPT-4o for planning).
 * How much **autonomy** agents have for:

--- a/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/pricing-faqs.mdx
@@ -279,7 +279,7 @@ Regardless of plan, Warp never allows OpenAI, Anthropic, Google, or other model 
 
 ### Can I bring my own API key?
 
-Yes. On Free, Build, Max, Business, and Enterprise plans, you can configure your own OpenAI, Anthropic, or Google API key in **Settings** > **Agents** > **Oz** > **Manage models**. Requests routed through your own key don't consume Warp credits — you're billed directly by the model provider.
+Yes. On Free, Build, Max, Business, and Enterprise plans, you can configure your own OpenAI, Anthropic, or Google API key in **Settings** > **Agents** > **Warp Agent** > **Manage models**. Requests routed through your own key don't consume Warp credits — you're billed directly by the model provider.
 
 See [Bring Your Own API Key](/agents/inference/bring-your-own-api-key/) for setup steps, the list of supported providers and models, and the differences between BYOK, custom inference endpoints, and BYOLLM.
 
@@ -398,7 +398,7 @@ Unused add-on credits remain valid for 12 months from purchase, as long as you h
 
 #### Can I bring my own API key on the Free plan now?
 
-Yes. As of May 21, 2026, **Bring Your Own API Key (BYOK)** is available on all plans, including Free. Previously, BYOK required a Build, Business, or Enterprise subscription. You can configure your OpenAI, Anthropic, or Google key under **Settings** > **Agents** > **Oz** > **Manage models**.
+Yes. As of May 21, 2026, **Bring Your Own API Key (BYOK)** is available on all plans, including Free. Previously, BYOK required a Build, Business, or Enterprise subscription. You can configure your OpenAI, Anthropic, or Google key under **Settings** > **Agents** > **Warp Agent** > **Manage models**.
 
 See [Bring Your Own API Key](/agents/inference/bring-your-own-api-key/) for the full list of supported providers and setup steps.
 

--- a/src/content/docs/terminal/input/universal-input.mdx
+++ b/src/content/docs/terminal/input/universal-input.mdx
@@ -90,7 +90,7 @@ The model Warp uses to detect natural language automatically is completely local
 
 By default, auto-detection is enabled. This means Warp decides whether to treat your input as a command or an Agent prompt.
 
-* **To turn off auto-detection**: go to **Settings** > **Agents** > **Oz** > **Input** > **Natural Language Detection**
+* **To turn off auto-detection**: go to **Settings** > **Agents** > **Warp Agent** > **Input** > **Natural Language Detection**
 * When disabled: You’ll explicitly be in either Terminal or Agent Mode. Use the following keyboard shortcuts to switch between modes:
   * `CMD+I` (macOS)
   * `CTRL+I` (Windows/Linux)
@@ -195,11 +195,11 @@ Warp can automatically detect when you’re writing in plain English and switch 
 
 #### Fixing false detections
 
-If certain shell commands are mistakenly detected as natural language, you can add them to the denylist: **Settings** > **Agents** > **Oz** > **Input** > **Natural language denylist**
+If certain shell commands are mistakenly detected as natural language, you can add them to the denylist: **Settings** > **Agents** > **Warp Agent** > **Input** > **Natural language denylist**
 
 #### Turning off auto-detection
 
-To disable natural language detection entirely, go to: **Settings** > **Agents** > **Oz** > **Input Auto-detection**
+To disable natural language detection entirely, go to: **Settings** > **Agents** > **Warp Agent** > **Input Auto-detection**
 
 When auto-detection is turned off, you’ll need to explicitly switch between Terminal Mode and Agent Mode using `CMD + I` (macOS) or `CTRL + I` (Windows/Linux).
 


### PR DESCRIPTION
## What

Updates nine references across six pages from **Settings** > **Agents** > **Oz** to
**Settings** > **Agents** > **Warp Agent**.

## Why

`SettingsSection::WarpAgent` renders as "Warp Agent"; `"Oz"` is only accepted as a legacy alias for
backward compatibility (`app/src/settings_view/mod.rs`). Roughly 30 other doc pages already use
"Warp Agent", so these were the stragglers and the docs were internally inconsistent.

Menu-path validation is normally owned by the `validate_ui_refs` skill. These were corrected here
because the `missing_docs` run had already verified the current label against the client source
while researching the `auto_approve_bypasses_command_denylist` setting.

## Source of truth

`app/src/settings_view/mod.rs` — `SettingsSection::WarpAgent => write!(f, "Warp Agent")`, with
`"Oz" | "Warp Agent"` both parsed for backward compatibility.

## Overlap with #452

#452 (documentation quality sweep) makes some of the same terminology corrections, but all of its
files are under the old `agent-platform/` tree that #420 renamed to `agents/`, so it needs a rebase
before it can merge. This PR is narrowly scoped to the menu-path label and targets current paths. If
#452 is rebased first, close this one.

---

_Conversation: https://staging.warp.dev/conversation/c45bb2ea-d33b-4723-8249-478547f81a47_
_Run: https://oz.staging.warp.dev/runs/019fc891-7c04-779b-b006-328169d8a0d7_

_This PR was generated with [Oz](https://warp.dev/oz)._
