### PR TITLE
docs: fix stale Docs Agent environment reference in weekly-404-monitor

### DIFF
--- a/.agents/skills/weekly-404-monitor/SKILL.md
+++ b/.agents/skills/weekly-404-monitor/SKILL.md
@@ -236,17 +236,23 @@ Check: Vercel project env vars include `PUBLIC_RUDDERSTACK_WRITE_KEY` and `PUBLI
 
 This skill is designed for an Oz scheduled agent with a weekly cron trigger: every Monday at 9am PT (`0 17 * * 1` in UTC).
 
+The live schedule (`Weekly docs 404 monitor`, schedule ID `xAqd8EBlaJ3EihLlfF3fOs`) runs in the **buzz** Oz environment (`qDewDp082oqhaq7ZJd6LJI`) — not the `Docs Agent` environment (`K5KStCm5aYvhfBJb8cHol6`) referenced by other docs automations (e.g. `validate_ui_refs`, `release_updates`). Point secret checks and schedule registration at the `buzz` environment for this skill.
+
 To deploy (one-time setup):
 1. Push this skill to `main` in the docs repo.
-2. Verify the **Docs Agent** Oz environment (`K5KStCm5aYvhfBJb8cHol6`) has these secrets set:
-   - `METABASE_API_KEY` — Metabase API key for BigQuery
-   - `BUZZ_SLACK_TOKEN` — Slack bot token (already provisioned; used by other doc agents in this environment)
+2. Verify the **buzz** Oz environment (`qDewDp082oqhaq7ZJd6LJI`) has:
+   - `warpdotdev/docs` in its configured repos, so `/home/user/warpdotdev/docs` exists at run start (confirmed present as of 2026-08-03).
+   - These secrets set (both are Team-scoped and already provisioned):
+     - `METABASE_API_KEY` — Metabase API key for BigQuery
+     - `BUZZ_SLACK_TOKEN` — Slack bot token (used by other doc agents in this environment)
 3. Register the schedule via the Oz CLI:
    ```sh
    oz-dev schedule create \
      --name "weekly-404-monitor" \
      --cron "0 17 * * 1" \
-     --environment K5KStCm5aYvhfBJb8cHol6 \
+     --environment qDewDp082oqhaq7ZJd6LJI \
      --prompt "You are running in the warpdotdev/docs repo. Read and follow the instructions in .agents/skills/weekly-404-monitor/SKILL.md."
    ```
    This will make the schedule visible in oz.warp.dev under Schedules and ensure runs open PRs under the @oz-by-warp bot account.
+
+**2026-08-03 incident note**: An earlier run this week failed with "METABASE_API_KEY is not set" while pointing at the nonexistent `K5KStCm5aYvhfBJb8cHol6` environment referenced by this section (that ID is not visible/resolvable from the Oz account operating this schedule). The live schedule already runs against `qDewDp082oqhaq7ZJd6LJI` (`buzz`), which has both secrets and now has the `docs` repo checked out. This section was corrected to match; see `.agents/logs/weekly_404_monitor_runs.md` for the run history.


### PR DESCRIPTION
## Problem

The `#growth-docs` Slack channel received a failure alert this week:

> ⚠️ docs.warp.dev 404 Report — week of 2026-08-03
> Failed: METABASE_API_KEY is not set in this Oz environment.
> Fix: add METABASE_API_KEY to the Docs Agent Oz environment secrets, then re-run.
> Environment expected: K5KStCm5aYvhfBJb8cHol6 (Docs Agent).

## Investigation

- The `weekly-404-monitor` SKILL.md's `## Scheduling` section instructed operators to verify secrets on the **Docs Agent** Oz environment (`K5KStCm5aYvhfBJb8cHol6`) and to register the schedule against that environment.
- The actual live schedule (`Weekly docs 404 monitor`, schedule ID `xAqd8EBlaJ3EihLlfF3fOs`) is registered against a **different** environment: `qDewDp082oqhaq7ZJd6LJI` ("buzz").
- `K5KStCm5aYvhfBJb8cHol6` is not visible/resolvable via `oz-dev environment get`/`list` from the Oz account operating this schedule, so anyone following the doc to "verify secrets" on that environment for this schedule would be looking in the wrong (inaccessible) place.
- The `buzz` environment (`qDewDp082oqhaq7ZJd6LJI`) already has `METABASE_API_KEY` and `BUZZ_SLACK_TOKEN` provisioned as Team-scoped secrets — confirmed by a successful run today that posted a full report with real data (323 total 404s this week, down from 458) to `#growth-docs`.
- Separately, the `buzz` environment did **not** have `warpdotdev/docs` in its configured repos, even though the skill's prompt assumes `/home/user/warpdotdev/docs` is already checked out. Fixed via `oz-dev environment update qDewDp082oqhaq7ZJd6LJI --repo warpdotdev/docs`.

Note: other docs automations (`validate_ui_refs`, `release_updates` / `release-docs-update.yml`, `refresh-ui-paths.yml`) still reference `K5KStCm5aYvhfBJb8cHol6` and appear to dispatch successfully via a separate GitHub Actions `WARP_API_KEY`/service-account scope, so that environment likely exists under a different account scope than the one running this schedule. This PR only corrects the `weekly-404-monitor` skill's docs to match its actual, working configuration — it does not touch the other workflows.

## Changes

- Updated `.agents/skills/weekly-404-monitor/SKILL.md` `## Scheduling` section to reference the correct, live environment (`qDewDp082oqhaq7ZJd6LJI` / "buzz") instead of the inaccessible `K5KStCm5aYvhfBJb8cHol6`.
- Added an incident note documenting the 2026-08-03 failure and resolution.

## Already applied (not part of this diff)

- Added `warpdotdev/docs` to the `buzz` Oz environment's repo list via `oz-dev environment update`.
- This week's 404 report already ran successfully and posted to `#growth-docs`.

_Conversation: https://staging.warp.dev/conversation/1703d43c-d6c3-46bc-adf9-d0531cc582ac_
_Run: https://oz.staging.warp.dev/runs/019fc891-7eb9-7b39-a1ed-ed7a50b7f6d3_

_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
