### PR TITLE
docs: fix broken external links found in link audit

### DIFF
--- a/src/content/docs/knowledge-and-collaboration/warp-drive/environment-variables.mdx
+++ b/src/content/docs/knowledge-and-collaboration/warp-drive/environment-variables.mdx
@@ -80,8 +80,6 @@ The CLI will require you to authenticate and then provide you with a list of ava
 Selecting a secret name never stores the actual secret. Warp uses your selection to generate a command that dynamically pulls in your selected secret at runtime.
 :::
 
-![Selecting a secret name from the password manager CLI's available list of secrets.](https://lh7-rt.googleusercontent.com/docsz/AD_4nXcqiazhpRvaHxxSW5n3Ql6nFRDDRkyVdlRB9E-Q6HE0lpL2KFgwLM1P1PPrJG_i0KIHWuEKp2PMFq4T1auWvQOxXrpuERpLRZG1h2V4DDYmNRZRqShxjPzWyqGR2VfXYNhttAK0HT2-aQNjAt3xdCA9MwE?key=q_xMyXgvJVA02ysqZAH4Jw)
-
 ### How to write a custom secret command
 
 Reference the documentation for your external secret manager. Then, write a custom command to retrieve secrets.
@@ -95,8 +93,6 @@ For example, you can write a command using the [Hashicorp Vault CLI](https://dev
 ```
 // vault kv get -field=password secret/staging/app/server/creds
 ```
-
-![Custom command using the Hashicorp Vault CLI to retrieve a password field at runtime.](https://lh7-rt.googleusercontent.com/docsz/AD_4nXcltckpSwesjA1O84nzZhUKc0Wuie0OH3iN6g0WPBojhtY5pckPSZgOZxqIjiV12ppe9t0jtF9z2Yf7d-fIZJhSu8-tLIT8CoG_Xh_NvCzFbrJgD5FA2ounNtHurq9nDLALiOekjPeVoru-FzeYOWkfm9PN?key=q_xMyXgvJVA02ysqZAH4Jw)
 
 ### Using environment variables
 
@@ -124,10 +120,6 @@ To load environment variables into a subshell, you will need to open [Warp Drive
 
 Loading an environment into a subshell reduces the risk of your environment variables accidentally contaminating your workspace. The subshell is clearly defined and once you exit it, any environment variables set by Warp Environment Variables will be cleared, unless they are already present in the parent session.
 
-![Selecting Load in subshell from an environment variable's overflow menu in Warp Drive.](https://lh7-rt.googleusercontent.com/docsz/AD_4nXeqhj2saz5AJTYUCx-PClwCLX421mKEzXelcnnkeHkqvDexelvBDmPpESHOmV_SjAOEuLKk8YgYaIodX-cOuXm1Nm05wUU88zcIv3otd1HRvXO455EiKEfs5tTB5ft9OoW7qxMK9BV1OPAVIc9AhMqsgweK?key=q_xMyXgvJVA02ysqZAH4Jw)
-
-![Environment variables loaded into a subshell, isolated from the parent terminal session.](https://lh7-rt.googleusercontent.com/docsz/AD_4nXeeXyJEMxJV2DpOBJS7pKOEpBSm6aypAIKd4ygJKT13opDBxeS5k0S5NtM8Cr_Z_lafyj-cn1T-hJ-93AkZhpWTrbvYHYIRs96_V7dr3mfiM3lPx6-kMS_eLjINPHIr6Ex0NaMr-TRCkNQ1fdVv8cApJ0QJ?key=q_xMyXgvJVA02ysqZAH4Jw)
-
 #### Select to load with a workflow
 
 Any time you run a workflow, you can select from existing environment variables. This allows you to dynamically inject environment variables into a parameterized workflow so you can use a single workflow command in multiple environments, such as production and staging.
@@ -135,8 +127,6 @@ Any time you run a workflow, you can select from existing environment variables.
 For example, you may have a workflow to create a new team that uses the environment variable $SERVER\_URL. By using the environment variables dropdown in the workflow card, you can dynamically inject the necessary variables. This ensures the workflow references the appropriate values so the command runs with the relevant environment-specific information.
 
 These environment variables will now be present for the remainder of your session until you clear them or overwrite them with a different environment.
-
-![Selecting environment variables from the dropdown when running a parameterized workflow.](https://lh7-rt.googleusercontent.com/docsz/AD_4nXcuOxH8UeVLSvWRpZwvdoVBgbpFhb2rXKbDw2CnZ5BQCTWSgzjwERe-fzKLEYBQZGKzjV-Pdd_z6tB9BTSWYos9ADRaDbChskSg-MZpjaKme0kG8UwWsJ2HBJk7iBu4SKbGZCobZy0uD2nFkrNoVjNZEEOW?key=q_xMyXgvJVA02ysqZAH4Jw)
 
 ### Import and export environment variables in Warp Drive
 

--- a/src/content/docs/reference/api-and-sdk/troubleshooting/errors/external-authentication-required.mdx
+++ b/src/content/docs/reference/api-and-sdk/troubleshooting/errors/external-authentication-required.mdx
@@ -66,7 +66,7 @@ This error includes extra fields beyond the standard response format:
   "error": "User does not have access to the following repositories in the environment: acme/backend (inaccessible repos: acme/backend)",
   "retryable": false,
   "provider": "github",
-  "auth_url": "https://github.com/apps/warp-dev/installations/new",
+  "auth_url": "https://github.com/apps/oz-by-warp/installations/new",
   "inaccessible_repos": ["acme/backend"]
 }
 ```


### PR DESCRIPTION
## Summary
Ran a full broken-link audit of the docs (363 content files). Internal links are clean; this PR fixes the two genuine external-link problems found.

**Audit results:**
- **Internal links: 2,852 root-relative links checked, 0 broken.** Every `/path/` link resolves to a page in `src/content/docs` or a `vercel.json` redirect.
- **External links: 1,355 unique URLs checked, 56 non-2xx responses.** 54 of those are expected: documented placeholders (`https://your-mcp-host.com/...`, `$TOKEN@...`, `https://{server}`), auth-gated MCP endpoints (`mcp.linear.app`, `mcp.sentry.dev`, `mcp.notion.com`, `api.githubcopilot.com`), package-repository roots inside code blocks (`releases.warp.dev/linux/deb`), the private `warpdotdev/warp-internal` example, GitHub rate limiting (HTTP 429 — all verified 200 individually), and hosts that block datacenter IPs (`vimdoc.sourceforge.net`, `zsh.sourceforge.io`, `superuser.com`, `help.openai.com`, `platform.openai.com`).

## Fixes
### Dead hotlinked screenshots (5 images)
`src/content/docs/knowledge-and-collaboration/warp-drive/environment-variables.mdx` embedded five screenshots hotlinked from `lh7-rt.googleusercontent.com`. Those URLs return HTTP 403 for every reader (verified with a browser user agent), so the images render broken on the published page. No local copies exist in `src/assets/`, and the legacy GitBook source has the same hotlinks rather than committed files, so the embeds are removed. The surrounding prose already describes each step.

Screenshots that would be worth re-capturing and committing under `src/assets/terminal/`:
- Selecting a secret name from a password manager CLI's list of secrets
- A custom Hashicorp Vault CLI command retrieving a password field
- Selecting **Load in subshell** from an environment variable's overflow menu
- Environment variables loaded into a subshell
- Selecting environment variables from the dropdown when running a parameterized workflow

### Stale GitHub App URL
The example error payload in `reference/api-and-sdk/troubleshooting/errors/external-authentication-required.mdx` used `https://github.com/apps/warp-dev/installations/new`, which returns HTTP 404. Everywhere else the docs reference the **Oz by Warp** app, and `https://github.com/apps/oz-by-warp/installations/new` returns 200, so the sample `auth_url` now uses that slug.

> Note for reviewers: if the API genuinely returns `apps/warp-dev` in this payload today, that's a server-side bug worth fixing rather than a docs change — please confirm the value the API emits.

## Note on the legacy GitBook repo
The audit was originally requested against `warpdotdev/gitbook`, which is archived and read-only. That repo has 25 broken external links (stale `LICENSE` links, `docs.warp.dev/warp/...` prefixes, and `agent-platform/cli-agents/...` paths), but since it is archived and no longer publishes `docs.warp.dev`, no PR can be opened there and the content is superseded by this repo. The equivalent problems either don't exist here or are already fixed (this repo already links to `LICENSE-AGPL`).

_Conversation: https://app.warp.dev/conversation/ec9d220b-ee95-4e4b-b425-70a102528fa5_
_Run: https://oz.warp.dev/runs/019fcdb7-df08-745e-b6c5-47af87592cbc_

_This PR was generated with [Oz](https://warp.dev/oz)._
