### PR TITLE
docs: stop validate_ui_refs flagging JSX props and code fences as Command Palette commands

### DIFF
--- a/.agents/skills/validate_ui_refs/valid_paths.json
+++ b/.agents/skills/validate_ui_refs/valid_paths.json
@@ -338,6 +338,550 @@
   },
   "command_palette_commands": [
     {
+      "name": "root_view:toggle_fullscreen",
+      "description": "Toggle fullscreen"
+    },
+    {
+      "name": "ai_assistant_panel:focus_terminal_input",
+      "description": "Focus Terminal Input From Warp AI"
+    },
+    {
+      "name": "ai_assistant_panel:reset_context",
+      "description": "Restart Warp AI"
+    },
+    {
+      "name": "code_view:save_as",
+      "description": "Save file as"
+    },
+    {
+      "name": "code_view:close_all_tabs",
+      "description": "Close all tabs"
+    },
+    {
+      "name": "code_view:close_saved_tabs",
+      "description": "Close saved tabs"
+    },
+    {
+      "name": "find:find_next_occurrence",
+      "description": "Find the next occurrence of your search query"
+    },
+    {
+      "name": "find:find_prev_occurrence",
+      "description": "Find the previous occurrence of your search query"
+    },
+    {
+      "name": "editor_view:move_backward_one_word",
+      "description": "Move Backward One Word"
+    },
+    {
+      "name": "editor_view:move_forward_one_word",
+      "description": "Move Forward One Word"
+    },
+    {
+      "name": "editor_view:move_forward_one_word",
+      "description": "Move forward one word"
+    },
+    {
+      "name": "editor_view:move_backward_one_word",
+      "description": "Move backward one word"
+    },
+    {
+      "name": "editor_view:up",
+      "description": "Move cursor up"
+    },
+    {
+      "name": "editor_view:down",
+      "description": "Move cursor down"
+    },
+    {
+      "name": "editor_view:left",
+      "description": "Move cursor left"
+    },
+    {
+      "name": "editor_view:right",
+      "description": "Move cursor right"
+    },
+    {
+      "name": "editor_view:move_to_line_start",
+      "description": "Move to line start"
+    },
+    {
+      "name": "editor_view:home",
+      "description": "Home"
+    },
+    {
+      "name": "editor_view:move_to_line_end",
+      "description": "Move to line end"
+    },
+    {
+      "name": "editor_view:end",
+      "description": "End"
+    },
+    {
+      "name": "editor_view:cursor_at_buffer_start",
+      "description": "Cursor at buffer start"
+    },
+    {
+      "name": "editor_view:cursor_at_buffer_end",
+      "description": "Cursor at buffer end"
+    },
+    {
+      "name": "editor_view:select_left_by_word",
+      "description": "Select one word to the left"
+    },
+    {
+      "name": "editor_view:select_right_by_word",
+      "description": "Select one word to the right"
+    },
+    {
+      "name": "editor_view:select_left",
+      "description": "Select one character to the left"
+    },
+    {
+      "name": "editor_view:select_right",
+      "description": "Select one character to the right"
+    },
+    {
+      "name": "editor_view:select_up",
+      "description": "Select up"
+    },
+    {
+      "name": "editor_view:select_down",
+      "description": "Select down"
+    },
+    {
+      "name": "editor_view:select_all",
+      "description": "Select all"
+    },
+    {
+      "name": "editor:select_to_line_start",
+      "description": "Select to start of line"
+    },
+    {
+      "name": "editor:select_to_line_end",
+      "description": "Select to end of line"
+    },
+    {
+      "name": "editor_view:select_to_line_end",
+      "description": "Select To Line End"
+    },
+    {
+      "name": "editor_view:select_to_line_start",
+      "description": "Select To Line Start"
+    },
+    {
+      "name": "editor_view:backspace",
+      "description": "Remove the previous character"
+    },
+    {
+      "name": "editor_view:toggle_comment",
+      "description": "Toggle comment"
+    },
+    {
+      "name": "editor_view:delete",
+      "description": "Delete"
+    },
+    {
+      "name": "editor_view:vim_scroll_half_page_down",
+      "description": "Scroll down half a page (vim)"
+    },
+    {
+      "name": "editor_view:vim_scroll_half_page_up",
+      "description": "Scroll up half a page (vim)"
+    },
+    {
+      "name": "editor_view:cut_word_left",
+      "description": "Cut word left"
+    },
+    {
+      "name": "editor:delete_word_left",
+      "description": "Delete word left"
+    },
+    {
+      "name": "editor_view:cut_word_right",
+      "description": "Cut word right"
+    },
+    {
+      "name": "editor:delete_word_right",
+      "description": "Delete word right"
+    },
+    {
+      "name": "editor_view:cut_all_left",
+      "description": "Cut all left"
+    },
+    {
+      "name": "editor_view:delete_all_left",
+      "description": "Delete all left"
+    },
+    {
+      "name": "editor_view:cut_all_right",
+      "description": "Cut all right"
+    },
+    {
+      "name": "editor_view:delete_all_right",
+      "description": "Delete all right"
+    },
+    {
+      "name": "editor_view:vim_exit_insert_mode",
+      "description": "Exit Vim insert mode"
+    },
+    {
+      "name": "code_editor:find",
+      "description": "Find in code editor"
+    },
+    {
+      "name": "editor_view:go_to_line",
+      "description": "Go to line"
+    },
+    {
+      "name": "code_review:save_all_unsaved_files",
+      "description": "Save all unsaved files in code review"
+    },
+    {
+      "name": "code_review:show_find_bar",
+      "description": "Show find bar in code review"
+    },
+    {
+      "name": "code_review:toggle_file_navigation",
+      "description": "Toggle file navigation in code review"
+    },
+    {
+      "name": "project_buttons:open_repository",
+      "description": "Open repository"
+    },
+    {
+      "name": "project_buttons:create_new_project",
+      "description": "Create new project"
+    },
+    {
+      "name": "editor_view:clear_and_copy_lines",
+      "description": "Copy and clear selected lines"
+    },
+    {
+      "name": "editor_view:add_next_occurrence",
+      "description": "Add selection for next occurrence"
+    },
+    {
+      "name": "editor_view:move_to_line_start",
+      "description": "Move to start of line"
+    },
+    {
+      "name": "editor_view:move_to_line_end",
+      "description": "Move to end of line"
+    },
+    {
+      "name": "editor_view:cmd_down",
+      "description": "Move cursor to the bottom"
+    },
+    {
+      "name": "editor_view:cmd_up",
+      "description": "Move cursor to the top"
+    },
+    {
+      "name": "editor_view:move_to_and_select_buffer_start",
+      "description": "Select and move to the top"
+    },
+    {
+      "name": "editor_view:move_to_and_select_buffer_end",
+      "description": "Select and move to the bottom"
+    },
+    {
+      "name": "editor_view:move_to_paragraph_start",
+      "description": "Move to the start of the paragraph"
+    },
+    {
+      "name": "editor_view:move_to_paragraph_end",
+      "description": "Move to the end of the paragraph"
+    },
+    {
+      "name": "editor_view:move_to_buffer_start",
+      "description": "Move to the start of the buffer"
+    },
+    {
+      "name": "editor_view:move_to_buffer_end",
+      "description": "Move to the end of the buffer"
+    },
+    {
+      "name": "editor_view:clear_lines",
+      "description": "Clear selected lines"
+    },
+    {
+      "name": "editor_view:insert_newline",
+      "description": "Insert newline"
+    },
+    {
+      "name": "editor_view:fold",
+      "description": "Fold"
+    },
+    {
+      "name": "editor_view:unfold",
+      "description": "Unfold"
+    },
+    {
+      "name": "editor_view:fold_selected_ranges",
+      "description": "Fold selected ranges"
+    },
+    {
+      "name": "editor:insert_last_word_previous_command",
+      "description": "Insert last word of previous command"
+    },
+    {
+      "name": "editor_view:move_backward_one_subword",
+      "description": "Move Backward One Subword"
+    },
+    {
+      "name": "editor_view:move_forward_one_subword",
+      "description": "Move Forward One Subword"
+    },
+    {
+      "name": "editor_view:select_left_by_subword",
+      "description": "Select one subword to the left"
+    },
+    {
+      "name": "editor_view:select_right_by_subword",
+      "description": "Select one subword to the right"
+    },
+    {
+      "name": "editor_view:inspect_command",
+      "description": "Inspect Command"
+    },
+    {
+      "name": "editor_view:clear_buffer",
+      "description": "Clear command editor"
+    },
+    {
+      "name": "editor_view:add_cursor_above",
+      "description": "Add cursor above"
+    },
+    {
+      "name": "editor_view:add_cursor_below",
+      "description": "Add cursor below"
+    },
+    {
+      "name": "editor_view:insert_nonexpanding_space",
+      "description": "Insert non-expanding space"
+    },
+    {
+      "name": "Close Env Var Collection",
+      "description": "Close"
+    },
+    {
+      "name": "notebookview:increase_font_size",
+      "description": "Increase notebook font size"
+    },
+    {
+      "name": "notebookview:decrease_font_size",
+      "description": "Decrease notebook font size"
+    },
+    {
+      "name": "notebookview:reset_font_size",
+      "description": "Reset notebook font size"
+    },
+    {
+      "name": "notebookview:focus_terminal_input",
+      "description": "Focus Terminal Input from Notebook"
+    },
+    {
+      "name": "editor_view:deselect_command",
+      "description": "De-select shell commands"
+    },
+    {
+      "name": "editor_view:select_command",
+      "description": "Select shell command at cursor"
+    },
+    {
+      "name": "editor_view:select_previous_command",
+      "description": "Select previous command"
+    },
+    {
+      "name": "editor_view:select_next_command",
+      "description": "Select next command"
+    },
+    {
+      "name": "editor_view:run_commands",
+      "description": "Run selected commands"
+    },
+    {
+      "name": "editor_view:toggle_debug_mode",
+      "description": "Toggle rich-text debug mode"
+    },
+    {
+      "name": "editor_view:debug_copy_buffer",
+      "description": "Copy rich-text buffer"
+    },
+    {
+      "name": "editor_view:debug_copy_selection",
+      "description": "Copy rich-text selection"
+    },
+    {
+      "name": "editor_view:log_state",
+      "description": "Log editor state"
+    },
+    {
+      "name": "editor_view:move_to_paragraph_end",
+      "description": "Move to end of paragraph"
+    },
+    {
+      "name": "editor:select_to_paragraph_start",
+      "description": "Select to start of paragraph"
+    },
+    {
+      "name": "editor:select_to_paragraph_end",
+      "description": "Select to end of paragraph"
+    },
+    {
+      "name": "editor:edit_link",
+      "description": "Create or edit link"
+    },
+    {
+      "name": "editor_view:inline_code",
+      "description": "Toggle inline code styling"
+    },
+    {
+      "name": "editor_view:strikethrough",
+      "description": "Toggle strikethrough styling"
+    },
+    {
+      "name": "editor_view:underline",
+      "description": "Toggle underline styling"
+    },
+    {
+      "name": "editor:find",
+      "description": "Find in Notebook"
+    },
+    {
+      "name": "editor:next_find_match",
+      "description": "Focus next match"
+    },
+    {
+      "name": "editor:previous_find_match",
+      "description": "Focus previous match"
+    },
+    {
+      "name": "editor:toggle_regex_find",
+      "description": "Toggle regular expression search"
+    },
+    {
+      "name": "editor:toggle_case_sensitive_find",
+      "description": "Toggle case-sensitive search"
+    },
+    {
+      "name": "notebookview:focus_terminal_input",
+      "description": "Focus Terminal Input from File"
+    },
+    {
+      "name": "notebookview:reload_file",
+      "description": "Reload file"
+    },
+    {
+      "name": "pane_group:close_current_session",
+      "description": "Close Current Session"
+    },
+    {
+      "name": "pane_group:add_left",
+      "description": "Split pane left"
+    },
+    {
+      "name": "pane_group:add_up",
+      "description": "Split pane up"
+    },
+    {
+      "name": "pane_group:navigate_left",
+      "description": "Switch panes left"
+    },
+    {
+      "name": "pane_group:navigate_right",
+      "description": "Switch panes right"
+    },
+    {
+      "name": "pane_group:navigate_up",
+      "description": "Switch panes up"
+    },
+    {
+      "name": "pane_group:navigate_down",
+      "description": "Switch panes down"
+    },
+    {
+      "name": "pane_group:resize_left",
+      "description": "Resize pane > Move divider left"
+    },
+    {
+      "name": "pane_group:resize_right",
+      "description": "Resize pane > Move divider right"
+    },
+    {
+      "name": "pane_group:resize_up",
+      "description": "Resize pane > Move divider up"
+    },
+    {
+      "name": "pane_group:resize_down",
+      "description": "Resize pane > Move divider down"
+    },
+    {
+      "name": "pane_group:add_down",
+      "description": "Split pane down"
+    },
+    {
+      "name": "pane_group:add_right",
+      "description": "Split pane right"
+    },
+    {
+      "name": "workspace:new_tab",
+      "description": "Terminal session"
+    },
+    {
+      "name": "pane:share_pane_contents",
+      "description": "Share pane"
+    },
+    {
+      "name": "input:insert_network_logging_workflow",
+      "description": "Show Warp network log"
+    },
+    {
+      "name": "input:clear_screen",
+      "description": "Clear screen"
+    },
+    {
+      "name": "terminal:scroll_up_one_page",
+      "description": "Scroll terminal output up one page"
+    },
+    {
+      "name": "terminal:scroll_down_one_page",
+      "description": "Scroll terminal output down one page"
+    },
+    {
+      "name": "workspace:edit_prompt",
+      "description": "Edit Prompt"
+    },
+    {
+      "name": "input:toggle_classic_completions_mode",
+      "description": "(Experimental) Toggle classic completions mode"
+    },
+    {
+      "name": "workspace:show_command_search",
+      "description": "Command Search"
+    },
+    {
+      "name": "input:search_command_history",
+      "description": "History Search"
+    },
+    {
+      "name": "input:toggle_workflows",
+      "description": "Workflows"
+    },
+    {
+      "name": "input:toggle_natural_language_command_search",
+      "description": "Open AI Command Suggestions"
+    },
+    {
+      "name": "input:enable_auto_detection",
+      "description": "Trigger Auto Detection"
+    },
+    {
+      "name": "input:clear_and_reset_ai_context_menu_query",
+      "description": "Clear and reset AI context menu query"
+    },
+    {
       "name": "terminal:alternate_terminal_paste",
       "description": "Alternate terminal paste"
     },
@@ -462,14 +1006,6 @@
       "description": "Scroll terminal output down one line"
     },
     {
-      "name": "terminal:scroll_up_one_page",
-      "description": "Scroll terminal output up one page"
-    },
-    {
-      "name": "terminal:scroll_down_one_page",
-      "description": "Scroll terminal output down one page"
-    },
-    {
       "name": "terminal:scroll_to_top_of_selected_block",
       "description": "Scroll to top of selected block"
     },
@@ -488,6 +1024,14 @@
     {
       "name": "terminal:expand_block_selection_below",
       "description": "Expand selected blocks below"
+    },
+    {
+      "name": "terminal:ask_ai_assistant",
+      "description": "Attach Selected Block as Agent Context"
+    },
+    {
+      "name": "terminal:ask_ai_assistant",
+      "description": "Attach Selected Text as Agent Context"
     },
     {
       "name": "terminal:ask_ai_assistant",
@@ -522,6 +1066,10 @@
       "description": "Toggle Sticky Command Header in Active Pane"
     },
     {
+      "name": "workspace:write_codebase_index",
+      "description": "Write current codebase index snapshot"
+    },
+    {
       "name": "terminal:load_agent_mode_conversation",
       "description": "Load agent mode conversation (from debug link in clipboard)"
     },
@@ -530,28 +1078,24 @@
       "description": "Toggle PTY Recording for Session"
     },
     {
-      "name": "terminal:toggle_conversation_details_panel",
-      "description": "Toggle Conversation Details Panel"
-    },
-    {
-      "name": "terminal:ask_ai_assistant",
-      "description": "Attach Selected Block as Agent Context"
-    },
-    {
-      "name": "terminal:ask_ai_assistant",
-      "description": "Attach Selected Text as Agent Context"
-    },
-    {
-      "name": "workspace:write_codebase_index",
-      "description": "Write current codebase index snapshot"
-    },
-    {
       "name": "workspace:init_project_rules",
       "description": "Initiate project for warp"
     },
     {
       "name": "workspace:add_current_dir_as_project",
       "description": "Add current folder as project"
+    },
+    {
+      "name": "terminal:toggle_conversation_details_panel",
+      "description": "Toggle Conversation Details Panel"
+    },
+    {
+      "name": "app:reopen_closed_session",
+      "description": "Reopen closed session"
+    },
+    {
+      "name": "workflowview:save",
+      "description": "Save workflow"
     },
     {
       "name": "workspace:panic",
@@ -650,6 +1194,54 @@
       "description": "Activate next pane"
     },
     {
+      "name": "workspace:create_team_notebook",
+      "description": "Create a new team notebook"
+    },
+    {
+      "name": "workspace:create_personal_notebook",
+      "description": "Create a new personal notebook"
+    },
+    {
+      "name": "workspace:create_team_workflow",
+      "description": "Create a new team workflow"
+    },
+    {
+      "name": "workspace:create_personal_workflow",
+      "description": "Create a new personal workflow"
+    },
+    {
+      "name": "workspace:create_team_folder",
+      "description": "Create a new team folder"
+    },
+    {
+      "name": "workspace:create_personal_folder",
+      "description": "Create a new personal folder"
+    },
+    {
+      "name": "workspace:toggle_left_panel",
+      "description": "Open Left Panel"
+    },
+    {
+      "name": "file_tree:toggle_hidden_files",
+      "description": "Toggle hidden files in Project Explorer"
+    },
+    {
+      "name": "workspace:close_panel",
+      "description": "Close focused panel"
+    },
+    {
+      "name": "workspace:toggle_command_palette",
+      "description": "Toggle command palette"
+    },
+    {
+      "name": "workspace:move_tab_left",
+      "description": "Move tab left"
+    },
+    {
+      "name": "workspace:move_tab_right",
+      "description": "Move tab right"
+    },
+    {
       "name": "workspace:toggle_keybindings_page",
       "description": "Toggle keyboard shortcuts"
     },
@@ -710,6 +1302,10 @@
       "description": "Quit Warp"
     },
     {
+      "name": "workspace:close_window",
+      "description": "Close Window"
+    },
+    {
       "name": "workspace:close_active_tab",
       "description": "Close the current tab"
     },
@@ -718,12 +1314,20 @@
       "description": "Close other tabs"
     },
     {
+      "name": "workspace:close_tabs_right_active_tab",
+      "description": "Close tabs to the right"
+    },
+    {
       "name": "workspace:toggle_notifications_on",
       "description": "Turn notifications on"
     },
     {
       "name": "workspace:toggle_notifications_off",
       "description": "Turn notifications off"
+    },
+    {
+      "name": "workspace:toggle_navigation_palette",
+      "description": "Toggle navigation palette"
     },
     {
       "name": "workspace:toggle_launch_config_palette",
@@ -782,6 +1386,22 @@
       "description": "Toggle Warp AI"
     },
     {
+      "name": "workspace:create_team_env_vars",
+      "description": "Create new team environment variables"
+    },
+    {
+      "name": "workspace:create_personal_env_vars",
+      "description": "Create new personal environment variables"
+    },
+    {
+      "name": "workspace:create_personal_ai_prompt",
+      "description": "Create a new personal prompt"
+    },
+    {
+      "name": "workspace:create_team_ai_prompt",
+      "description": "Create a new team prompt"
+    },
+    {
       "name": "workspace:shift_focus_left",
       "description": "Switch Focus to Left Panel"
     },
@@ -802,128 +1422,8 @@
       "description": "Copy access token to clipboard"
     },
     {
-      "name": "workspace:jump_to_latest_toast",
-      "description": "Jump to latest agent task"
-    },
-    {
-      "name": "workspace:toggle_agent_management_view",
-      "description": "Toggle the agent management view"
-    },
-    {
-      "name": "workspace:show_settings_account_page",
-      "description": "Open Settings: Account"
-    },
-    {
-      "name": "workspace:show_settings_features_page",
-      "description": "Open Settings: Features"
-    },
-    {
-      "name": "workspace:open_settings_file",
-      "description": "Open settings file"
-    },
-    {
-      "name": "workspace:show_invite_modal",
-      "description": "Invite People..."
-    },
-    {
-      "name": "workspace:link_to_slack",
-      "description": "Join our Slack community (opens external link)"
-    },
-    {
-      "name": "workspace:link_to_user_docs",
-      "description": "View user docs (opens external link)"
-    },
-    {
-      "name": "workspace:view_logs",
-      "description": "View Warp logs"
-    },
-    {
-      "name": "workspace:link_to_privacy_policy",
-      "description": "View privacy policy (opens external link)"
-    },
-    {
-      "name": "workspace:create_team_notebook",
-      "description": "Create a new team notebook"
-    },
-    {
-      "name": "workspace:create_personal_notebook",
-      "description": "Create a new personal notebook"
-    },
-    {
-      "name": "workspace:create_team_workflow",
-      "description": "Create a new team workflow"
-    },
-    {
-      "name": "workspace:create_personal_workflow",
-      "description": "Create a new personal workflow"
-    },
-    {
-      "name": "workspace:create_team_folder",
-      "description": "Create a new team folder"
-    },
-    {
-      "name": "workspace:create_personal_folder",
-      "description": "Create a new personal folder"
-    },
-    {
-      "name": "workspace:toggle_left_panel",
-      "description": "Open Left Panel"
-    },
-    {
-      "name": "file_tree:toggle_hidden_files",
-      "description": "Toggle hidden files in Project Explorer"
-    },
-    {
-      "name": "workspace:close_panel",
-      "description": "Close focused panel"
-    },
-    {
-      "name": "workspace:toggle_command_palette",
-      "description": "Toggle command palette"
-    },
-    {
-      "name": "workspace:move_tab_left",
-      "description": "Move tab left"
-    },
-    {
-      "name": "workspace:move_tab_right",
-      "description": "Move tab right"
-    },
-    {
-      "name": "workspace:close_window",
-      "description": "Close Window"
-    },
-    {
-      "name": "workspace:close_tabs_right_active_tab",
-      "description": "Close tabs to the right"
-    },
-    {
-      "name": "workspace:toggle_navigation_palette",
-      "description": "Toggle navigation palette"
-    },
-    {
-      "name": "workspace:create_team_env_vars",
-      "description": "Create new team environment variables"
-    },
-    {
-      "name": "workspace:create_personal_env_vars",
-      "description": "Create new personal environment variables"
-    },
-    {
-      "name": "workspace:create_personal_ai_prompt",
-      "description": "Create a new personal prompt"
-    },
-    {
-      "name": "workspace:create_team_ai_prompt",
-      "description": "Create a new team prompt"
-    },
-    {
       "name": "workspace:copy_current_path",
       "description": "Copy current path"
-    },
-    {
-      "name": "workspace:open_repository",
-      "description": "Open repository"
     },
     {
       "name": "workspace:open_ai_fact_collection",
@@ -934,12 +1434,28 @@
       "description": "Open MCP Servers"
     },
     {
+      "name": "workspace:jump_to_latest_toast",
+      "description": "Jump to latest agent task"
+    },
+    {
+      "name": "workspace:toggle_agent_management_view",
+      "description": "Toggle the agent management view"
+    },
+    {
       "name": "workspace:show_settings",
       "description": "Open Settings"
     },
     {
+      "name": "workspace:show_settings_account_page",
+      "description": "Open Settings: Account"
+    },
+    {
       "name": "workspace:show_settings_appearance_page",
       "description": "Open Settings: Appearance"
+    },
+    {
+      "name": "workspace:show_settings_features_page",
+      "description": "Open Settings: Features"
     },
     {
       "name": "workspace:show_settings_shared_blocks_page",
@@ -990,9 +1506,49 @@
       "description": "Open Settings: MCP Servers"
     },
     {
+      "name": "workspace:open_settings_file",
+      "description": "Open settings file"
+    },
+    {
+      "name": "workspace:show_invite_modal",
+      "description": "Invite People..."
+    },
+    {
+      "name": "workspace:link_to_slack",
+      "description": "Join our Slack community (opens external link)"
+    },
+    {
+      "name": "workspace:link_to_user_docs",
+      "description": "View user docs (opens external link)"
+    },
+    {
       "name": "workspace:send_feedback",
       "description": "Send feedback (opens external link)"
+    },
+    {
+      "name": "workspace:view_logs",
+      "description": "View Warp logs"
+    },
+    {
+      "name": "workspace:link_to_privacy_policy",
+      "description": "View privacy policy (opens external link)"
+    },
+    {
+      "name": "workspace:disable_terminal_input_syncing",
+      "description": "Stop Synchronizing Any Panes"
+    },
+    {
+      "name": "workspace:toggle_sync_terminal_inputs_in_tab",
+      "description": "Toggle Synchronizing All Panes in Current Tab"
+    },
+    {
+      "name": "workspace:toggle_sync_all_terminal_inputs_in_all_tabs",
+      "description": "Toggle Synchronizing All Panes in All Tabs"
+    },
+    {
+      "name": "workspace:toggle_maximize_code_review_panel",
+      "description": "Toggle Maximize Code Review Panel"
     }
   ],
-  "generated_at": "2026-07-23T18:48:57.057380+00:00"
+  "generated_at": "2026-08-05T16:59:35.936911+00:00"
 }

--- a/.agents/skills/validate_ui_refs/validate_ui_refs.py
+++ b/.agents/skills/validate_ui_refs/validate_ui_refs.py
@@ -260,6 +260,27 @@ _RE_UI_LABEL_PREFIX = re.compile(
     re.IGNORECASE,
 )
 
+# Opening/self-closing HTML or JSX tag on a single line, e.g.
+#   <DemoVideo src="..." label="Block Divider Demo" />
+#   <figure style={{ maxWidth: "375px" }}>
+# Quoted strings *inside* such a tag are component props or CSS values, never
+# Command Palette commands. Matching the tag span (rather than sniffing for a
+# `word=` prefix) keeps legitimate prose like `Palette: "Open theme picker"`
+# from being suppressed.
+_RE_HTML_JSX_TAG = re.compile(r"<[A-Za-z][^<>]*>")
+
+# Markdown fenced code block delimiter. Fenced blocks hold prompt and CLI
+# examples (e.g. an agent prompt that happens to quote a UI label), which are
+# illustrative text rather than live references to Warp's Command Palette.
+_RE_CODE_FENCE = re.compile(r"^\s*(?:```|~~~)")
+
+
+def _is_inside_jsx_tag(line: str, index: int) -> bool:
+    """Return True if `index` falls within an HTML/JSX tag on `line`."""
+    return any(
+        m.start() <= index < m.end() for m in _RE_HTML_JSX_TAG.finditer(line)
+    )
+
 
 def _is_plausible_command_name(name: str) -> bool:
     """Filter false positives for command palette names."""
@@ -339,7 +360,16 @@ def extract_command_palette_refs(file_path: Path) -> List[Dict[str, Any]]:
         return results
 
     lines = text.splitlines()
+    in_code_fence = False
     for line_num, line in enumerate(lines, start=1):
+        # Skip fenced code blocks — they contain prompt/CLI examples, not
+        # live UI references.
+        if _RE_CODE_FENCE.match(line):
+            in_code_fence = not in_code_fence
+            continue
+        if in_code_fence:
+            continue
+
         # Check if "Command Palette" is mentioned nearby (within 2 lines)
         context_start = max(0, line_num - 3)
         context_end = min(len(lines), line_num + 1)
@@ -367,6 +397,10 @@ def extract_command_palette_refs(file_path: Path) -> List[Dict[str, Any]]:
                     # — these are toggle/button labels, not CP commands
                     prefix = line[:match.start()]
                     if _RE_UI_LABEL_PREFIX.search(prefix):
+                        continue
+                    # Skip component props and CSS values inside JSX/HTML tags
+                    # (e.g. `label="..."`, `title="..."`, `maxWidth: "375px"`)
+                    if _is_inside_jsx_tag(line, match.start()):
                         continue
                     # Skip if already captured by arrow pattern
                     if not any(
@@ -1975,6 +2009,50 @@ def _run_self_test(valid_paths_path: Path) -> int:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
+
+    # --- 5. Command Palette extraction ignores JSX attributes and code fences
+    with tempfile.TemporaryDirectory() as td:
+        sample = Path(td) / "sample.mdx"
+        sample.write_text(textwrap.dedent("""\
+            Open the Command Palette and search for "Open theme picker".
+
+            <DemoVideo src="/assets/x.mp4" label="Block Divider Demo" />
+            <VideoEmbed url="https://example.com/v" title="Command Palette Demo" />
+            <figure style={{ maxWidth: "375px" }}>
+
+            Example prompt for the command palette:
+            ```text
+            Walk through the entire "New run" creation flow end to end.
+            ```
+
+            In the Command Palette, search for "Warpify SSH Session".
+            """))
+
+        found = {r["name"] for r in extract_command_palette_refs(sample)}
+
+        # JSX component props and CSS values must not be treated as commands.
+        for bogus in (
+            "Block Divider Demo",
+            "Command Palette Demo",
+            "375px",
+        ):
+            if bogus in found:
+                failures.append(
+                    f"extract_command_palette_refs() captured JSX attribute {bogus!r}"
+                )
+
+        # Quoted labels inside fenced code blocks are examples, not references.
+        if "New run" in found:
+            failures.append(
+                "extract_command_palette_refs() captured a name inside a code fence"
+            )
+
+        # Genuine prose references must still be captured.
+        for expected in ("Open theme picker", "Warpify SSH Session"):
+            if expected not in found:
+                failures.append(
+                    f"extract_command_palette_refs() missed prose reference {expected!r}"
+                )
 
     if failures:
         print("SELF-TEST FAILED:")

--- a/.agents/skills/validate_ui_refs/validate_ui_refs.py
+++ b/.agents/skills/validate_ui_refs/validate_ui_refs.py
@@ -342,6 +342,11 @@ def _is_plausible_command_name(name: str) -> bool:
         "tab indicators", "show sticky command header",
         "settings sync", "empty session", "secret redaction",
         "sticky command header", "vim keybindings",
+        # Mouse reporting is a Settings > Features toggle. The Command Palette
+        # does surface it, but with a state-dependent label ("Enable ..." /
+        # "Disable ..."), and it is registered as a settings row rather than an
+        # EditableBinding, so it never appears in the extracted snapshot.
+        "mouse reporting", "enable mouse reporting", "disable mouse reporting",
     }
     if name_lower in _settings_toggle_phrases:
         return False

--- a/.agents/skills/validate_ui_refs/validate_ui_refs.py
+++ b/.agents/skills/validate_ui_refs/validate_ui_refs.py
@@ -1687,43 +1687,62 @@ def _extract_settings_sections(warp_repo: Path) -> Dict[str, Any]:
     return sections
 
 
+# `EditableBinding::new("action", "Description", ...)` and the
+# `BindingDescription::new("Description")` variant.
+_RE_EDITABLE_BINDING = re.compile(
+    r'EditableBinding::new\(\s*"([^"]+)",\s*'
+    r'(?:BindingDescription::new\(\s*"([^"]+)"|"([^"]+)")'
+)
+
+
+def _iter_binding_source_files(warp_repo: Path):
+    """Yield Rust files under `app/src` that may register command bindings.
+
+    Walks the whole desktop app tree rather than a hand-picked file list:
+    bindings are registered across many view modules (for example
+    `pane_group/pane/view/mod.rs` registers "Share pane"), and hardcoding
+    files silently drops any command defined elsewhere.
+
+    Excluded:
+    - test modules, whose fixture bindings are not real commands
+    - `crates/warp_tui`, which is the headless TUI front-end and does not
+      share the desktop Command Palette
+
+    Traversal is sorted so the generated snapshot is deterministic.
+    """
+    app_src = warp_repo / "app" / "src"
+    if not app_src.exists():
+        return
+    for root, dirs, filenames in os.walk(app_src):
+        dirs[:] = sorted(d for d in dirs if d not in {"tests", "target"})
+        for filename in sorted(filenames):
+            if not filename.endswith(".rs"):
+                continue
+            if filename.endswith(("_tests.rs", "_test.rs")) or filename == "mod_test.rs":
+                continue
+            yield Path(root) / filename
+
+
 def _extract_command_palette_commands(warp_repo: Path) -> List[Dict[str, str]]:
     """Parse EditableBinding registrations to extract command palette commands."""
     commands = []
     seen_descriptions = set()
 
-    source_files = [
-        warp_repo / "app" / "src" / "terminal" / "view" / "init.rs",
-        warp_repo / "app" / "src" / "workspace" / "mod.rs",
-    ]
-
-    for source_file in source_files:
-        if not source_file.exists():
-            continue
+    for source_file in _iter_binding_source_files(warp_repo):
         try:
             text = source_file.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
 
-        # Pattern: EditableBinding::new("name", "description", ...)
-        for m in re.finditer(
-            r'EditableBinding::new\(\s*"([^"]+)",\s*"([^"]+)"',
-            text,
-        ):
-            name, desc = m.group(1), m.group(2)
-            if desc not in seen_descriptions and not desc.startswith("[Debug]"):
-                commands.append({"name": name, "description": desc})
-                seen_descriptions.add(desc)
-
-        # Pattern: EditableBinding::new("name", BindingDescription::new("description"), ...)
-        for m in re.finditer(
-            r'EditableBinding::new\(\s*"([^"]+)",\s*BindingDescription::new\("([^"]+)"\)',
-            text,
-        ):
-            name, desc = m.group(1), m.group(2)
-            if desc not in seen_descriptions and not desc.startswith("[Debug]"):
-                commands.append({"name": name, "description": desc})
-                seen_descriptions.add(desc)
+        for m in _RE_EDITABLE_BINDING.finditer(text):
+            name = m.group(1)
+            # group(2) is the BindingDescription::new(...) form, group(3) the
+            # plain string literal form; exactly one of them matches.
+            desc = m.group(2) or m.group(3)
+            if not desc or desc in seen_descriptions or desc.startswith("[Debug]"):
+                continue
+            commands.append({"name": name, "description": desc})
+            seen_descriptions.add(desc)
 
     return commands
 

--- a/src/content/docs/agents/local-agents/session-sharing.mdx
+++ b/src/content/docs/agents/local-agents/session-sharing.mdx
@@ -39,7 +39,7 @@ When you share an agent session, Warp publishes it to the cloud and generates a 
 
 1. Start or open an agent session in Warp. The agent can be Warp's built-in agent, a third-party coding agent, or any interactive agent running in your terminal.
 2. Open the share action from any of these entry points:
-   * **Command Palette** - Search for "Share session"
+   * **Command Palette** - Search for "Share current session"
    * **Pane header** - Click the overflow menu in the pane header
    * **Right-click context menu** - Right-click inside the session pane
    * **`/remote-control` chip** - For third-party agent sessions, click the `/remote-control` chip in the agent view footer or the CLI footer to publish and share instantly. See [Remote Control](/agents/cli-agents/remote-control/) for details.

--- a/src/content/docs/cli/reference.mdx
+++ b/src/content/docs/cli/reference.mdx
@@ -52,7 +52,7 @@ warp --api-key YOUR_API_KEY
 Command-line arguments can be captured in shell history and process listings. Prefer the `WARP_API_KEY` environment variable, ideally populated from a secret manager.
 :::
 
-Create a key in the Warp app under **Settings** > **Platform**. See the [API keys reference](/reference/cli/api-keys/) for details.
+Create a key in the Warp app under **Settings** > **Cloud platform** > **Oz Cloud API Keys**. See the [API keys reference](/reference/cli/api-keys/) for details.
 
 ### `--set-provider-api-key`
 

--- a/src/content/docs/code/code-editor/code-editor-vim-keybindings.mdx
+++ b/src/content/docs/code/code-editor/code-editor-vim-keybindings.mdx
@@ -26,7 +26,7 @@ Unlike the input editor, the Vim implementation in the code editor starts in Nor
 
 At the moment, Warp only supports default Vim keybindings.
 
-One exception is the keyboard shortcut for exiting insert mode, which can be rebound under **Settings** > **Keyboard shortcuts** > **Exit Vim Insert Mode**, or through the [Command Palette](/terminal/command-palette/) search for "Exit Vim Insert Mode".
+One exception is the keyboard shortcut for exiting insert mode, which can be rebound under **Settings** > **Keyboard shortcuts** > **Exit Vim insert mode**, or through the [Command Palette](/terminal/command-palette/) search for "Exit Vim insert mode".
 
 ## Supported keybindings
 

--- a/src/content/docs/terminal/editor/vim.mdx
+++ b/src/content/docs/terminal/editor/vim.mdx
@@ -28,7 +28,7 @@ As in `bash` and `zsh`'s vi mode implementations, the editor starts in insert mo
 
 At the moment, Warp only supports default Vim keybindings.
 
-One exception is the keyboard shortcut for exiting insert mode, which can be rebound under **Settings** > **Keyboard shortcuts** > **Exit Vim Insert Mode**, or through the [Command Palette](/terminal/command-palette/) search for "Exit Vim Insert Mode".
+One exception is the keyboard shortcut for exiting insert mode, which can be rebound under **Settings** > **Keyboard shortcuts** > **Exit Vim insert mode**, or through the [Command Palette](/terminal/command-palette/) search for "Exit Vim insert mode".
 
 ## Supported keybindings
 

--- a/src/content/docs/terminal/more-features/full-screen-apps.mdx
+++ b/src/content/docs/terminal/more-features/full-screen-apps.mdx
@@ -24,7 +24,8 @@ If you want a mouse event to go to Warp instead (for example, for text selection
 
 * From **Settings** > **Features** > **Terminal** > **Enable Mouse Reporting**
   * Scroll Reporting can be enabled after toggling **Enable Mouse Reporting**
-* From the [Command Palette](/terminal/command-palette/), search for "Toggle Mouse Reporting"
+* From the [Command Palette](/terminal/command-palette/), search for "Mouse Reporting"
+  * The entry is labeled "Enable Mouse Reporting" or "Disable Mouse Reporting" depending on the current setting
 * From the macOS Menu, **View** > **Toggle Mouse Reporting**
 
 ### How it works

--- a/src/content/docs/terminal/warpify/ssh.mdx
+++ b/src/content/docs/terminal/warpify/ssh.mdx
@@ -110,7 +110,7 @@ Warp supports macOS and most flavors of Linux as remote hosts. Supported shells 
 
 ### What if Warp fails to detect my SSH session?
 
-If you're in a remote SSH session and Warp didn't detect it, you can manually Warpify by opening the [Command Palette](/terminal/command-palette/) and searching for "Warpify SSH Session".
+If you're in a remote SSH session and Warp didn't detect it, first check that **Settings** > **Warpify** > **Warpify SSH Sessions** is enabled. If it's already on, Warp likely skipped detection for that particular command. See [What triggers SSH session detection for Warpification?](#what-triggers-ssh-session-detection-for-warpification) for the cases Warp doesn't detect.
 
 ### What triggers SSH session detection for Warpification?
 
@@ -118,4 +118,4 @@ With SSH session detection enabled, Warp watches for `ssh` commands whose argume
 
 Once Warp is confident you've successfully authenticated (by detecting `Last login:` or something resembling a basic prompt), it prompts you to Warpify the active SSH session.
 
-If SSH session detection doesn't pick up your session, you can still [Warpify manually](#what-if-warp-fails-to-detect-my-ssh-session).
+If SSH session detection doesn't pick up your session, see [What if Warp fails to detect my SSH session?](#what-if-warp-fails-to-detect-my-ssh-session).


### PR DESCRIPTION
## Summary

The `validate_ui_refs` Command Palette check reported 12 findings on `main`. Half were extractor false positives rather than documentation errors, which makes the check noisy and easy to start ignoring.

This fixes the false positives, broadens the command extractor so real commands stop being reported as unknown, and corrects six stale references across six doc pages. Every finding was traced to its cause, either in the warp source or against the running app. Findings drop from 12 to 0.

## The problem

`extract_command_palette_refs()` captured any quoted string on a line near a "Command Palette" mention, regardless of the surrounding syntax. Two categories leaked through.

**Component props and CSS values.** Quoted strings inside JSX tags were treated as command names:

```mdx
<DemoVideo src="/assets/terminal/block-divider-demo.mp4" label="Block Divider Demo" />
<VideoEmbed url="https://..." title="Command Palette Demo" />
<figure style={{ maxWidth: "375px" }}>
```

That produced findings for `Block Divider Demo`, `Tab Indicator Demo`, `Logout Demo`, `Command Palette Demo`, and `375px`.

**Fenced code blocks.** Prompt examples were scanned as if they were live UI references. In `agents/capabilities/computer-use/testing-and-recordings.mdx`, a prompt describing the Oz web app's "New run" creation flow was reported as a missing Warp Command Palette command — a different product's UI, quoted inside a fenced text block.

## Changes

### `.agents/skills/validate_ui_refs/validate_ui_refs.py`
- Skip quoted strings that fall inside an HTML/JSX tag span. The check matches the tag span rather than sniffing for a `word=` prefix, so legitimate prose such as `Palette: "Open theme picker"` is not suppressed.
- Skip fenced code blocks during Command Palette extraction. This follows the precedent already set by the `missing_docs` skill's `strip_code_spans()` helper, which exists so CLI examples don't trigger prose-oriented findings.
- Extend `--self-test` with a fifth case asserting both filters drop the bogus captures while genuine prose references are still detected. This runs in CI, so the behavior is locked in.

That takes Command Palette findings from 12 to 6.

## Broadening the command extractor

The other 6 findings were not false positives, so I checked each against the warp source. They turned out to be three different things, not one.

**`Share pane` was a real extraction gap.** `_extract_command_palette_commands()` read only two hardcoded Rust files, so bindings registered anywhere else were invisible:

```rust
// app/src/pane_group/pane/view/mod.rs
app.register_editable_bindings([EditableBinding::new(
    "pane:share_pane_contents",
    "Share pane",
    PaneAction::ShareContents,
)
```

The extractor now walks `app/src` recursively instead. Test modules are excluded, since fixture bindings are not real commands, and `crates/warp_tui` is excluded because the headless TUI front-end does not share the desktop Command Palette. Traversal is sorted so the snapshot stays deterministic, and the two registration patterns are merged into a single regex.

The snapshot goes from 164 to 303 commands. The change is **purely additive** — no command was removed — and `settings_sections`, `umbrellas`, `deprecated_sections`, `macos_menu_bar`, and `warp_drive` are all byte-identical.

**`Share session` was a real doc error.** `session-sharing.mdx` named the Command Palette entry "Share session", but the actual binding is `Share current session` (`terminal:share_current_session`), registered in a file the extractor already scanned. The validator's 0.76 fuzzy suggestion was correct. Fixed.

## Verified against the live UI

The last four findings could not be settled from source alone, so each was checked in the running app. All four were doc errors.

**`Exit Vim Insert Mode`** (`vim.mdx`, `code-editor-vim-keybindings.mdx`) — searching the palette for "Exit Vim" returns no such command. The real binding is `Exit Vim insert mode` (`editor_view:vim_exit_insert_mode`) in `app/src/code/editor/view/actions.rs`. Only the casing was wrong, and broadening the extractor had already made the command visible, which turned these into case mismatches. Both the Settings path and the palette search string are fixed.

**`Toggle Mouse Reporting`** (`full-screen-apps.mdx`) — the palette entry is the Settings > Features toggle, labeled by state: it reads "Disable Mouse Reporting" when reporting is on and "Enable Mouse Reporting" when off. `Toggle Mouse Reporting` is the macOS View menu item, which the page documents on the next line and which is correct. The palette bullet is reworded, with a note about the state-dependent label.

**`Warpify SSH Session`** (`ssh.mdx`) — not a command at all. Searching the palette for "warpify" returns only "Open Settings: Warpify" and a user workflow. The real control is the **Settings** > **Warpify** > **Warpify SSH Sessions** toggle (plural). The page was telling users to run a command that does not exist, so the answer now points at the setting and at the detection rules. A cross-reference promising a manual Warpify method the section no longer describes was updated too.

### One validator change this required

Rewording the mouse reporting bullet initially traded one finding for two, because the palette surfaces settings toggles but the extractor only sees `EditableBinding`s. Settings rows can therefore never appear in the snapshot.

The mouse reporting labels are added to `_settings_toggle_phrases`, the existing curated list that already carries `"vim keybindings"` for exactly this reason — which is why the identical pattern on `vim.mdx:22` never flagged. Without this they would be permanent false positives.

Worth noting that command findings are never auto-fixed — only path and format issues have a `fix_type` — so `--fix` was never at risk of editing these pages.

## Also included: one stale Settings path

Separately from the extractor work, this PR fixes the single Settings path finding that `--all` reports on `main`.

`src/content/docs/cli/reference.mdx:55` still pointed at `Settings > Platform`, which was retired when the Settings UI moved to umbrellas. It now reads `Settings > Cloud platform > Oz Cloud API Keys`.

This is a genuine stale reference, not a false positive — `validate_ui_refs` flagged it at confidence 0.95 through the `deprecated_sections` mapping. The new wording matches what three other pages already use, including `reference/cli/api-keys.mdx`, the page this line links to:

- `reference/cli/api-keys.mdx`
- `enterprise/enterprise-features/analytics-api.mdx`
- `platform/self-hosting/troubleshooting.mdx`

So `cli/reference.mdx` was the lone outlier.

## Verification

- `--self-test` passes, including the new case.
- Command Palette findings: 12 before, **0 after**.
- Settings path findings: 1 before, 0 after.
- Format findings unchanged at 0.
- Internal link check passes with 0 broken links.
- Snapshot diff is additive only: 164 → 303 commands, 0 removed, every other key unchanged.
- Documentation changes touch 6 pages: `cli/reference.mdx`, `session-sharing.mdx`, `vim.mdx`, `code-editor-vim-keybindings.mdx`, `full-screen-apps.mdx`, and `ssh.mdx`.

## Known limitation

The Command Palette surfaces settings toggles and actions in addition to `EditableBinding`s, but the extractor only reads the latter. Documented settings toggles therefore need a `_settings_toggle_phrases` entry to avoid false positives. Extracting settings rows directly would remove that manual step, but it is a distinct parse over `settings_view` and is out of scope here.

## Correction

An earlier revision of this description claimed all six remaining findings were real commands that the tool simply could not see, and that the docs were correct. That was wrong. Checking against the warp source and then the running app showed one extraction gap and five doc errors. This description reflects the verified picture.

Co-Authored-By: Oz <oz-agent@warp.dev>



