### PR TITLE
docs: document the CLI start screen freeze-animation setting

### DIFF
--- a/src/content/docs/cli/configuration.mdx
+++ b/src/content/docs/cli/configuration.mdx
@@ -106,6 +106,7 @@ The start screen appears when you launch the CLI, showing a rotating ASCII objec
 * **`object`** - The rotating object. Keep the built-in one, or point the setting at your own ASCII art file (a path relative to the CLI settings directory). Changing the setting reloads the object. Edits to the linked file take effect after a restart.
 * **`rotation_period_seconds`** - Seconds per full rotation, from 1 through 60.
 * **`show_signed_in_user`, `show_changelog`, `show_project_info`, `show_mcp`, `show_animation`** - Toggle individual start-screen sections.
+* **`freeze_animation_when_unfocused`** - Stop repainting the animation while your terminal window is unfocused, so an idle start screen doesn't use CPU in the background. Off by default, and applied as soon as you save the setting.
 
 The fastest way to change these is to [ask the agent](#ask-the-agent), for example "use my own ASCII art for the start screen object".
 


### PR DESCRIPTION
## Summary

A `missing_docs` drift-watch run flagged `appearance.zero_state.freeze_animation_when_unfocused` as a new, undocumented setting. It's a GA (`always_on`), user-facing Warp Agent CLI setting, so it belongs alongside the other `appearance.zero_state` knobs on the CLI configuration page.

Source of truth: `app/src/settings/tui_zero_state.rs` (`TuiZeroStateFreezeAnimationWhenUnfocusedSetting`, `SettingSurfaces::TUI`, default `false`) and `crates/warp_tui/src/session.rs`, which subscribes to the setting and applies it without a restart.

## Changes

### src/content/docs/cli/configuration.mdx
- Added `freeze_animation_when_unfocused` to the **Start screen** settings list, noting that it stops repainting while the terminal window is unfocused, that it's off by default, and that changes apply as soon as you save.

The surface-map entry pointing this setting at the CLI configuration page ships in the companion audit-bookkeeping PR.

## Validation

- `npm run build` passes.
- `check_links.py` reports 0 broken links.
- Re-running the audit no longer reports the setting as undocumented.

## Deferred findings from this audit run

Summarized in full in the companion audit-bookkeeping PR:

- OpenAPI spec drift for three released endpoints — belongs to the `sync-openapi-spec` skill.
- 30 low-severity terminology flags, verified as false positives.
- 81 `--weak-coverage` findings, spot-checked as heuristic noise.

Co-Authored-By: Oz <oz-agent@warp.dev>
Co-Authored-By: Warp Agent <agent@warp.dev>
