### PR TITLE
docs: document shareable media artifact links and artifact media pages

### DIFF
--- a/src/content/docs/agents/capabilities/computer-use/artifacts-in-prs.mdx
+++ b/src/content/docs/agents/capabilities/computer-use/artifacts-in-prs.mdx
@@ -23,7 +23,7 @@ Attachment is automatic: once a screenshot or recording artifact is associated w
 
 A team-level setting controls how artifacts are attached:
 
-* **Link only (default)** - Screenshots and recordings are attached as links to the run's page in the {VARS.WEB_APP}. Artifacts stay private: opening a link requires access to the run.
+* **Link only (default)** - Screenshots and recordings are attached as links to a media page in the {VARS.WEB_APP} that shows the single capture. Artifacts stay private: opening a link requires access to the run.
 * **Embed** - Screenshots render inline as images in the PR description, and recordings are attached as direct download links. To make this work, the attached artifacts are published at stable, publicly accessible URLs.
 * **Disabled** - No screenshots or recordings are attached to pull requests.
 
@@ -44,12 +44,27 @@ Team admins control the attachment mode from the [Admin Panel](https://app.warp.
 <figcaption>The Pull request artifact attachments setting in the Admin Panel.</figcaption>
 </figure>
 
+## Sharing captures outside pull requests
+
+A pull request isn't always where the evidence belongs. When an agent posts to Slack, comments on an issue or pull request, updates a Linear issue, or answers you in chat, it can pull shareable links for the screenshots and recordings the run captured and include the relevant ones in that message.
+
+Each link opens a media page in the {VARS.WEB_APP} that shows one capture — for example, `https://oz.warp.dev/artifacts/ARTIFACT_UID`, where `ARTIFACT_UID` identifies the screenshot or recording. Access is checked when the link is opened, so a link is safe to paste into an external tool: viewers who can't access the run are asked to sign in and are turned away if they lack permission.
+
+The team attachment mode applies here too:
+
+* **Link only (default)** - The agent gets media page links. Captures stay private.
+* **Embed** - The agent also gets direct image and video URLs, so screenshots and video thumbnails can render inline where the destination supports it. As in pull requests, those URLs are publicly accessible to anyone who has them.
+* **Disabled** - No links are available, and the agent reports that sharing is turned off for your team.
+
+To ask for this explicitly, tell the agent where the captures should go — for example, "post the screenshots to #eng-releases" or "reply with a link to the recording."
+
 ## Where else artifacts appear
 
 Pull requests aren't the only place captures end up:
 
 * **In the conversation** - Screenshots and recordings appear as blocks in the agent's conversation as they're captured.
 * **On the run page** - Open the run in the [{VARS.WEB_APP}](/platform/oz-web-app/#runs) to view, play, or download all artifacts the run produced.
+* **On a media page** - Every attached screenshot or recording also has its own page in the {VARS.WEB_APP} for viewing a single capture. See [Artifact media pages](/platform/oz-web-app/#artifact-media-pages).
 
 ## Related pages
 

--- a/src/content/docs/platform/oz-web-app.mdx
+++ b/src/content/docs/platform/oz-web-app.mdx
@@ -80,6 +80,12 @@ To start a new run:
 
 **Quick run** runs as your own user. A saved agent uses its saved defaults, and your prompt adds context for this particular execution.
 
+### Artifact media pages
+
+A screenshot or video recording an agent captured also has its own page at `/artifacts/<artifact-uid>`, showing that single capture with its description. Agents link to these pages when they attach captures to a pull request or share them in Slack, an issue comment, or a chat reply, so a reviewer can open one capture without opening the whole run.
+
+Access follows the artifact: private captures require signing in with an account that can access the run, while captures your team has published for embedding open without signing in. See [Screenshots and videos in pull requests](/agents/capabilities/computer-use/artifacts-in-prs/) for the team setting that controls this.
+
 ### Inspecting orchestrated runs
 
 The Oz web app renders [multi-agent orchestrations](/platform/orchestration/) as nested rows on the **Runs** page, so you can follow parent and child execution together.


### PR DESCRIPTION
## Summary

A `missing_docs` drift-watch run detected two new surfaces that ship the same user-facing capability and had no docs coverage:

- A new server-side agent tool, `get_media_artifact_links`, which returns shareable links to a run's Computer Use screenshots and video recordings so an agent can include them in a Slack message, an issue or PR comment, a Linear comment, or a chat reply.
- A new Oz web app route, `artifacts/:artifactUid`, the per-artifact media page those links open.

Both are enabled in production (`media_artifact_links_tool` and `artifact_media_page_links` in `config/prod.yaml`). The same rollout also changed what **Link only** attachments point at: PR links now open the artifact's media page rather than the run page, so the existing wording on the artifacts page was stale.

## Changes

### src/content/docs/agents/capabilities/computer-use/artifacts-in-prs.mdx
- Corrected the **Link only** attachment mode description: links open a media page showing the single capture.
- Added a "Sharing captures outside pull requests" section covering where shared links can go, the media page URL shape, permission checking on open, how each attachment mode (Link only / Embed / Disabled) behaves, and how to ask for it in a prompt.
- Added a media page bullet to "Where else artifacts appear".

### src/content/docs/platform/oz-web-app.mdx
- Added an "Artifact media pages" subsection under **Runs** describing the `/artifacts/<artifact-uid>` page and its access behavior.

## Source of truth

- `logic/ai/multi_agent/runtime/get_media_artifact_links.go` — link building, attachment-mode gating, embed URLs and video thumbnails.
- `logic/ai/multi_agent/artifact_attachments/media_page_links.go` — `MediaPageArtifactURL` (`<oz origin>/artifacts/<uuid>`).
- `client/packages/agents/src/pages/Artifacts/index.tsx` — public media viewer; public artifacts render without auth, private ones redirect to login.

## Validation

- `npm run build` passes.
- `check_links.py` reports 0 broken links (including the new `#artifact-media-pages` anchor).

## Deferred findings from this audit run

Summarized in full in the companion audit-bookkeeping PR:

- OpenAPI spec drift for three released endpoints (`GET /agent/artifacts/{artifactUid}/download`, `GET /agent/run-by-external-reference`, `POST /agent/runs/{runId}/scores`) — belongs to the `sync-openapi-spec` skill, and the regenerated subset would also pull in research-preview Agent Memory schemas, which needs a policy decision first.
- Factory MCP OAuth discovery routes and `GET /factory/{uid}/metrics` — mapped internal (unreleased product / `x-internal` in the canonical spec).
- 30 low-severity terminology flags, verified as false positives.

Co-Authored-By: Oz <oz-agent@warp.dev>
Co-Authored-By: Warp Agent <agent@warp.dev>
