### PR TITLE
docs: use canonical agent terminology in software factory guides

### DIFF
--- a/src/content/docs/guides/agent-workflows/run-a-software-factory-in-the-cloud.mdx
+++ b/src/content/docs/guides/agent-workflows/run-a-software-factory-in-the-cloud.mdx
@@ -98,4 +98,4 @@ See [Multi-agent orchestration](/platform/orchestration) for fan-out, sharding, 
 * [Build a self-improving agent](/guides/agent-workflows/build-a-self-improving-agent) — Add the outer improvement loop on a schedule.
 * [Environments](/platform/environments) — Full reference for cloud agent environments.
 * [Deployment patterns](/platform/deployment-patterns) — Choose the right architecture for your team.
-* [Self-hosting](/platform/self-hosting) — Run Oz agent workers on your own infrastructure when code must stay on-premises.
+* [Self-hosting](/platform/self-hosting) — Run cloud agent workers on your own infrastructure when code must stay on-premises.

--- a/src/content/docs/guides/agent-workflows/set-up-a-software-factory.mdx
+++ b/src/content/docs/guides/agent-workflows/set-up-a-software-factory.mdx
@@ -166,4 +166,4 @@ The reviewer agent surfaces issues and inconsistencies; the human makes the fina
 * [Build a self-improving agent](/guides/agent-workflows/build-a-self-improving-agent) — Add the outer improvement loop.
 * [Review AI-generated code](/guides/agent-workflows/how-to-review-ai-generated-code) — The human review workflow for agent-generated PRs.
 * [`warpdotdev/oz-for-oss`](https://github.com/warpdotdev/oz-for-oss) — The complete reference implementation.
-* [GitHub Actions integration](/platform/integrations/github-actions) — Full documentation for triggering Oz agents from CI.
+* [GitHub Actions integration](/platform/integrations/github-actions) — Full documentation for triggering cloud agents from CI.


### PR DESCRIPTION
## Summary

The `missing_docs` staleness audit flagged 32 pages for potentially outdated terminology. Triaging every match line by line, two were real violations of the "Terms to avoid" list in `AGENTS.md` ("Oz agent"/"Oz agents" → "agent"/"cloud agent"); the rest are false positives (see below).

## Changes

### src/content/docs/guides/agent-workflows/run-a-software-factory-in-the-cloud.mdx
- "Run Oz agent workers on your own infrastructure" → "Run cloud agent workers on your own infrastructure".

### src/content/docs/guides/agent-workflows/set-up-a-software-factory.mdx
- "triggering Oz agents from CI" → "triggering cloud agents from CI".

## Triage of the remaining 30 staleness findings

Each match was inspected in context and confirmed to be correct as written:

- `privacy.mdx` — the telemetry event tables list literal event names and their shipped descriptions ("Warp AI Request Issued", "AmbientAgent.DispatchFailed", "AI Command Search opened"). Renaming them would misrepresent the data Warp collects.
- "AI Command Search" — a current feature name, not the legacy "AI command".
- "agent-mode" — every hit is a URL slug or image filename (`/warp-drive/agent-mode-context/`, `agent-mode-suggestion-1.png`).
- "AI credits" — the name of one of the three metered credit buckets (AI, compute, platform) used consistently across the billing pages and the product UI.
- "Warp terminal"/"Warp Terminal" — used where the page is deliberately distinguishing the local terminal from Oz or a cloud harness, which the style guide allows.
- "What happened to the old Warp AI chat panel?" — an intentional historical reference in the agents FAQ.
- "generate command suggestions" — an ordinary verb phrase, not the retired Generate feature.

Broader wording enforcement stays with the `style_lint` skill; this PR only fixes the terminology violations.

## Validation

- `npm run build` passes.
- `check_links.py` reports 0 broken links.

Co-Authored-By: Oz <oz-agent@warp.dev>
Co-Authored-By: Warp Agent <agent@warp.dev>
