### PR TITLE
docs(skills): do not emit a self-redirect for error codes without underscores

### DIFF
--- a/.agents/skills/sync-error-docs/SKILL.md
+++ b/.agents/skills/sync-error-docs/SKILL.md
@@ -88,7 +88,7 @@ Rules:
 - Only add an explicit `{ slug, label }` object if the auto-derived title is wrong; the existing error entries all rely on the derived title.
 - Append after the last existing error entry unless a grouping order is obvious from the surrounding entries. The list is not alphabetized and has no section labels.
 
-### Step 6: Add the underscore-to-hyphen redirect
+### Step 6: Add the underscore-to-hyphen redirects (only when the forms differ)
 
 Error codes are underscored (`insufficient_credits`) but page slugs are hyphenated (`insufficient-credits`). Add redirects to `vercel.json` (at the repo root) so the underscore form resolves.
 

--- a/.agents/skills/sync-error-docs/SKILL.md
+++ b/.agents/skills/sync-error-docs/SKILL.md
@@ -92,7 +92,9 @@ Rules:
 
 Error codes are underscored (`insufficient_credits`) but page slugs are hyphenated (`insufficient-credits`). Add redirects to `vercel.json` (at the repo root) so the underscore form resolves.
 
-**Add two entries, not one.** Every error code currently in `vercel.json` has both a no-trailing-slash and a trailing-slash source (34 entries covering 17 codes, with no code having only one form). Adding a single variant leaves the new code with half the coverage of every existing one, and the `/errors/:code/` catch-all forwards a trailing slash through, so the slashed underscore path would not resolve.
+**Skip this step entirely for a code that contains no underscore.** Its hyphenated slug is the same string as the code, so there is nothing to redirect: the no-slash entry would be a redundant trailing-slash normalization, and the trailing-slash entry would have `source` equal to `destination` — a self-redirect, which is an infinite loop. `conflict` is the current example. It has no redirect entries in `vercel.json`, and that is correct, not a gap. Only add redirects when `{underscore_code}` and `{hyphen-code}` actually differ.
+
+**Otherwise add two entries, not one.** Every multi-word error code currently in `vercel.json` has both a no-trailing-slash and a trailing-slash source (34 entries covering 17 codes, with no code having only one form). Adding a single variant leaves the new code with half the coverage of every existing one, and the `/errors/:code/` catch-all forwards a trailing slash through, so the slashed underscore path would not resolve.
 
 Check for existing entries first, to stay idempotent across re-runs:
 
@@ -186,6 +188,7 @@ Summarize what was found:
 - Number of existing doc pages
 - New codes that were missing pages (list them)
 - Pages created, `src/sidebar.ts` entries added, redirects configured
+- Any codes skipped for redirects because they contain no underscore
 - Or confirm everything is already in sync
 
 Follow the actionable-only Slack rule in `.agents/references/skill-authoring-guidelines.md`: a run that finds everything already in sync writes this report to the run output and posts nothing.

--- a/.agents/skills/sync-error-docs/references/redirect-patterns.md
+++ b/.agents/skills/sync-error-docs/references/redirect-patterns.md
@@ -19,7 +19,7 @@ https://docs.warp.dev/reference/api-and-sdk/troubleshooting/errors/insufficient-
 Two gaps separate them:
 
 1. **Path prefix** — `/errors/{code}` versus the full `/reference/api-and-sdk/troubleshooting/errors/{code}` path.
-2. **Separator** — error codes are underscored (`insufficient_credits`); page slugs are hyphenated (`insufficient-credits`).
+2. **Separator** — error codes are underscored (`insufficient_credits`); page slugs are hyphenated (`insufficient-credits`). A single-word code such as `conflict` has no separator to convert, so this gap does not exist for it.
 
 Both are handled by entries in `vercel.json` at the repo root. All redirects for the site live in that one file.
 
@@ -40,7 +40,7 @@ Catch-alls already cover every error code, current and future, in both slash for
 }
 ```
 
-`:code` is forwarded unchanged, so `/errors/insufficient_credits` lands on the underscored path, which the separator redirects below then resolve. Note that the trailing-slash catch-all preserves the slash into the destination, which is why the separator step must also cover the slashed form.
+`:code` is forwarded unchanged, so `/errors/insufficient_credits` lands on the underscored path, which the separator redirects below then resolve. For a single-word code the forwarded path is already the canonical slug, so nothing further is needed. Note that the trailing-slash catch-all preserves the slash into the destination, which is why the separator step must also cover the slashed form whenever it applies.
 
 Because these rules are generic, **adding a new error code requires no change here.** Just confirm both still exist:
 
@@ -53,9 +53,13 @@ If either is missing, restore that rule rather than adding one entry per code.
 
 There are also bare `/errors` and `/errors/` redirects pointing at the errors index, which likewise need no per-code maintenance.
 
-## 2. Separator redirects (two entries per code)
+## 2. Separator redirects (zero or two entries per code)
 
-These are the only redirects a new error code needs. They map the underscored form to the hyphenated page slug, in both slash forms:
+These are the only redirects a new error code can need, and some codes need none.
+
+**First check whether the code contains an underscore.** If it does not, its hyphenated slug is the same string, there is no separator to bridge, and you add nothing — skip to the rules below for why. Only codes whose underscored and hyphenated forms actually differ get entries, and those get two.
+
+For a code that does differ, map the underscored form to the hyphenated page slug in both slash forms:
 
 ```json
 {
@@ -70,7 +74,7 @@ These are the only redirects a new error code needs. They map the underscored fo
 }
 ```
 
-Example for `insufficient_credits`:
+Example for `insufficient_credits`, whose forms differ:
 
 ```json
 {

--- a/.agents/skills/sync-error-docs/references/redirect-patterns.md
+++ b/.agents/skills/sync-error-docs/references/redirect-patterns.md
@@ -87,7 +87,8 @@ Example for `insufficient_credits`:
 
 Rules:
 
-- **Add both slash variants.** All 17 codes currently in `vercel.json` have both (34 entries); none has only one. A single variant leaves the new code less covered than every existing one, and the trailing-slash catch-all in section 1 forwards its slash through, so the slashed underscore path would otherwise 404.
+- **Skip a code with no underscore.** If `{underscore_code}` and `{hyphen-code}` are the same string, there is nothing to bridge. The no-slash entry would be a redundant trailing-slash normalization and the trailing-slash entry would be a self-redirect with `source` equal to `destination` — an infinite loop. `conflict` is the current example and correctly has no entries.
+- **Otherwise add both slash variants.** All 17 multi-word codes currently in `vercel.json` have both (34 entries); none has only one. A single variant leaves the new code less covered than every existing one, and the trailing-slash catch-all in section 1 forwards its slash through, so the slashed underscore path would otherwise 404.
 - `source` has a **leading slash** and no file extension.
 - `destination` has a **trailing slash** in both entries. Every existing error redirect does.
 - Always set `"statusCode": 308`.


### PR DESCRIPTION
## Summary

Follow-up to #487, found by dry-running the repaired `sync-error-docs` skill before scheduling it.

Step 6 tells the agent to add **two** redirect entries per error code, bridging the underscored code to the hyphenated page slug. That is correct for every multi-word code — but wrong for a code with no underscore, where the two forms are the same string.

`conflict` is the only such code today. Abbreviating the shared prefix `/reference/api-and-sdk/troubleshooting/errors/` as `…`:

```
entry 1   …/conflict   →  …/conflict/     harmless slash normalization
entry 2   …/conflict/  →  …/conflict/     source == destination
```

Entry 2 is a self-redirect: an infinite loop on a live docs route.

This also explains something the dry run initially flagged as a coverage gap. `conflict` has no redirect entries in `vercel.json` while the other 17 codes each have two. That absence is **correct**, not an oversight — there is nothing to bridge.

## Changes

* `sync-error-docs/SKILL.md` step 6 — skip redirects entirely when `{underscore_code}` and `{hyphen-code}` are identical, with the reasoning inline so it doesn't get "fixed" back.
* `sync-error-docs/SKILL.md` step 9 — report any codes skipped for this reason, so a reviewer can see the decision was deliberate.
* `references/redirect-patterns.md` — same rule, stated before the "add both variants" rule it qualifies.

## Dry run result

Run against merged `main` (`ee77efd7`) with `warp-server` at `6ca991369`. Verified that `src/sidebar.ts`, `vercel.json`, and the errors directory were byte-identical to `main` before running.

```
Step 1  18 error codes extracted from platformerrors.go
Step 2  18 doc pages present
Step 3  0 codes missing a page
Step 5  18/18 registered in src/sidebar.ts (bare-slug format confirmed)
Step 6  conflict correctly needs no redirect; 17/17 others have both variants
Step 7  both /errors/:code and /errors/:code/ catch-alls present

VERDICT: everything in sync, no PR, and under the actionable-only rule no Slack post.
```

Every assumption the repaired skill makes held against reality: the `../warp-server` sibling path, the errors directory location, the bare-slug sidebar format, and the redirect shape. Those were the parts most likely to be wrong, since the pre-#487 version of this skill referenced files that did not exist.

## Unverified claims

None — the error codes, page list, sidebar entries, and redirect entries were each read directly from the repos rather than inferred.

Co-Authored-By: Warp Agent <agent@warp.dev>
