### PR TITLE
Update agent notifications support for Auggie

### DIFF
--- a/src/content/docs/agents/cli-agents/overview.mdx
+++ b/src/content/docs/agents/cli-agents/overview.mdx
@@ -48,7 +48,7 @@ Not every feature is available for every agent. The table below shows current su
 | Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Claude Code | Codex | OpenCode | Amp | Auggie | Copilot CLI | Cursor | Gemini CLI | Droid | Pi |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Rich input editor (`Ctrl-G`) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Agent notifications | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Agent notifications | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Code review comments | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Attach code as context | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Vertical tabs + metadata | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |


### PR DESCRIPTION
## Summary

Marks **Auggie** as supporting **Agent notifications** in the CLI agents feature-support table (`src/content/docs/agents/cli-agents/overview.mdx`).

This replicates external contribution #475 onto a branch in this repo. That PR came from a fork, so Vercel gates its preview build behind manual authorization; recreating the change here lets a preview deployment build automatically. Credit to @tkossak for the original change.

## Related

Supersedes / mirrors #475

## Validation

Docs-only, single-line table edit.

_Conversation: https://staging.warp.dev/conversation/294921fa-4386-476d-a23c-0c54d636df75_
_Run: https://oz.staging.warp.dev/runs/019fdccc-b601-75b0-8b47-a74e058e6c4a_

_This PR was generated with [Oz](https://warp.dev/oz)._
