### PR TITLE
docs: collapse the Agents intro pages and de-duplicate the CLI conversation doc

### DIFF
--- a/src/content/docs/agents/capabilities/index.mdx
+++ b/src/content/docs/agents/capabilities/index.mdx
@@ -24,4 +24,4 @@ Agent capabilities are the core building blocks that define how agents operate, 
 ## Related
 
 * [Inference & providers](/agents/inference/model-choice/) - Pick the model that powers your agents, bring your own API key, or connect a custom inference endpoint.
-* [Local Agents](/agents/local-agents/overview/) - Hands-on agent interactions in Warp.
+* [Using the Warp Agent](/agents/local-agents/overview/) - Hands-on agent interactions in Warp.

--- a/src/content/docs/agents/cli/agent-conversations.mdx
+++ b/src/content/docs/agents/cli/agent-conversations.mdx
@@ -48,7 +48,7 @@ When the agent needs a decision from you mid-task, it asks a question with an in
 
 Options the agent suggests as the best fit are labeled `(recommended)`. For multi-select questions, chosen options are marked with a check mark so you can select more than one. When the agent asks several questions at once, the card advances through them.
 
-To control whether the agent pauses to ask at all, see [Agent questions](/agents/local-agents/interacting-with-agents/agent-questions/).
+To control whether the agent pauses to ask questions, see [Agent questions](/agents/local-agents/interacting-with-agents/agent-questions/).
 
 ## Task lists
 
@@ -88,7 +88,7 @@ The CLI saves every agent conversation as you work, so closing your terminal won
 
 The CLI shows one conversation at a time. Opening a past conversation replaces the current transcript, and the previous one remains available in history. You can't switch conversations while the current conversation is responding or a command is running. Finish or stop it with `Ctrl+C` first.
 
-Conversations sync to your Warp account, so the same history is available in the Warp app and on your other devices. See [Cloud-synced conversations](/agents/local-agents/cloud-conversations/) for how syncing, restoring, and sharing work.
+Conversations sync to your Warp account, so the same history is available in the Warp app and on your other devices. See [Cloud-synced conversations](/agents/local-agents/cloud-conversations/) for details about syncing, restoring, and sharing work.
 
 ### Starting a new conversation
 

--- a/src/content/docs/agents/cli/agent-conversations.mdx
+++ b/src/content/docs/agents/cli/agent-conversations.mdx
@@ -36,6 +36,8 @@ When the agent edits files, the edit renders as a diff in the transcript:
 
 Diffs are fully expanded while the agent waits for your approval, then collapse to their headers once the edits are applied. Press `E` while the approval card is active to expand or collapse all diffs at once.
 
+The CLI renders diffs inline rather than in a separate editor. For how agent-generated changes work in the Warp app, including refining a diff in natural language, see [Agent code diffs and review](/agents/local-agents/code-diffs/).
+
 ## Thinking blocks
 
 For models that expose their reasoning, the agent's thinking streams into a collapsible section with the header `Thinking...`, which collapses to a single `Thought for` row once it finishes.
@@ -45,6 +47,8 @@ For models that expose their reasoning, the agent's thinking streams into a coll
 When the agent needs a decision from you mid-task, it asks a question with an interactive option list that temporarily replaces the input. Use the arrow keys to navigate between options, or press an option's number on your keyboard to select it. **Other…** accepts a free-form answer when the listed options don't fit.
 
 Options the agent suggests as the best fit are labeled `(recommended)`. For multi-select questions, chosen options are marked with a check mark so you can select more than one. When the agent asks several questions at once, the card advances through them.
+
+To control whether the agent pauses to ask at all, see [Agent questions](/agents/local-agents/interacting-with-agents/agent-questions/).
 
 ## Task lists
 
@@ -82,9 +86,9 @@ The CLI saves every agent conversation as you work, so closing your terminal won
 
 ### Conversation persistence
 
-Conversations save to your Warp account, so the same history is available in the Warp app and on your other devices. Reopening a conversation restores the full transcript, including agent responses, tool calls, and file-edit diffs. You can continue prompting from where the agent left off.
-
 The CLI shows one conversation at a time. Opening a past conversation replaces the current transcript, and the previous one remains available in history. You can't switch conversations while the current conversation is responding or a command is running. Finish or stop it with `Ctrl+C` first.
+
+Conversations sync to your Warp account, so the same history is available in the Warp app and on your other devices. See [Cloud-synced conversations](/agents/local-agents/cloud-conversations/) for how syncing, restoring, and sharing work.
 
 ### Starting a new conversation
 
@@ -95,6 +99,8 @@ Use any of these slash commands to clear the transcript and start a fresh conver
 * `/clear`
 
 Each command accepts an optional prompt. For example, `/new write tests for the parser` starts a new conversation and immediately sends that prompt to the agent. To keep the history but reduce its size instead, use [`/compact`](#compacting-context).
+
+For guidance on when to start fresh rather than follow up, see [Interacting with agents](/agents/local-agents/interacting-with-agents/).
 
 ### Conversation history
 
@@ -129,7 +135,7 @@ warp --resume YOUR_CONVERSATION_TOKEN
 
 ### Compacting context
 
-Long conversations eventually fill the model's context window, which can degrade response quality. The `/compact` command frees up context by asking the agent to summarize the conversation history so far and carry only the summary forward.
+Long conversations eventually fill the model's [context window](/agents/local-agents/interacting-with-agents/#context-window-management), which can degrade response quality. The `/compact` command frees up context by asking the agent to summarize the conversation history so far and carry only the summary forward.
 
 * **`/compact`** - Summarizes the conversation history with default instructions.
 * **`/compact <instructions>`** - Adds custom summarization instructions. For example, `/compact keep the API design decisions` tells the agent what to preserve in the summary.
@@ -144,3 +150,5 @@ After compaction, a collapsed **Conversation summary** block appears in the tran
 * [{VARS.WARP_CLI} reference](/agents/cli/reference/) - Command-line flags, slash commands, and keyboard shortcuts.
 * [Planning](/agents/capabilities/planning/) - The full planning workflow.
 * [Task lists](/agents/capabilities/task-lists/) - How agents create and update task lists.
+* [Agent code diffs and review](/agents/local-agents/code-diffs/) - Reviewing and refining agent-generated changes.
+* [Cloud-synced conversations](/agents/local-agents/cloud-conversations/) - How conversations sync, restore, and share across devices.

--- a/src/content/docs/agents/getting-started/agents-in-warp.mdx
+++ b/src/content/docs/agents/getting-started/agents-in-warp.mdx
@@ -50,6 +50,12 @@ For each action, set the autonomy level to:
 
 You can also configure an **allowlist** and **denylist** for specific commands you always want to run—either with or without confirmation.
 
+:::note
+Warp's AI features can be globally disabled in **Settings** > **Agents** > **Warp Agent** with the AI toggle.\
+\
+These features send input data to various LLM providers through their API. Warp is **SOC 2 compliant** and has **Zero Data Retention** policies with all contracted LLM providers — no customer AI data is retained, stored, or used for training. Read more about data privacy for Warp features [on our privacy page](https://www.warp.dev/privacy).
+:::
+
 ---
 
 ## Agent profiles
@@ -88,44 +94,9 @@ Agents work best when they understand your codebase and workflows. Warp provides
 
 ---
 
-## The Warp Agent CLI
+## Next steps
 
-The Warp Agent isn't limited to the Warp app. The [Warp Agent CLI](/agents/cli/) is a standalone terminal program that starts an agent conversation from the `warp` command, so you can use the same agent over SSH, in a different terminal emulator, or on a machine where the Warp app isn't installed.
-
-It runs the same agent, so your account, plan, model access, rules, and skills work the same way. Conversations sync to your Warp account, and you can hand work off to cloud agents from the CLI.
-
-→ [Get started with the Warp Agent CLI](/agents/cli/quickstart/)
-
----
-
-## Third-party CLI agents
-
-In addition to Warp's built-in agent, Warp provides first-class support for third-party CLI coding agents like Claude Code, Codex, and OpenCode. Run any supported agent inside Warp and get rich input, code review, agent notifications, vertical tabs with agent metadata, and more.
-
-→ [Learn about Third-party CLI agents](/agents/cli-agents/overview/)
-
----
-
-## From local to cloud
-
-The same agent capabilities that power interactive conversations in Warp also run in the cloud. Cloud agents can:
-
-* React to events from Slack, Linear, or GitHub
-* Run on a [schedule](/platform/triggers/scheduled-agents/) for recurring tasks like dependency updates
-* Execute in parallel across repos or tasks with [multi-agent orchestration](/platform/orchestration/)
-* Produce tracked, auditable, shareable runs you can inspect in the [Agent Management Panel](/platform/managing-cloud-agents/)
-
-Cloud agents are ideal for work that doesn't need your immediate attention—PR reviews, issue triage, routine maintenance, and integration-driven workflows. For a trigger comparison across schedules, Slack, Linear, GitHub Actions, the CLI, and the API, see [Run unattended agents](/guides/agent-workflows/how-to-run-unattended-agents/).
-
-→ [Learn about Cloud Agents](/platform/)
-
----
-
-## Resources
-
-* [**Oz web app**](https://oz.warp.dev) - Create runs, manage schedules, browse skills, and configure integrations
-* [**Using the Warp Agent**](/agents/local-agents/overview/) - Detailed guide to working with agents in Warp
-* [**Warp Agent CLI**](/agents/cli/) - Run the Warp Agent from any terminal
-* [**Capabilities**](/agents/capabilities/) - All agent capabilities: planning, task lists, model choice, and more
-* [**Oz CLI**](/reference/cli/) - Run agents from the command line
-* [**Oz API & SDK**](/reference/api-and-sdk/) - Programmatic access to agent runs
+* [**Using the Warp Agent**](/agents/local-agents/overview/) - Every agent feature available in the Warp app, from code review to voice.
+* [**Agent capabilities**](/agents/capabilities/) - Planning, skills, rules, MCP servers, task lists, and model choice.
+* [**Running agents on a schedule**](/platform/triggers/scheduled-agents/) - Hand recurring work to a cloud agent. For a comparison of triggers across schedules, Slack, Linear, GitHub Actions, the CLI, and the API, see [Run unattended agents](/guides/agent-workflows/how-to-run-unattended-agents/).
+* [**Agent FAQs**](/agents/getting-started/faqs/) - Common questions about models, privacy, and limits.

--- a/src/content/docs/agents/getting-started/agents-in-warp.mdx
+++ b/src/content/docs/agents/getting-started/agents-in-warp.mdx
@@ -53,7 +53,7 @@ You can also configure an **allowlist** and **denylist** for specific commands y
 :::note
 Warp's AI features can be globally disabled in **Settings** > **Agents** > **Warp Agent** with the AI toggle.\
 \
-These features send input data to various LLM providers through their API. Warp is **SOC 2 compliant** and has **Zero Data Retention** policies with all contracted LLM providers — no customer AI data is retained, stored, or used for training. Read more about data privacy for Warp features [on our privacy page](https://www.warp.dev/privacy).
+These features send input data to various LLM providers through their API. Warp is **SOC 2 compliant** and has **Zero Data Retention** policies with all contracted LLM providers. No customer AI data is retained, stored, or used for training. Read more about data privacy for Warp features [on our privacy page](https://www.warp.dev/privacy).
 :::
 
 ---

--- a/src/content/docs/agents/local-agents/overview.mdx
+++ b/src/content/docs/agents/local-agents/overview.mdx
@@ -5,32 +5,15 @@ description: >-
   Review, voice, and Active AI Recommendations.
 ---
 
-The Warp Agent runs directly in your terminal, with full context from your codebase, Warp Drive, and connected tools, while you stay in control of every action.
+The Warp Agent runs directly in your terminal, with full context from your codebase, Warp Drive, and connected tools, while you stay in control of every action. It can look up commands, execute tasks, fix bugs, and adapt to your workflows.
 
-## AI in Warp
-
-Warp includes intelligent agents designed to help you build, test, deploy, and debug while keeping you in control. Interactive agent conversations in Warp can look up commands, execute tasks, fix bugs, and adapt to your workflows. You can manage agent behavior directly, with full context from your Warp Drive and your team.
-
-:::note
-Warp's AI features can be globally disabled in **Settings** > **Agents** > **Warp Agent** with the AI toggle.\
-\
-These features send input data to various LLM providers through their API. Warp is **SOC 2 compliant** and has **Zero Data Retention** policies with all contracted LLM providers — no customer AI data is retained, stored, or used for training. Read more about data privacy for Warp features [on our privacy page](https://www.warp.dev/privacy).
-:::
-
-Warp's client is open source under [AGPL v3](https://github.com/warpdotdev/warp/blob/master/LICENSE-AGPL) at [`warpdotdev/warp`](https://github.com/warpdotdev/warp). The agent surface you're reading about is built in the open — see [Contributing to Warp](/support-and-community/community/contributing/) to read the code, file issues, or shape the roadmap.
-
-## Outside the Warp app
-
-The same agent runs outside the Warp app. The [Warp Agent CLI](/agents/cli/) is a standalone terminal program that starts an agent conversation from the `warp` command, so you can use it in any terminal emulator, over SSH, or on a machine where the Warp app isn't installed. Your rules, skills, and model access carry over, and conversations sync to your Warp account.
-
-The capabilities below apply to the agent wherever it runs. Behavior that is specific to the CLI is covered in the [Warp Agent CLI](/agents/cli/) section.
-
-→ [Get started with the Warp Agent CLI](/agents/cli/quickstart/)
+The same agent also runs outside the Warp app, in any terminal, through the [Warp Agent CLI](/agents/cli/).
 
 ## What you can do with agents
 
 This section covers how to interact with agents in Warp and the capabilities available during agent conversations:
 
+* [Agents in Warp](/agents/getting-started/agents-in-warp/) - Start here for what agents do, how autonomy and profiles work, and how to give them context.
 * [Interacting with Agents](/agents/local-agents/interacting-with-agents/) - Manage AI conversations tied to sessions, attach context, continue previous threads, or start new ones.
 * [Agent questions](/agents/local-agents/interacting-with-agents/agent-questions/) - Answer, skip, and configure clarifying questions the Agent asks during a conversation.
 * [Agent Context](/agents/local-agents/agent-context/) - Attach images, URLs, files, code blocks, and selections as context for your prompts.

--- a/src/content/docs/enterprise/getting-started/getting-started-developers.mdx
+++ b/src/content/docs/enterprise/getting-started/getting-started-developers.mdx
@@ -250,7 +250,7 @@ For common login, SSO, and access issues, see the [Enterprise FAQ](/enterprise/g
 
 Now that you're set up:
 
-* **Explore agent capabilities** - Learn about [agents in Warp](/agents/local-agents/overview/) and [cloud agents](/platform/)
+* **Explore agent capabilities** - Learn about [agents in Warp](/agents/getting-started/agents-in-warp/) and [cloud agents](/platform/)
 * **Contribute to team knowledge** - Add useful Workflows, Prompts, and Rules to your team's Warp Drive to compound productivity gains across your team
 * **Stay updated** - Check the [Warp changelog](/changelog/) for new features
 

--- a/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-claude-code.mdx
+++ b/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-claude-code.mdx
@@ -9,7 +9,7 @@ description: >-
 Claude Code is different from the other sources in this section: it's not a terminal emulator, it's a CLI agent that runs inside any terminal. Warp is an agentic development environment with a built-in [code editor](/code/code-editor/), [Code Review](/code/code-review/), [team collaboration](/knowledge-and-collaboration/warp-drive/), and [MCP](/agents/capabilities/mcp/) support — so you have two paths to choose from:
 
 * **[Using Claude Code inside Warp](#using-claude-code-inside-warp)** - you want to keep using Claude Code as your coding agent and run it in Warp's terminal.
-* **[Switching to Agent Mode from Claude Code](#switching-to-agent-mode-from-claude-code)** - you want to replace Claude Code with Warp's built-in [Agent Mode](/agents/local-agents/overview/).
+* **[Switching to Agent Mode from Claude Code](#switching-to-agent-mode-from-claude-code)** - you want to replace Claude Code with Warp's built-in [Agent Mode](/agents/getting-started/agents-in-warp/).
 
 ## Using Claude Code inside Warp
 
@@ -46,7 +46,7 @@ Claude Code's authentication (API key or Anthropic account) is handled by Claude
 If you're ready to replace Claude Code with Warp's built-in Agent, the core workflow is:
 
 1. Open a new tab in Warp.
-2. From terminal mode, press `⌘+Enter` (macOS) or `Ctrl+Shift+Enter` (Linux/Windows) to switch to [Agent Mode](/agents/local-agents/overview/).
+2. From terminal mode, press `⌘+Enter` (macOS) or `Ctrl+Shift+Enter` (Linux/Windows) to switch to [Agent Mode](/agents/local-agents/interacting-with-agents/terminal-and-agent-modes/).
 3. Describe what you want in natural language.
 
 Warp's Agent reads your codebase, runs commands, and edits files the same way Claude Code does.
@@ -88,4 +88,4 @@ Use this table to find the closest Warp equivalent for Claude Code concepts:
 | Tool definitions | [MCP](/agents/capabilities/mcp/) |
 | Resume conversation | Warp persists agent conversations per tab; pair with [tab configs](/terminal/windows/tab-configs/) to reopen the same project layout |
 
-For a deeper tour of Agent Mode, see [Coding in Warp](/getting-started/quickstart/coding-in-warp/) and the [Warp Agents docs](/agents/local-agents/overview/).
+For a deeper tour of Agent Mode, see [Coding in Warp](/getting-started/quickstart/coding-in-warp/) and [Agents in Warp](/agents/getting-started/agents-in-warp/).

--- a/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-cursor.mdx
+++ b/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-cursor.mdx
@@ -15,7 +15,7 @@ Warp doesn't have a one-click Cursor importer. Cursor is built on the VS Code co
 
 The fastest way to bring over your Cursor terminal setup is to ask Warp's Agent to translate your `settings.json` directly. Warp ships a [`settings.toml` file](/terminal/settings/) and a bundled `modify-settings` skill that lets the Agent read your existing config and write equivalent values into Warp's settings.
 
-1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/overview/) with `⌘+I` (macOS) or `Ctrl+I` (Linux/Windows).
+1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/interacting-with-agents/terminal-and-agent-modes/) with `⌘+I` (macOS) or `Ctrl+I` (Linux/Windows).
 2. Copy and paste this prompt into the Agent Mode input, then press `Enter`.
 
    > Read my Cursor `settings.json` (`~/Library/Application Support/Cursor/User/settings.json` on macOS) and port the equivalent terminal settings (font, cursor style, default profile) into my Warp `settings.toml` using the `modify-settings` skill. Show me a diff before applying.
@@ -34,7 +34,7 @@ Terminal settings in Cursor follow the same schema as VS Code. The migration ste
 
 Cursor's Composer and Agent features don't have a one-to-one migration path; they map to different Warp concepts.
 
-* **Composer / Agent** - In Cursor, these features map to Warp's [Agent Mode](/agents/local-agents/overview/). Start an Agent conversation in any tab.
+* **Composer / Agent** - In Cursor, these features map to Warp's [Agent Mode](/agents/getting-started/agents-in-warp/). Start an Agent conversation in any tab.
 * **Rules files** - Warp uses [Rules](/agents/capabilities/rules/) stored in Warp Drive or committed to your repo as `AGENTS.md` (or `WARP.md`). Run `/init` in Agent Mode to generate an `AGENTS.md`, or copy your `.cursorrules` content directly.
 * **MCP servers** - Warp supports MCP natively. See [MCP](/agents/capabilities/mcp/) for configuration.
 
@@ -53,7 +53,7 @@ Warp's [keyboard shortcuts](/getting-started/keyboard-shortcuts/) differ from Cu
 Keep Cursor as your editor for tight in-file AI assistance, and use Warp as the terminal you switch to for:
 
 * Long-running commands and SSH.
-* [Agent Mode](/agents/local-agents/overview/) conversations that execute commands, not just edit files.
+* [Agent Mode](/agents/getting-started/agents-in-warp/) conversations that execute commands, not just edit files.
 * [Code Review](/code/code-review/) for managing diffs.
 * [Warp Drive](/knowledge-and-collaboration/warp-drive/) for team knowledge.
 
@@ -67,8 +67,8 @@ Use this table to find Warp equivalents for Cursor features you might look for a
 
 | From Cursor | In Warp |
 | --- | --- |
-| Composer / Agent panel | [Agent Mode](/agents/local-agents/overview/) in any tab (toggle with `⌘+I` on macOS or `Ctrl+I` on Linux/Windows) |
-| Agent tabs | Multiple [agents in parallel](/agents/local-agents/overview/) across tabs |
+| Composer / Agent panel | [Agent Mode](/agents/local-agents/interacting-with-agents/terminal-and-agent-modes/) in any tab (toggle with `⌘+I` on macOS or `Ctrl+I` on Linux/Windows) |
+| Agent tabs | Multiple [agents in parallel](/agents/getting-started/agents-in-warp/) across tabs |
 | `.cursorrules` | `AGENTS.md` / `WARP.md` at the project root, picked up as a [Rule](/agents/capabilities/rules/) |
 | MCP servers | [MCP](/agents/capabilities/mcp/) |
 | Model choice per conversation | [Model selector](/agents/inference/model-choice/) |

--- a/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-ghostty.mdx
+++ b/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-ghostty.mdx
@@ -16,7 +16,7 @@ Warp doesn't have a one-click Ghostty importer. Because Ghostty stores its confi
 
 The fastest way to bring over your Ghostty setup is to ask Warp's Agent to translate your config directly. Warp ships a [`settings.toml` file](/terminal/settings/) and a bundled `modify-settings` skill that lets the Agent read your existing config and write equivalent values into Warp's settings, including translating your Ghostty theme into a Warp [custom theme](/terminal/appearance/custom-themes/).
 
-1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/overview/) with `⌘+I` (macOS) or `Ctrl+I` (Linux/Windows).
+1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/interacting-with-agents/terminal-and-agent-modes/) with `⌘+I` (macOS) or `Ctrl+I` (Linux/Windows).
 2. Paste this prompt into Agent Mode, then press `Enter`.
 
    > Read my Ghostty config at `~/.config/ghostty/config` and any referenced theme files in `~/.config/ghostty/themes/`. Port the equivalent settings (theme, font, keybindings, shell) into my Warp `settings.toml` using the `modify-settings` skill, and create a matching custom theme. Show me a diff before applying.
@@ -65,6 +65,6 @@ Use this table to find the closest Warp equivalent for Ghostty features you migh
 | Kitty graphics protocol | Image rendering for most common workflows (see [more features](/terminal/more-features/)) |
 | Shaders and custom visual effects | Not supported; closest: [size, opacity, and blurring](/terminal/appearance/size-opacity-blurring/) + [pane dimming](/terminal/appearance/pane-dimming/) |
 
-Beyond parity, Warp adds [Agent Mode](/agents/local-agents/overview/), [Code Review](/code/code-review/), and [Warp Drive](/knowledge-and-collaboration/warp-drive/) for AI-assisted development and team collaboration.
+Beyond parity, Warp adds [Agent Mode](/agents/getting-started/agents-in-warp/), [Code Review](/code/code-review/), and [Warp Drive](/knowledge-and-collaboration/warp-drive/) for AI-assisted development and team collaboration.
 
 For more on what you can configure, see [Customizing Warp](/getting-started/quickstart/customizing-warp/).

--- a/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-iterm2.mdx
+++ b/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-iterm2.mdx
@@ -36,7 +36,7 @@ To run the importer:
 
 If the importer doesn't pick up something you care about, such as a non-default profile, an unusual keybinding, or a specific setting, ask Warp's Agent to translate it directly. Warp ships a [`settings.toml` file](/terminal/settings/) and a bundled `modify-settings` skill that lets the Agent read your iTerm2 plist and write equivalent values into Warp's settings.
 
-1. In the Warp app, switch to [Agent Mode](/agents/local-agents/overview/) with `⌘+I`.
+1. In the Warp app, switch to [Agent Mode](/agents/local-agents/interacting-with-agents/terminal-and-agent-modes/) with `⌘+I`.
 2. Paste this prompt into Agent Mode, then press `Enter`.
 
    > Read my iTerm2 preferences with `defaults read com.googlecode.iterm2` and port any settings that the importer didn't cover (extra profiles, custom keybindings) into my Warp `settings.toml` using the `modify-settings` skill. Show me a diff before applying.

--- a/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-macos-terminal.mdx
+++ b/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-macos-terminal.mdx
@@ -15,7 +15,7 @@ Warp doesn't have a one-click Terminal.app importer. Because Terminal.app stores
 
 The fastest way to bring over a Terminal.app theme is to ask Warp's Agent to translate it directly. Warp ships a [`settings.toml` file](/terminal/settings/) and a bundled `modify-settings` skill that lets the Agent read your Terminal.app preferences and write equivalent values into Warp's settings, including creating a matching [custom theme](/terminal/appearance/custom-themes/).
 
-1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/overview/) with `⌘+I`.
+1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/interacting-with-agents/terminal-and-agent-modes/) with `⌘+I`.
 2. Paste this prompt into Agent Mode, then press `Enter`.
 
    > Read my Terminal.app preferences with `defaults read com.apple.Terminal` and port the active profile (theme, font, window size) into my Warp `settings.toml` using the `modify-settings` skill. Create a matching custom theme. Show me a diff before applying.
@@ -70,4 +70,4 @@ Most Terminal.app features have a Warp equivalent with additional capabilities o
 | Copy-on-select | **Settings** > **Features** > **Session** |
 | Inspector | [Command inspector](/terminal/editor/command-inspector/) (exit code, duration, working directory) |
 
-Beyond matching Terminal.app, Warp adds [Agent Mode](/agents/local-agents/overview/) for natural-language commands, [blocks](/terminal/blocks/) for structured command output, and [Warp Drive](/knowledge-and-collaboration/warp-drive/) for shared workflows. New to Warp? Start with the [Warp quickstart](/quickstart/).
+Beyond matching Terminal.app, Warp adds [Agent Mode](/agents/getting-started/agents-in-warp/) for natural-language commands, [blocks](/terminal/blocks/) for structured command output, and [Warp Drive](/knowledge-and-collaboration/warp-drive/) for shared workflows. New to Warp? Start with the [Warp quickstart](/quickstart/).

--- a/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-vs-code-terminal.mdx
+++ b/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-vs-code-terminal.mdx
@@ -29,7 +29,7 @@ Warp doesn't have a VS Code importer because it's a standalone application, not 
 
 The fastest way to bring over your VS Code terminal setup is to ask Warp's Agent to translate `settings.json` directly. Warp ships a [`settings.toml` file](/terminal/settings/) and a bundled `modify-settings` skill that lets the Agent read your existing config and write equivalent values into Warp's settings.
 
-1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/overview/) with `⌘+I` (macOS) or `Ctrl+I` (Linux/Windows).
+1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/interacting-with-agents/terminal-and-agent-modes/) with `⌘+I` (macOS) or `Ctrl+I` (Linux/Windows).
 2. Paste this prompt into Agent Mode, then press `Enter`.
 
    > Read my VS Code `settings.json` (`~/Library/Application Support/Code/User/settings.json` on macOS) and port the equivalent terminal settings (`terminal.integrated.*` keys) into my Warp `settings.toml` using the `modify-settings` skill. Show me a diff before applying.
@@ -62,7 +62,7 @@ Warp's [default keyboard shortcuts](/getting-started/keyboard-shortcuts/) are la
 
 Many developers keep VS Code as their editor and use Warp as the terminal they switch to for long-running commands, SSH sessions, or AI-assisted workflows. You don't need to change VS Code. Install Warp and open it when you want a richer terminal.
 
-VS Code's integrated terminal still works; use it for quick one-off commands, and jump to Warp when you need [blocks](/terminal/blocks/), [Agent Mode](/agents/local-agents/overview/), or [persistent sessions](/terminal/sessions/session-restoration/).
+VS Code's integrated terminal still works; use it for quick one-off commands, and jump to Warp when you need [blocks](/terminal/blocks/), [Agent Mode](/agents/getting-started/agents-in-warp/), or [persistent sessions](/terminal/sessions/session-restoration/).
 
 ### Replace VS Code with Warp
 

--- a/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-windows-terminal.mdx
+++ b/src/content/docs/getting-started/migrate-to-warp/migrate-to-warp-from-windows-terminal.mdx
@@ -19,7 +19,7 @@ Warp doesn't have a one-click Windows Terminal importer. Because Windows Termina
 
 The fastest way to bring over your Windows Terminal setup is to ask Warp's Agent to translate `settings.json` directly. Warp ships a [`settings.toml` file](/terminal/settings/) and a bundled `modify-settings` skill that lets the Agent read your existing config and write equivalent values into Warp's settings, including translating your color schemes into a Warp [custom theme](/terminal/appearance/custom-themes/).
 
-1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/overview/) with `Ctrl+I`.
+1. In the Warp app, open a new tab and switch to [Agent Mode](/agents/local-agents/interacting-with-agents/terminal-and-agent-modes/) with `Ctrl+I`.
 2. Paste this prompt into Agent Mode, then press `Enter`.
 
    > Read my Windows Terminal `settings.json` at `%LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json` and port the active profile and color scheme into my Warp `settings.toml` using the `modify-settings` skill. Create a matching custom theme. Show me a diff before applying.
@@ -73,4 +73,4 @@ Use this table to find Warp equivalents for Windows Terminal features you might 
 | Oh My Posh prompts | Keep using them; pick [Shell prompt (PS1)](/terminal/appearance/prompt/#custom-prompt) in Warp |
 | Quake mode | [Global hotkey](/terminal/windows/global-hotkey/) |
 
-Beyond Windows Terminal's feature set, Warp adds [Agent Mode](/agents/local-agents/overview/), [blocks](/terminal/blocks/), and [Warp Drive](/knowledge-and-collaboration/warp-drive/). See [Warp for Windows installation](/getting-started/quickstart/installation-and-setup/) if you haven't installed yet.
+Beyond Windows Terminal's feature set, Warp adds [Agent Mode](/agents/getting-started/agents-in-warp/), [blocks](/terminal/blocks/), and [Warp Drive](/knowledge-and-collaboration/warp-drive/). See [Warp for Windows installation](/getting-started/quickstart/installation-and-setup/) if you haven't installed yet.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -47,7 +47,7 @@ Real-time, interactive coding assistance alongside your terminal.
 
 You stay in control. Review changes, steer the agent mid-task, and approve actions before they execute.
 
-→ [Get started with agents in Warp](/agents/local-agents/overview/)
+→ [Get started with agents in Warp](/agents/getting-started/agents-in-warp/)
 
 ### In any terminal, with the Warp Agent CLI
 

--- a/src/content/docs/knowledge-and-collaboration/warp-drive/workflows.mdx
+++ b/src/content/docs/knowledge-and-collaboration/warp-drive/workflows.mdx
@@ -83,7 +83,7 @@ Once a workflow has been created, you can edit it at any time, as long as you ha
 
 #### AI autofill
 
-Workflows also have the option to use an [agent](/agents/local-agents/overview/) to automatically generate a title, descriptions, or parameters.
+Workflows also have the option to use an [agent](/agents/getting-started/agents-in-warp/) to automatically generate a title, descriptions, or parameters.
 
 * Create or edit a Workflow, in the edit view you should see the option to AutoFill.
 * Warp will fill in the fields based on the Workflow you're creating.

--- a/src/content/docs/platform/handoff/local-to-cloud.mdx
+++ b/src/content/docs/platform/handoff/local-to-cloud.mdx
@@ -33,7 +33,7 @@ If any changes fail to apply in the cloud run, the cloud agent reports which cha
 
 ## Prerequisites
 
-* **An active local conversation** - Have a [Warp Agent](/agents/local-agents/overview/) conversation open in Warp with the work you want to hand off.
+* **An active local conversation** - Have a [Warp Agent](/agents/getting-started/agents-in-warp/) conversation open in Warp with the work you want to hand off.
 * **A configured environment** - The cloud agent needs an [environment](/platform/environments/) that includes the same repositories you're working in locally. The environment's repos must match your local checkout so the workspace snapshot applies cleanly.
 * **Cloud conversation storage enabled** - In the Warp app, go to **Settings** > **Privacy** and turn on **Store AI conversations in the cloud** so the conversation can be forked. See [Cloud-synced conversations](/agents/local-agents/cloud-conversations/).
 * **Sufficient credits** - Cloud agent runs consume credits. See [Credits](/support-and-community/plans-and-billing/credits/) for how credit usage works, and [Access, billing, and identity](/platform/team-access-billing-and-identity/) for team-specific credit requirements.

--- a/src/content/docs/platform/managing-cloud-agents.mdx
+++ b/src/content/docs/platform/managing-cloud-agents.mdx
@@ -80,7 +80,7 @@ Each row represents a single item in the agents list (either an interactive conv
 
 Where the agent was launched from. Common sources include:
 
-* **Interactive:** an [agent conversation](/agents/local-agents/overview/) started in the Warp app
+* **Interactive:** an [agent conversation](/agents/getting-started/agents-in-warp/) started in the Warp app
 * **CLI**: a local run triggered by the [Oz CLI](/reference/cli/)
 * **API**: a run triggered by [Warp's API](/reference/api-and-sdk/)
 * **Slack / Linear**: runs triggered by [integrations](/platform/integrations/)

--- a/src/content/docs/platform/orchestration/index.mdx
+++ b/src/content/docs/platform/orchestration/index.mdx
@@ -27,7 +27,7 @@ Orchestrations today are exactly one level deep: a parent and its direct childre
 
 The parent and child don't have to run in the same place. Orchestration supports four combinations:
 
-* **Local → local** - a [Warp Agent](/agents/local-agents/overview/) conversation in the Warp app spawns child Warp Agent conversations on the same machine. Useful for trying orchestration patterns without spinning up cloud infrastructure.
+* **Local → local** - a [Warp Agent](/agents/getting-started/agents-in-warp/) conversation in the Warp app spawns child Warp Agent conversations on the same machine. Useful for trying orchestration patterns without spinning up cloud infrastructure.
 * **Local → cloud** - a local parent spawns one or more cloud children that run in [environments](/platform/environments/) on Warp-hosted or self-hosted infrastructure. The parent keeps working while children execute in parallel.
 * **Cloud → cloud** - a cloud parent spawns cloud children that each run in their own environment. This is the canonical pattern for review swarms, large fan-outs, and any orchestration triggered from Slack, Linear, a schedule, or the API.
 * **Cloud → cloud-local** - a cloud parent spawns children that run inside the parent's own cloud environment, rather than each child getting its own environment. Useful when children need to share state with the parent (a filesystem, a long-running process, a shell session) or when spinning up an environment per child would be wasteful.

--- a/src/content/docs/platform/overview.mdx
+++ b/src/content/docs/platform/overview.mdx
@@ -46,7 +46,7 @@ In practice: **triggers create tasks; tasks execute on a host (optionally in an 
 
 ### Oz CLI
 
-The [Oz CLI](/reference/cli/) is the **headless interface** for running agents in non-interactive mode. It's commonly used in CI, scripts, and server environments where there is no interactive UI. For interactive workflows, use the [agent](/agents/local-agents/overview/) embedded in Warp's desktop app.
+The [Oz CLI](/reference/cli/) is the **headless interface** for running agents in non-interactive mode. It's commonly used in CI, scripts, and server environments where there is no interactive UI. For interactive workflows, use the [agent](/agents/getting-started/agents-in-warp/) embedded in Warp's desktop app.
 
 A key property of the CLI is that it is **cloud-connected**. Even when an agent is started on a local machine or in CI, it reports progress to Warp’s servers. This enables team visibility, session sharing (where supported), and programmatic tracking through the API.
 

--- a/src/content/docs/support-and-community/plans-and-billing/credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/credits.mdx
@@ -49,7 +49,7 @@ You can view your total credit usage, along with other billing details, in **Set
 
 In addition to direct Agent conversations, the following features also consume credits:
 
-* [Generate](/agents/local-agents/overview/) helps you look up commands and suggestions as you type. As you refine your input, multiple credits may be used before you select a final suggestion.
+* [Generate](/agents/local-agents/generate/) helps you look up commands and suggestions as you type. As you refine your input, multiple credits may be used before you select a final suggestion.
 * [AI Autofill in Workflows](/knowledge-and-collaboration/warp-drive/workflows/#ai-autofill) counts as a credit each time it is run.
 
 :::tip

--- a/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
+++ b/src/content/docs/support-and-community/privacy-and-security/privacy.mdx
@@ -26,7 +26,7 @@ Warp collects high-level telemetry and usage data to discover product quality is
 If you haven't opted out of "Help improve Warp", we may collect:
 
 1. High level product usage and analytics data to analyze feature uptake and usage patterns. See the full list of tracked events in the [exhaustive telemetry table](/support-and-community/privacy-and-security/privacy/#exhaustive-telemetry-table) below. These are all high level metrics and do not include any user generated content.
-2. AI interactions and console inputs that power our [AI features](/agents/local-agents/overview/). Warp unconditionally applies [Secret Redaction](/support-and-community/privacy-and-security/secret-redaction/) in all AI interactions to ensure that any sensitive data is _never_ collected or sent to third parties.
+2. AI interactions and console inputs that power our [AI features](/agents/getting-started/agents-in-warp/). Warp unconditionally applies [Secret Redaction](/support-and-community/privacy-and-security/secret-redaction/) in all AI interactions to ensure that any sensitive data is _never_ collected or sent to third parties.
 
 :::note
 Telemetry must be enabled to use AI features on the Free plan, while paid plans can opt out at any time and continue using Warp, including AI.

--- a/src/content/docs/support-and-community/troubleshooting-and-support/known-issues.mdx
+++ b/src/content/docs/support-and-community/troubleshooting-and-support/known-issues.mdx
@@ -23,7 +23,7 @@ To enable Blocks over SSH, Warp uses an SSH Wrapper function; navigate to **Sett
 
 ### Online features don't work
 
-There is a known issue that can occur that causes online features to break ([Agent](/agents/local-agents/overview/), [Generate](/agents/local-agents/generate/), [Block Sharing](/terminal/blocks/block-sharing/), [Refer a Friend](/support-and-community/community/refer-a-friend/) ). This is due to the login token going stale, typically due to a password change, and can be resolved by the following steps:
+There is a known issue that can occur that causes online features to break ([Agent](/agents/getting-started/agents-in-warp/), [Generate](/agents/local-agents/generate/), [Block Sharing](/terminal/blocks/block-sharing/), [Refer a Friend](/support-and-community/community/refer-a-friend/) ). This is due to the login token going stale, typically due to a password change, and can be resolved by the following steps:
 
 <Tabs>
   <TabItem label="macOS">

--- a/src/content/docs/support-and-community/troubleshooting-and-support/using-warp-offline.mdx
+++ b/src/content/docs/support-and-community/troubleshooting-and-support/using-warp-offline.mdx
@@ -17,9 +17,9 @@ Warp is "Offline" when you aren't connected to the internet, or if you're blocki
 Warp’s cloud-based features which require an internet connection will not work in offline mode. Those features include:
 
 * [Warp Drive](/knowledge-and-collaboration/warp-drive/#using-warp-drive-offline) (Some files may be read-only in offline mode)
-* [Agent](/agents/local-agents/overview/)
+* [Agent](/agents/getting-started/agents-in-warp/)
   * [Agent Mode](/agents/local-agents/interacting-with-agents/)
-  * [Generate](/agents/local-agents/overview/)
+  * [Generate](/agents/local-agents/generate/)
   * [AI Autofill](/knowledge-and-collaboration/warp-drive/workflows/#warp-ai-autofill)
   * [Prompts](/knowledge-and-collaboration/warp-drive/prompts/)
   * [Active AI Recommendations](/agents/local-agents/active-ai/)


### PR DESCRIPTION
## Summary
Follow-up to [#486](https://github.com/warpdotdev/docs/pull/486), which deliberately deferred two content problems as out of scope. This picks up both, as two independently reviewable commits.

1. **Three pages competed as "here's the agent."** `agents/getting-started/agents-in-warp` becomes the single narrative intro; `agents/local-agents/overview` becomes the index for the Warp Agents group.
2. **The CLI conversations page re-explained app concepts from scratch.** It now links out to canonical pages and keeps only TUI-specific behavior.

No slug, path, or URL changes, so no redirects are needed. `vercel.json`, `src/sidebar.ts`, and `astro.config.mjs` are untouched.

## Note for reviewers: #497's cross-links were relocated, not reverted
[#497](https://github.com/warpdotdev/docs/pull/497) (an `aeo_crosslink_audit` run) added four AEO cross-links to the *From local to cloud* section of `agents-in-warp` — a section this PR removes. `agents-in-warp` is the **only page in the Agents tab** linking to `/platform/triggers/scheduled-agents/` and the unattended-agents guide, so deleting the section outright would have stranded both.

Both links moved into the new **Next steps** block. `/platform/managing-cloud-agents/` is still linked from the surviving *Managing agents* section, and `/platform/orchestration/` has six other inbound links from the Agents tab. Verified post-change: all four destinations still have at least one Agents-tab inbound link.

## Changes

### Commit 1 — collapse the competing intro pages

**`agents/getting-started/agents-in-warp.mdx`** (131 → 102 lines)
- Removed *The Warp Agent CLI*, *Third-party CLI agents*, and *From local to cloud*. The scope line added during #486 review already names all three with links, two screens above.
- Replaced the *Resources* list with a focused **Next steps** block that carries the two at-risk #497 links.
- Moved the global AI-disable / SOC 2 / Zero Data Retention `:::note` here from the overview page, where it was the only copy in the Agents tab.

**`agents/local-agents/overview.mdx`** (46 → 29 lines)
- Removed *AI in Warp*, the open-source paragraph (already on `/agents/`), and *Outside the Warp app*.
- Kept an orienting paragraph rather than reducing to a bare list: this page is the destination of roughly **60 legacy redirects** (`/warp-ai`, `/agent-mode`, `/ai-features`, `/generate`).
- `Agents in Warp` is now the first entry in the list, framed as the place to start.

**Inbound link retargeting (18 files)** — applied by category, not with a blanket replace:
- Procedural "switch to Agent Mode with `⌘+I`" steps in the 7 migration guides → `terminal-and-agent-modes`, which is what those steps actually describe.
- Conceptual "Agent Mode" / "AI features" references (privacy, known issues, offline, migration closers, enterprise onboarding, homepage, 4 platform pages, Warp Drive workflows) → `agents-in-warp`.
- Index-to-index links stay on `local-agents/overview`.
- Fixed two **pre-existing** mislinks where the word "Generate" pointed at the overview page instead of `/agents/local-agents/generate/` (`credits.mdx`, `using-warp-offline.mdx`).
- Updated stale anchor text `Local Agents` → `Using the Warp Agent` in `capabilities/index.mdx`, matching the #486 retitle.

Net effect: `local-agents/overview` goes from 33 inbound links to 4 (all index-to-index); `agents-in-warp` goes from 1 to 20 across 18 files.

### Commit 2 — link the CLI conversations page out to canonical pages

`agents/cli/agent-conversations.mdx` already used the right pattern in its *Task lists* and *Planning* sections. This extends it to the sections that were missing it:

- **Code diffs** → links to `Agent code diffs and review`.
- **Agent questions** → links to `Agent questions`, which documents the `Ask questions` permission.
- **Conversation persistence** → leads with the two CLI-only constraints, links sync/restore to `Cloud-synced conversations`.
- **Starting a new conversation** → keeps the slash commands, links follow-up-vs-fresh guidance to `Interacting with agents`.
- **Compacting context** → links the context-window explanation to the canonical section.

Unchanged because it is genuinely CLI-only: transcript rendering, tool-call display, thinking blocks, terminal text selection, `--resume`, and `/compact` itself. No other CLI page is touched, and `cli/reference.mdx` keeps its slash-command and flag tables — that feature-doc-vs-reference split is intentional, not duplication.

## Validation
- `npm run build` — 364 pages, no errors.
- Internal link check — 3,483 links, **0 broken** (baseline on `origin/main` was also 0).
- `style_lint --all` — **1460 → 1457** issues. No net-new; the 3 resolved were hardcoded `Oz web app` / `oz.warp.dev` / `Oz CLI` strings that left with the Resources section.
- Confirmed no page was orphaned by the removed links.
- `trunk check` not run: Trunk CLI is not installed in this environment.

## Unverified claims
None — this PR only removes, relocates, and re-points existing prose. It introduces no new UI labels, Settings paths, CLI flags, permission defaults, or plan-eligibility claims. The one retained UI path (**Settings** > **Agents** > **Warp Agent**, in the moved AI-disable note) is carried over verbatim from `local-agents/overview.mdx`.

Co-Authored-By: Warp Agent <agent@warp.dev>
