### PR TITLE
docs: invite readers to edit pages or open issues in place of feedback widget

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ npm run dev
 
 Open [http://localhost:4321](http://localhost:4321) to preview the docs site.
 
-The site runs without local environment variables. To enable optional integrations like the Ask AI button and the "Was this helpful?" widget, copy `.env.example` to `.env` and fill in the public values:
+The site runs without local environment variables. To enable optional integrations like the Ask AI button, copy `.env.example` to `.env` and fill in the public values:
 
 ```bash
 cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Open [http://localhost:4321](http://localhost:4321) to preview the docs site loc
 
 ## Environment variables
 
-The site runs without local environment variables. To enable optional integrations like the Ask AI button and the "Was this helpful?" widget, copy `.env.example` to `.env` and fill in the public values:
+The site runs without local environment variables. To enable optional integrations like the Ask AI button, copy `.env.example` to `.env` and fill in the public values:
 
 ```bash
 cp .env.example .env

--- a/src/components/DocsFeedbackLinks.astro
+++ b/src/components/DocsFeedbackLinks.astro
@@ -9,9 +9,10 @@
  *     (.github/ISSUE_TEMPLATE/CONTENT.yml) with the page URL already in
  *     the "Page or pages affected" field.
  *
- * `editUrl` is optional: pages that don't map to a single source file (or
- * where the caller wants to point at a different source, e.g. the
- * generated /api reference) can omit it and only the issue link renders.
+ * `editUrl` is optional: pages that don't map to a single editable source
+ * file can omit it and render only the issue link. Pages backed by a
+ * non-MDX source, such as the generated /api reference, can instead pass
+ * that source's own GitHub edit URL explicitly (see `pages/api.astro`).
  */
 interface Props {
   /** Absolute GitHub URL to edit the page's source file (opens a PR). */

--- a/src/components/DocsFeedbackLinks.astro
+++ b/src/components/DocsFeedbackLinks.astro
@@ -1,0 +1,61 @@
+---
+/**
+ * Invites readers to fix or report a problem with a page directly on
+ * GitHub, in place of the "Was this helpful?" PushFeedback widget removed
+ * in #100 (see `FeedbackFooter.astro`). Warp Docs is open source (MIT,
+ * warpdotdev/docs), so every page can point straight at:
+ *   - an "Edit this page" GitHub edit-in-place flow (opens a PR), and
+ *   - a pre-filled "Docs content issue" template
+ *     (.github/ISSUE_TEMPLATE/CONTENT.yml) with the page URL already in
+ *     the "Page or pages affected" field.
+ *
+ * `editUrl` is optional: pages that don't map to a single source file (or
+ * where the caller wants to point at a different source, e.g. the
+ * generated /api reference) can omit it and only the issue link renders.
+ */
+interface Props {
+  /** Absolute GitHub URL to edit the page's source file (opens a PR). */
+  editUrl?: string;
+  /** Absolute URL of the current page, pre-filled into the issue template. */
+  pageUrl: string;
+  /** Extra class(es) so callers can control placement (e.g. fixed position on /api). */
+  class?: string;
+}
+
+const { editUrl, pageUrl, class: className } = Astro.props;
+
+const issueUrl = new URL('https://github.com/warpdotdev/docs/issues/new');
+issueUrl.searchParams.set('template', 'CONTENT.yml');
+issueUrl.searchParams.set('pages', pageUrl);
+---
+
+<p class:list={['docs-feedback-links', className]}>
+  {
+    editUrl ? (
+      <>
+        See something wrong? <a href={editUrl}>Edit this page</a> or{' '}
+        <a href={issueUrl.toString()}>open an issue</a>.
+      </>
+    ) : (
+      <>
+        See something wrong? <a href={issueUrl.toString()}>Open an issue</a>.
+      </>
+    )
+  }
+</p>
+
+<style>
+  @layer starlight.core {
+    .docs-feedback-links {
+      margin: 0;
+      color: var(--sl-color-gray-3);
+      font-size: var(--sl-text-sm);
+    }
+    .docs-feedback-links a {
+      color: var(--sl-color-gray-2);
+    }
+    .docs-feedback-links a:hover {
+      color: var(--sl-color-white);
+    }
+  }
+</style>

--- a/src/components/FeedbackFooter.astro
+++ b/src/components/FeedbackFooter.astro
@@ -1,11 +1,18 @@
 ---
-// Custom footer: drops EditLink + LastUpdated from Starlight's default
-// footer and keeps Pagination + the Starlight credits link.
+// Custom footer: drops Starlight's default EditLink + LastUpdated, replacing
+// EditLink with DocsFeedbackLinks (an "Edit this page" / "open an issue"
+// CTA, since Warp Docs is open source) and keeps Pagination + the Starlight
+// credits link.
 import Pagination from 'virtual:starlight/components/Pagination';
 import config from 'virtual:starlight/user-config';
+import DocsFeedbackLinks from './DocsFeedbackLinks.astro';
+
+const { editUrl } = Astro.locals.starlightRoute;
+const pageUrl = Astro.url.href;
 ---
 
 <footer class="sl-flex">
+  <DocsFeedbackLinks editUrl={editUrl} pageUrl={pageUrl} />
   <Pagination />
 
   {

--- a/src/components/FeedbackFooter.astro
+++ b/src/components/FeedbackFooter.astro
@@ -7,12 +7,15 @@ import Pagination from 'virtual:starlight/components/Pagination';
 import config from 'virtual:starlight/user-config';
 import DocsFeedbackLinks from './DocsFeedbackLinks.astro';
 
+// `starlightRoute.editUrl` is typed as `URL | undefined`; DocsFeedbackLinks
+// expects a plain string so it can pass the same value through untouched
+// for both Starlight and non-Starlight (e.g. /api) callers.
 const { editUrl } = Astro.locals.starlightRoute;
 const pageUrl = Astro.url.href;
 ---
 
 <footer class="sl-flex">
-  <DocsFeedbackLinks editUrl={editUrl} pageUrl={pageUrl} />
+  <DocsFeedbackLinks editUrl={editUrl?.toString()} pageUrl={pageUrl} />
   <Pagination />
 
   {

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -13,6 +13,7 @@
 import fs from 'node:fs';
 import { parse } from 'yaml';
 import WarpTopbar from '../components/WarpTopbar.astro';
+import DocsFeedbackLinks from '../components/DocsFeedbackLinks.astro';
 const yamlContent = fs.readFileSync('developers/agent-api-openapi.yaml', 'utf-8');
 const specObject = parse(yamlContent);
 const specJson = JSON.stringify(specObject);
@@ -391,5 +392,64 @@ const specBaseUrl = (specObject.servers as Array<{ url?: string }> | undefined)?
       })();
     </script>
     <script is:inline src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.57.1" crossorigin="anonymous"></script>
+    <div class="api-feedback-links">
+      <DocsFeedbackLinks
+        editUrl="https://github.com/warpdotdev/docs/edit/main/developers/agent-api-openapi.yaml"
+        pageUrl="https://docs.warp.dev/api/"
+      />
+    </div>
+    <style is:inline>
+      /* `.warp-topbar*` rules ship with `<WarpTopbar />` itself; only the
+         /api-specific feedback CTA styling lives here.
+
+         Anchored to the bottom-RIGHT so the CTA sits where users naturally
+         look for inline page actions (matches the removed PushFeedback
+         widget's placement). Scalar's Shell client picker / dark-mode
+         toggle live inside the operations column rather than fixed to the
+         viewport, so the two don't actually collide at this z-index.
+
+         `.docs-feedback-links` comes from `<DocsFeedbackLinks />`; its own
+         scoped styles use Starlight's `--sl-*` tokens, which aren't defined
+         on this standalone Scalar page, so we override color/size here with
+         a higher-specificity descendant selector and Scalar's `--scalar-*`
+         tokens instead. */
+      .api-feedback-links {
+        position: fixed;
+        bottom: 1.25rem;
+        right: 1.25rem;
+        max-width: min(20rem, calc(100vw - 2.5rem));
+        padding: 0.5625rem 0.875rem;
+        border-radius: 0.625rem;
+        background: var(--scalar-background-2);
+        border: 1px solid var(--scalar-border-color);
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18), 0 1px 2px rgba(0, 0, 0, 0.12);
+        z-index: 1000;
+      }
+      .light-mode .api-feedback-links {
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+      }
+      .api-feedback-links .docs-feedback-links {
+        color: var(--scalar-color-2);
+        font-size: 0.8125rem;
+        font-family: var(--scalar-font, 'Inter', sans-serif);
+        line-height: 1.4;
+      }
+      .api-feedback-links .docs-feedback-links a {
+        color: var(--scalar-color-accent);
+      }
+      .api-feedback-links .docs-feedback-links a:hover {
+        color: var(--scalar-color-1);
+      }
+      @media (max-width: 640px) {
+        .api-feedback-links {
+          bottom: 1rem;
+          right: 1rem;
+          padding: 0.5rem 0.75rem;
+        }
+        .api-feedback-links .docs-feedback-links {
+          font-size: 0.75rem;
+        }
+      }
+    </style>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Warp Docs is open source, but until now no page on docs.warp.dev invited readers to fix or report a problem directly on GitHub. The former "Was this helpful?" PushFeedback widget was removed in #100 (no team plan, sparse submissions), leaving that spot empty. This PR replaces it with a lightweight, no-dependency CTA: "See something wrong? Edit this page or open an issue."

## Changes

### src/components/DocsFeedbackLinks.astro (new)
- Shared component rendering "See something wrong? Edit this page or open an issue."
- "Edit this page" uses Starlight's already-configured `editLink` to open a GitHub edit-in-place/PR flow for the page's source file.
- "Open an issue" links to the existing `.github/ISSUE_TEMPLATE/CONTENT.yml` template with the current page's URL pre-filled into the "Page or pages affected" field.

### src/components/FeedbackFooter.astro
- Renders `DocsFeedbackLinks` above pagination on every Starlight page, in the same footer slot the removed PushFeedback widget and Starlight's default `EditLink` used to occupy.

### src/pages/api.astro
- Adds the same CTA as a fixed bottom-right pill on the standalone `/api` Scalar reference page, matching the removed widget's placement and using the page's `--scalar-*` theme tokens. The edit link points at `developers/agent-api-openapi.yaml`, the actual source for that page's content.

### README.md, CONTRIBUTING.md
- Removed stale references to the "Was this helpful?" widget in the environment variables section (it was already fully removed in #100, but these docs weren't updated).

## Unverified claims
None — all links (editLink base URL, issue template name/field IDs) were verified against existing repo config and `.github/ISSUE_TEMPLATE/CONTENT.yml`.

## Additional context
Verified with `npm run build` (364 pages) and by inspecting the rendered HTML for both a regular docs page and `/api`, confirming the edit link and pre-filled issue link render correctly.

Co-Authored-By: Warp Agent <agent@warp.dev>



<!-- oz:computer-use-videos start -->
### Computer-use video recordings

[![Visit a regular Starlight docs page, show and inspect the footer feedback links (Edit this page / open an issue), then visit /api and inspect the floating feedback CTA's edit and issue link destinations.](https://staging.warp.dev/api/v1/agent/artifacts/019ff221-24b3-75c6-a51d-cd89a355266d/download)](https://oz.staging.warp.dev/artifacts/019ff221-20bc-7b74-b48e-a3be738d9c17)
**Docs feedback CTA inspection**: Visit a regular Starlight docs page, show and inspect the footer feedback links (Edit this page / open an issue), then visit /api and inspect the floating feedback CTA's edit and issue link destinations.
<!-- oz:computer-use-videos end -->

<!-- oz:computer-use-screenshots start -->
<details>
<summary>Computer-use screenshots (3)</summary>

![Regular Starlight docs page (block-basics) footer showing the feedback CTA "See something wrong? Edit this page or open an issue." above the Previous/Next nav.](https://staging.warp.dev/api/v1/agent/artifacts/019ff21f-6937-7091-ae4d-2c3167cdcfc6/download)
Regular Starlight docs page (block-basics) footer showing the feedback CTA "See something wrong? Edit this page or open an issue." above the Previous/Next nav.

![/api Scalar page with floating feedback CTA (bottom-right); status bar shows the Edit this page link destination pointing to the OpenAPI YAML source.](https://staging.warp.dev/api/v1/agent/artifacts/019ff220-9d1f-71ca-b1a5-581b05323597/download)
/api Scalar page with floating feedback CTA (bottom-right); status bar shows the Edit this page link destination pointing to the OpenAPI YAML source.

![/api floating CTA with status bar showing the open-an-issue link, whose pages= prefill points to the production URL docs.warp.dev/api/.](https://staging.warp.dev/api/v1/agent/artifacts/019ff221-0acd-7b81-a619-9f4be88e8ee4/download)
/api floating CTA with status bar showing the open-an-issue link, whose pages= prefill points to the production URL docs.warp.dev/api/.

</details>
<!-- oz:computer-use-screenshots end -->
