### PR TITLE
docs: match Slack install steps to Oz web app UI (Connect button)

### DIFF
--- a/src/content/docs/platform/integrations/slack.mdx
+++ b/src/content/docs/platform/integrations/slack.mdx
@@ -13,11 +13,10 @@ The Slack integration lets your team trigger cloud agents directly from Slack co
 
 #### Installation
 
-1. Log in to the [Oz web app](https://oz.warp.dev).
-2. Go to **Integrations** and select **Slack**.
-3. Click **Add to Slack**. You'll be prompted to install the Warp app into your Slack workspace.
-4. If you haven't yet, create an [environment](/platform/environments/) defining the repos, Docker image, and setup commands agents should use.
-5. Start using Warp in Slack by mentioning **@Warp** with a task.
+1. Log in to the [Oz web app](https://oz.warp.dev) and go to the [Integrations page](https://oz.warp.dev/integrations).
+2. Click **Connect** next to **Slack**. You'll be prompted to install the Warp app into your Slack workspace.
+3. After installing, you're returned to the Integrations page to finish setup: choose the [environment](/platform/environments/) agents should use, which defines the repos, Docker image, and setup commands.
+4. Start using Warp in Slack by mentioning **@Warp** with a task.
 
 Alternatively, install via the [Oz CLI](/reference/cli/):
 


### PR DESCRIPTION
## Summary
Follow-up to #509, which was merged just before this commit landed on the branch. Corrects the Slack install steps to match the actual Oz web app UI.

## Changes

### src/content/docs/platform/integrations/slack.mdx
- Install steps now link directly to oz.warp.dev/integrations and use the real button label **Connect** (there is no "Add to Slack" button)
- Post-install step reflects the finish-setup flow where the user chooses the environment on return to the Integrations page

## Unverified claims
None — button label and flow verified against `client/packages/agents/src/components/IntegrationList/index.tsx` in warp-server.

Co-Authored-By: Oz <oz-agent@warp.dev>
