### PR TITLE
docs(factories): document Slack integration

### DIFF
--- a/src/content/docs/factories/integrations/slack.mdx
+++ b/src/content/docs/factories/integrations/slack.mdx
@@ -28,6 +28,8 @@ If you select Slack while creating a factory, Warp tries to install the factory'
 
 To try it out, mention the app in a channel or send it a direct message. The app reacts with the eyes emoji (👀) to show it accepted the request.
 
+The app is the factory's persona in Slack: it carries the factory's name and avatar, and it stays in sync when you rename the factory. If your team runs several factories, each one appears in Slack as its own app, so a channel can host more than one factory and you choose which one to mention.
+
 ## Start and continue work from Slack
 
 | Slack activity                         | Context used by the factory                                             | Slack output                                                                           |

--- a/src/content/docs/factories/integrations/slack.mdx
+++ b/src/content/docs/factories/integrations/slack.mdx
@@ -18,7 +18,7 @@ Installing the app grants the Slack permissions shown on the authorization scree
 
 ## Connect the factory
 
-If you select Slack while creating a factory, Warp tries to install the factory's Slack app automatically once the factory is created. If the installation can't complete (for example, because your workspace requires administrator approval), the factory is still created. Click **Add to Slack** to finish connecting.
+If you select Slack while creating a factory, Warp installs the factory's Slack app automatically. If the installation can't complete (for example, because your workspace requires administrator approval), click **Add to Slack** to finish connecting.
 
 1. In factory setup, go to **Add your Factory to your team**.
 2. In the **Slack** row, click **Add to Slack**.
@@ -47,16 +47,16 @@ To start work with a mention or direct message, your Slack account must be linke
 
 Automations don't run as a requester: they run as the factory agent selected under **Agents**. An automation's conversation and author filters only decide which events start work; they don't change what the Slack app is authorized to access or the credentials the work runs with.
 
-## Configure Slack automations
+## Configure factory automations for Slack
 
-Use an automation to start work from Slack activity automatically, without anyone mentioning the app. For example, an automation can act on every message posted in a triage channel or on a specific emoji reaction.
+Use a factory automation to start work from Slack activity automatically, without anyone mentioning the app. For example, an automation can act on every message posted in a triage channel or on a specific emoji reaction.
 
 1. In the factory's control room, open **Automations**, then create or edit an automation.
 2. Under **Triggers**, click **Add trigger** > **Slack**, then choose an event.
 3. Select the conversations and people that the event must match. Click **More filters** to add the event's available content filters.
 4. Choose the receiving agent under **Agents**, add any **Additional instructions**, then click **Save**.
 
-Slack automations support these events:
+Slack triggers support these events:
 
 - **App mentioned** - Filter by joined conversations, authors, and keywords.
 - **Direct message received** - Filter by direct-message conversations, authors, and keywords.
@@ -66,7 +66,7 @@ Slack automations support these events:
 
 The **Conversations** picker only shows conversations the factory's app has joined. If a channel is missing, invite the app to it; for direct messages, send the app a DM first. Then refresh the automation editor.
 
-Avoid pointing **App mentioned** and **Message posted in channel** triggers at the same conversations. A channel message that mentions the app matches both triggers and starts two runs.
+A single Slack message can match more than one automation. For example, if one automation triggers on **App mentioned** and another triggers on **Message posted in channel** in the same channel, a channel message that mentions the app starts two separate runs, one for each automation. To avoid duplicate runs, don't point both triggers at the same channel.
 
 ## Follow work and review outputs
 

--- a/src/content/docs/factories/integrations/slack.mdx
+++ b/src/content/docs/factories/integrations/slack.mdx
@@ -1,24 +1,24 @@
 ---
 title: Connect a factory to Slack
 description: >-
-  Connect a factory to Slack so mentions, direct messages, and automation
-  events create work and return results to the source conversation.
+  Connect a factory to Slack so your team can start work with mentions,
+  direct messages, and automations, and get results back in the same thread.
 sidebar:
   label: "Slack"
 topic: factories
 ---
 
-Connect a factory to Slack so conversations become work in a dedicated app that preserves source-thread context and posts results back.
+Connect a factory to Slack so your team can send it work without leaving their conversations. Each factory gets its own dedicated Slack app: mention the app in a channel or send it a direct message, and the factory picks up the request with the conversation as context, then posts progress and results back into the same thread. You can also set up automations that start work from Slack events without a mention.
 
 ## Prerequisites and authorization
 
 You need permission to update the factory and install apps in the target Slack workspace. Workspace policy can require administrator approval.
 
-Installation grants the Slack access shown during authorization. Automation filters route received events; they do not reduce app permissions. For workspace installation and removal behavior, see the [Slack platform integration](../../platform/integrations/slack).
+Installing the app grants the Slack permissions shown on the authorization screen. Filters on automations only control which events start work; they don't limit what the app can access. For workspace-level installation and removal behavior, see the [Slack platform integration](../../platform/integrations/slack).
 
 ## Connect the factory
 
-When you connect Slack during factory creation, Warp attempts to install the dedicated app after creation when the required user and workspace authorization are available. If installation cannot complete, factory creation still succeeds; use **Add to Slack** to finish setup.
+If you select Slack while creating a factory, Warp tries to install the factory's Slack app automatically once the factory is created. If the installation can't complete (for example, because your workspace requires administrator approval), the factory is still created. Click **Add to Slack** to finish connecting.
 
 1. In factory setup, go to **Add your Factory to your team**.
 2. In the **Slack** row, click **Add to Slack**.
@@ -26,28 +26,28 @@ When you connect Slack during factory creation, Warp attempts to install the ded
 4. Return to factory setup and confirm that **Slack** shows **Connected**.
 5. Invite the factory's app to each channel where it will receive requests. Private channels require an invitation.
 
-Mention the app in a channel or send it a direct message. An eyes reaction acknowledges accepted requests.
+To try it out, mention the app in a channel or send it a direct message. The app reacts with the eyes emoji (👀) to show it accepted the request.
 
-## Slack intake and continuity
+## Start and continue work from Slack
 
 | Slack activity                         | Context used by the factory                                             | Slack output                                                                           |
 | -------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Mention the app in a channel or thread | Triggering message, available thread history, and supported attachments | Acknowledgment, status, final summary, and available run, issue, or pull request links |
-| Send the app a direct message          | Direct-message conversation and supported attachments                   | Acknowledgment, status, and available artifact links                                   |
-| Reply in an existing factory thread    | Existing work item and the new reply                                    | A follow-up on the same workstream rather than a new work item                         |
-| Match a Slack automation               | Event details plus the automation's agent and instructions              | A configured factory run with results returned to the source when supported            |
+| Mention the app in a channel or thread | The triggering message, available thread history, and supported attachments | An acknowledgment, progress updates, a final summary, and links to the run, issue, or pull request when available |
+| Send the app a direct message          | The direct-message conversation and supported attachments                   | An acknowledgment, progress updates, and links to results when available               |
+| Reply in an existing factory thread    | The existing work item and your reply                                       | A follow-up on the existing work item instead of new work                              |
+| Slack activity matches an automation   | The event details plus the automation's agent and instructions              | A factory run, with results posted back to the source conversation when supported      |
 
-A plain thread reply continues work only after the thread has an existing factory work item. Start a new channel request by mentioning the app. When Slack files are supported, the factory includes them with the initial request or follow-up; files that cannot be included do not prevent the text request from continuing.
+A plain reply in a thread continues work only if that thread already has a factory work item; to start new work in a channel, mention the app. You can attach files to a request or a follow-up. The factory includes the files it supports, and a file it can't include doesn't stop the text of your request from going through.
 
-## Requester and execution identity
+## Who can start work
 
-People who start work through a mention or direct message must link their Slack identity to an active member of the factory's Warp team. Without that link, the app prompts the requester to connect an account instead of starting work.
+To start work with a mention or direct message, your Slack account must be linked to an active member of the factory's Warp team. If it isn't, the app prompts you to connect an account instead of starting work.
 
-Background event automations run as the factory agent selected under **Agents**. Conversation and author filters admit matching events; they do not change the Slack app's authorization or execution credential scope.
+Automations don't run as a requester: they run as the factory agent selected under **Agents**. An automation's conversation and author filters only decide which events start work; they don't change what the Slack app is authorized to access or the credentials the work runs with.
 
 ## Configure Slack automations
 
-Use an automation when Slack activity must start work without someone explicitly mentioning the app.
+Use an automation to start work from Slack activity automatically, without anyone mentioning the app. For example, an automation can act on every message posted in a triage channel or on a specific emoji reaction.
 
 1. In the factory's control room, open **Automations**, then create or edit an automation.
 2. Under **Triggers**, click **Add trigger** > **Slack**, then choose an event.
@@ -62,23 +62,23 @@ Slack automations support these events:
 - **Reaction added** - Filter by conversations, reactors, keywords, emoji, and reacted-message authors.
 - **Member joined channel** - Filter by conversations and members.
 
-Only conversations the factory's app has joined appear in the **Conversations** picker. Invite the app to a missing channel, or message it to establish a direct-message conversation, then refresh the automation editor.
+The **Conversations** picker only shows conversations the factory's app has joined. If a channel is missing, invite the app to it; for direct messages, send the app a DM first. Then refresh the automation editor.
 
-Avoid overlapping **App mentioned** and **Message posted in channel** triggers for the same conversations. A mentioned channel message can match both triggers and start two runs.
+Avoid pointing **App mentioned** and **Message posted in channel** triggers at the same conversations. A channel message that mentions the app matches both triggers and starts two runs.
 
 ## Follow work and review outputs
 
-The Slack thread remains the continuity point for the work item. Reply in the thread to add information or supported attachments while work is active or to continue the same workstream later. The factory posts progress and the final response into that thread.
+The Slack thread where work started is also where you follow it: the factory posts progress and the final response there. Reply in the thread to add information or attachments while work is active, or to pick the same work item back up later.
 
-Open the app's **Home** tab to view your factory tasks. App Home groups tasks by Factory task stage — Triage, Planning, Building, Reviewing, Completed, and Cancelled — and supports stage and date filters. Each task links back to the Slack thread, factory run, issue, or pull request when the link is available.
+For an overview of your factory tasks, open the app's **Home** tab in Slack. It groups tasks by stage (Triage, Planning, Building, Reviewing, Completed, and Cancelled), offers stage and date filters, and links each task back to its Slack thread, factory run, issue, or pull request when available.
 
-A factory can create an issue, branch, or pull request, but repository policy still controls review and merge. Slack installation permissions and factory routing do not replace required human review.
+A factory can create issues, branches, and pull requests, but your repository's review and merge rules still apply. Work that starts in Slack doesn't bypass required human review.
 
 ## Troubleshooting and reconnection
 
-- **The app does not acknowledge a request** - Confirm the Slack row shows **Connected**, mention the correct factory app, and invite it to the channel.
+- **The app doesn't acknowledge a request** - Confirm the **Slack** row in factory setup shows **Connected**, check that you mentioned that factory's app, and invite the app to the channel.
 - **A channel is missing from an automation** - Invite the app to that channel, then reload the **Conversations** picker.
 - **Installation is pending** - Ask a Slack workspace administrator to approve the app, then finish the installation.
 - **Two runs start for one mention** - Remove or narrow overlapping app-mention and channel-message triggers.
 
-Removing the app in Slack stops new Slack intake for that factory. Return to factory setup and use **Add to Slack** to reconnect it. Deleting the factory also removes its dedicated Slack connection. Next, review other intake paths in [Connect your factory](../connect-your-factory).
+Removing the app from your Slack workspace stops new requests from Slack for that factory; to reconnect it, return to factory setup and click **Add to Slack** again. Deleting the factory also removes its Slack connection. To route work into the factory from other tools, see [Connect your factory](../connect-your-factory).

--- a/src/content/docs/factories/integrations/slack.mdx
+++ b/src/content/docs/factories/integrations/slack.mdx
@@ -1,9 +1,84 @@
 ---
-title: Slack integration
+title: Connect a factory to Slack
 description: >-
-  Slack integration documentation for Warp Factories will be added in a follow-up PR.
+  Connect a factory to Slack so mentions, direct messages, and automation
+  events create work and return results to the source conversation.
 sidebar:
   label: "Slack"
+topic: factories
 ---
 
-Slack integration documentation for Warp Factories will land in a follow-up PR.
+Connect a factory to Slack so conversations become work in a dedicated app that preserves source-thread context and posts results back.
+
+## Prerequisites and authorization
+
+You need permission to update the factory and install apps in the target Slack workspace. Workspace policy can require administrator approval.
+
+Installation grants the Slack access shown during authorization. Automation filters route received events; they do not reduce app permissions. For workspace installation and removal behavior, see the [Slack platform integration](../../platform/integrations/slack).
+
+## Connect the factory
+
+When you connect Slack during factory creation, Warp attempts to install the dedicated app after creation when the required user and workspace authorization are available. If installation cannot complete, factory creation still succeeds; use **Add to Slack** to finish setup.
+
+1. In factory setup, go to **Add your Factory to your team**.
+2. In the **Slack** row, click **Add to Slack**.
+3. Choose the target workspace and approve access. If Slack requires administrator approval, finish installation after approval.
+4. Return to factory setup and confirm that **Slack** shows **Connected**.
+5. Invite the factory's app to each channel where it will receive requests. Private channels require an invitation.
+
+Mention the app in a channel or send it a direct message. An eyes reaction acknowledges accepted requests.
+
+## Slack intake and continuity
+
+| Slack activity                         | Context used by the factory                                             | Slack output                                                                           |
+| -------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Mention the app in a channel or thread | Triggering message, available thread history, and supported attachments | Acknowledgment, status, final summary, and available run, issue, or pull request links |
+| Send the app a direct message          | Direct-message conversation and supported attachments                   | Acknowledgment, status, and available artifact links                                   |
+| Reply in an existing factory thread    | Existing work item and the new reply                                    | A follow-up on the same workstream rather than a new work item                         |
+| Match a Slack automation               | Event details plus the automation's agent and instructions              | A configured factory run with results returned to the source when supported            |
+
+A plain thread reply continues work only after the thread has an existing factory work item. Start a new channel request by mentioning the app. When Slack files are supported, the factory includes them with the initial request or follow-up; files that cannot be included do not prevent the text request from continuing.
+
+## Requester and execution identity
+
+People who start work through a mention or direct message must link their Slack identity to an active member of the factory's Warp team. Without that link, the app prompts the requester to connect an account instead of starting work.
+
+Background event automations run as the factory agent selected under **Agents**. Conversation and author filters admit matching events; they do not change the Slack app's authorization or execution credential scope.
+
+## Configure Slack automations
+
+Use an automation when Slack activity must start work without someone explicitly mentioning the app.
+
+1. In the factory's control room, open **Automations**, then create or edit an automation.
+2. Under **Triggers**, click **Add trigger** > **Slack**, then choose an event.
+3. Select the conversations and people that the event must match. Click **More filters** to add the event's available content filters.
+4. Choose the receiving agent under **Agents**, add any **Additional instructions**, then click **Save**.
+
+Slack automations support these events:
+
+- **App mentioned** - Filter by joined conversations, authors, and keywords.
+- **Direct message received** - Filter by direct-message conversations, authors, and keywords.
+- **Message posted in channel** - Filter by joined conversations, authors, and keywords.
+- **Reaction added** - Filter by conversations, reactors, keywords, emoji, and reacted-message authors.
+- **Member joined channel** - Filter by conversations and members.
+
+Only conversations the factory's app has joined appear in the **Conversations** picker. Invite the app to a missing channel, or message it to establish a direct-message conversation, then refresh the automation editor.
+
+Avoid overlapping **App mentioned** and **Message posted in channel** triggers for the same conversations. A mentioned channel message can match both triggers and start two runs.
+
+## Follow work and review outputs
+
+The Slack thread remains the continuity point for the work item. Reply in the thread to add information or supported attachments while work is active or to continue the same workstream later. The factory posts progress and the final response into that thread.
+
+Open the app's **Home** tab to view your factory tasks. App Home groups tasks by Factory task stage — Triage, Planning, Building, Reviewing, Completed, and Cancelled — and supports stage and date filters. Each task links back to the Slack thread, factory run, issue, or pull request when the link is available.
+
+A factory can create an issue, branch, or pull request, but repository policy still controls review and merge. Slack installation permissions and factory routing do not replace required human review.
+
+## Troubleshooting and reconnection
+
+- **The app does not acknowledge a request** - Confirm the Slack row shows **Connected**, mention the correct factory app, and invite it to the channel.
+- **A channel is missing from an automation** - Invite the app to that channel, then reload the **Conversations** picker.
+- **Installation is pending** - Ask a Slack workspace administrator to approve the app, then finish the installation.
+- **Two runs start for one mention** - Remove or narrow overlapping app-mention and channel-message triggers.
+
+Removing the app in Slack stops new Slack intake for that factory. Return to factory setup and use **Add to Slack** to reconnect it. Deleting the factory also removes its dedicated Slack connection. Next, review other intake paths in [Connect your factory](../connect-your-factory).


### PR DESCRIPTION
## Summary
Adds factory-specific Slack documentation covering the dedicated app, authorization boundary, app mentions and DMs, background event automations, thread continuity, attachments, acknowledgments, App Home, writeback, channel scope, and troubleshooting.

**Final size:** 897 prose words. Generic provider installation details remain in the existing platform integration page; this PR focuses only on factory-specific behavior.

## Foundation
Shared navigation, route placeholders, Early Access badge support, and guide migrations are merged in #537. This PR now contains only its feature-owned files and passes CI independently.

## Validation
- Integrated `npm run typecheck`: 0 errors
- Integrated `npm run build`: 377 pages built
- Integrated link check: 3,566 internal links, 0 broken
- Provider-specific source assertions and style/guardrail checks passed
- Senior editorial, product-accuracy, and security reviews completed; all blocker and important findings resolved

## Latest source refresh
Adds best-effort Slack install-on-create with Add to Slack fallback and stage-based App Home grouping.

Verified against Warp `e72fd7aac` and warp-server `9be39e484b`. Broken, placeholder, partial, and spec-only surfaces remain excluded.

## Proposed reviewers
Based on the **Warp Factories Soft Launch (August 18th)** tracker. For planning only; no review requests have been sent.
- `@liliwilson`
- `@moirahuang`
- `@captainsafia`

## Screenshots
Not included. The page uses a compact trigger/context/output table and links to the existing provider setup page; no approved factory-specific UI assets exist yet.

## Unverified claims
None — UI labels, event classes, filters, authorization boundaries, continuity, and writeback behavior were verified against source.

_Conversation: https://staging.warp.dev/conversation/5ff89820-2d80-4518-981e-178845029de1_
_Plans: https://staging.warp.dev/drive/notebook/7ZPKWz7hM5I59o4Gg2ptYi and https://staging.warp.dev/drive/notebook/DpRWhMQ0DLCajPPMggXw5e_

Co-Authored-By: Warp Agent <agent@warp.dev>
