### PR TITLE
docs(factories): document Jira integration

### DIFF
--- a/src/content/docs/factories/integrations/jira.mdx
+++ b/src/content/docs/factories/integrations/jira.mdx
@@ -7,6 +7,7 @@ sidebar:
   label: Jira
 topic: factories
 ---
+import { VARS } from '@data/vars';
 
 Connect Jira Cloud to your factory so your team can start factory work without leaving Jira. When someone assigns or mentions **Warp** on a work item, Jira starts an agent session, a factory automation routes the request to the agent you chose, and the same session shows progress and the final result.
 
@@ -19,9 +20,13 @@ Connect Jira Cloud to your factory so your team can start factory work without l
 
 ## Connect Jira and add an automation
 
-1. Install the Warp app and connect it to your Warp workspace by following the [Jira integration setup](/platform/integrations/jira/#setup). Stop once the workspace is connected and return here; the label-triggered run steps on that page don't apply to factories. The connected installation is available to every factory in the workspace.
+1. Install the Warp app on your Jira site. In the <a href={`${VARS.WEB_APP_URL}/integrations`}>Integrations page of the {VARS.WEB_APP}</a>, find Jira and click **Set up**, then click **Get app** on the Atlassian installation page and install the app on your Jira Cloud site.
 
-2. Add a Jira automation to your factory definition. The control room's automation editor doesn't include the Jira trigger, so configure it with [definitions as code](../factory-as-code): declare the `jira` integration for the factory, then create an automation that listens for the `agent_session_created` event. The `agent` field names the factory agent that handles matching requests.
+2. Connect the installation to your Warp workspace. In Jira, open **Manage apps** and open the Warp app's **Configure** page, then click **Connect to Warp** and sign in to Warp if prompted. The page shows **Connected to Warp** when the connection succeeds, and every factory in the workspace can then use it.
+
+   The [Jira integration setup](/platform/integrations/jira/#setup) covers installation in more detail. The `warp-agent` label flow on that page starts standalone cloud agent runs; factories skip the label and start runs through an automation instead.
+
+3. Add a Jira automation to your factory definition. The control room's automation editor doesn't include the Jira trigger, so configure it with [definitions as code](../factory-as-code): declare the `jira` integration for the factory, then create an automation that listens for the `agent_session_created` event. The `agent` field names the factory agent that handles matching requests.
 
    ```markdown title="automations/jira-assignment/automation.md"
    ---
@@ -42,7 +47,7 @@ Connect Jira Cloud to your factory so your team can start factory work without l
 
    If you selected Jira projects when you created the factory, Warp already added this automation at `automations/jira-agent-sessions/automation.md`, scoped to those projects. Edit that file instead of creating a second automation.
 
-3. Apply the definition, then test it: assign or mention **Warp** on a work item and include an instruction. Jira starts an agent session, and the run appears under the matching automation in your factory.
+4. Apply the definition, then test it: assign or mention **Warp** on a work item and include an instruction. Jira starts an agent session, and the run appears under the matching automation in your factory.
 
 ## Filter which sessions start runs
 
@@ -59,17 +64,18 @@ Filters decide which sessions start runs; they don't limit access. The Warp app'
 
 ## What happens during a run
 
-The agent starts with the assignment text and the work item it came from. When the factory declares Jira as an integration, the agent can also read the work item's details, comments, and available workflow transitions.
+The agent runs in the cloud and starts with the assignment text and the work item it came from. When the factory declares Jira as an integration, the agent can also read the work item's details, comments, and available workflow transitions.
 
-Jira shows the task's status as it progresses: submitted, working, waiting for input, completed, failed, or canceled. Replies in the same agent session continue the same run, even after the agent finishes a turn, so you can answer questions or add direction mid-task. A new session on the same work item starts a separate run.
+Jira shows the task's status as it progresses: submitted, working, waiting for input, completed, failed, or canceled. For more than status updates, open the run under the matching automation in your factory: [cloud agent session sharing](/platform/viewing-cloud-agent-runs/) shows the full run, including every command, log, and output, in real time or after the run finishes.
+
+Replies in the same agent session continue the same run, even after the agent finishes a turn, so you can answer questions or add direction mid-task. A new session on the same work item starts a separate run.
 
 When the run finishes, the result appears in the agent session. The agent doesn't comment on the work item unless you ask it to. The agent can act in Jira when asked: update the work item, post or edit comments, change workflow status, add or remove labels, or reassign it. State the actions you want in the automation instructions or the assignment; Jira permissions and valid workflow transitions apply to everything the agent does.
 
-## Permissions and reliability
+## Permissions
 
 * **Runs act as the factory agent** - A run executes as the agent selected by the automation, not as the Jira user who started the session.
-* **Repeated deliveries don't repeat runs** - Jira occasionally delivers the same message more than once, and Warp treats the copies as one request. Prefer instructions that check state before writing anyway, such as looking for an existing comment or label before adding one.
-* **Code changes follow repository policy** - The Jira connection doesn't grant code access. Pull request review and merge requirements come from your repositories and factory workflow.
+* **Jira access doesn't include code access** - Connecting Jira lets agents read and update Jira work items, nothing more. Agents get repository access from the factory itself, and pull requests they open go through your usual review and merge process.
 
 ## Troubleshooting
 

--- a/src/content/docs/factories/integrations/jira.mdx
+++ b/src/content/docs/factories/integrations/jira.mdx
@@ -1,82 +1,81 @@
 ---
-title: Connect a factory to Jira
+title: Connect Jira to your factory
 description: >-
-  Connect Jira Cloud to a factory so Rovo agent sessions route assignments to
-  the configured agent and return results in Jira.
+  Connect Jira Cloud to a factory so work items assigned to Warp in Rovo start
+  factory runs and return results in Jira.
 sidebar:
   label: Jira
 topic: factories
 ---
 
-Connect Jira Cloud to a factory so people can assign Jira work items to **Warp** through Rovo. Jira starts an agent session, a factory automation routes the assignment to its configured agent, and Jira displays the task status and result in the same Rovo session.
+Connect Jira Cloud to your factory so your team can start factory work without leaving Jira. When someone assigns or mentions **Warp** on a work item, Jira starts a Rovo agent session, a factory automation routes the request to the agent you chose, and the same session shows progress and the final result.
 
-## Before you connect
+## Prerequisites
 
-* **Jira Cloud** - The integration supports Jira Cloud, not Jira Server or Data Center.
-* **Jira site admin** - A site admin installs the Warp app on the Jira site and connects the installation to a Warp workspace.
-* **Factory access** - You need a factory in the connected workspace and permission to update its definition.
-* **Rovo agent access** - The **Warp** agent must be available for Jira work items on the connected site.
+* **Jira Cloud** - The integration supports Jira Cloud only, not Jira Server or Data Center.
+* **A Jira site admin** - Installing the Warp app on a Jira site and connecting it to a Warp workspace requires site admin permissions.
+* **A factory** - You need a factory in the connected workspace and permission to edit its [definition](../factory-as-code).
+* **Rovo access** - The **Warp** agent must be available on your Jira site so people can assign or mention it on work items.
 
-The Jira app's authorization determines which site and projects Warp can access and what the configured agent can read or update. Automation filters only route assignments within that access. Project or keyword filters do not reduce the app's credential permissions.
+## Connect Jira and add an automation
 
-## Connect Jira and configure agent sessions
+1. Install the Warp app and connect it to your Warp workspace by following the [Jira integration setup](/platform/integrations/jira/#setup). Stop once the workspace is connected and return here; the label-triggered run steps on that page don't apply to factories. The connected installation is available to every factory in the workspace.
 
-1. Follow the [Jira integration setup](https://docs.warp.dev/platform/integrations/jira/#setup) through connecting Jira to your Warp workspace, then return to this page instead of following the label-triggered run steps. The Jira installation becomes available to factories in that Warp workspace.
-2. Review or add the Jira agent-session automation with [factory definitions as code](../factory-as-code). When you select Jira projects during a supported factory creation flow, Warp seeds an enabled `agent_session_created` automation scoped to those project keys. You can extend the seeded definition in `automations/jira-agent-sessions/automation.md`. Otherwise, declare Jira for the factory and add the trigger in `automations/<name>/automation.md`. The `agent` field selects the factory agent that handles matching Jira assignments.
+2. Add a Jira automation to your factory definition. The control room's automation editor doesn't include the Jira trigger, so configure it with [definitions as code](../factory-as-code): declare the `jira` integration for the factory, then create an automation that listens for the `agent_session_created` event. The `agent` field names the factory agent that handles matching requests.
 
-   The current control-room automation editor does not expose the Jira agent-session trigger. Configure this trigger in the version-controlled factory definition.
+   ```markdown title="automations/jira-assignment/automation.md"
+   ---
+   enabled: true
+   agent: foreman
+   triggers:
+     - provider: jira
+       event: agent_session_created
+       filter:
+         project_keys: [ENG]
+         keywords: [investigate, fix]
+   ---
 
-```markdown title="automations/jira-assignment/automation.md"
----
-enabled: true
-agent: foreman
-triggers:
-  - provider: jira
-    event: agent_session_created
-    filter:
-      project_keys: [ENG]
-      keywords: [investigate, fix]
----
+   Handle the Jira assignment and return a concise result.
+   ```
 
-Handle the Jira assignment and return a concise result.
-```
+   With this automation, the agent named `foreman` handles sessions for work items in the `ENG` project whose assignment text contains `investigate` or `fix`.
 
-`ENG` is a Jira project key. The keyword values match assignment text without regard to letter case. `foreman` is the name of the declared factory agent that receives the work.
+   If you selected Jira projects when you created the factory, Warp already added this automation at `automations/jira-agent-sessions/automation.md`, scoped to those projects. Edit that file instead of creating a second automation.
 
-3. Apply the factory definition, then assign or mention **Warp** on a Jira work item and include an instruction. Confirm that Jira creates the agent session and that the matching run appears for the automation.
+3. Apply the definition, then test it: assign or mention **Warp** on a work item and include an instruction. Jira starts an agent session, and the run appears under the matching automation in your factory.
 
-## The agent session trigger and filters
+## Filter which sessions start runs
 
-Jira intake uses a single event, `agent_session_created`. It fires when someone assigns or mentions **Warp** on a Jira work item, and a matching factory automation routes that assignment to its configured agent.
+All Jira work reaches the factory through a single event, `agent_session_created`, which fires when someone assigns or mentions **Warp** on a work item. A session starts a run only when it matches an enabled automation. Use the trigger's `filter` to narrow what matches:
 
-The `agent_session_created` filter accepts two fields:
+* **`project_keys`** - Match work items in these Jira projects.
+* **`keywords`** - Match assignment text that contains any of these words. Matching is case-insensitive.
 
-* **`project_keys`** - Match the work item's Jira project key.
-* **`keywords`** - Match the assignment text, without regard to letter case.
+A session must match every field you set; within a field, any listed value is a match. Omit a field to match everything.
 
-Both fields combine together, and multiple values in one field act as alternatives. Leave a field empty to match any value the connected installation can deliver.
+:::caution
+Filters decide which sessions start runs; they don't limit access. The Warp app's authorization in Jira controls which site and projects agents can read and update, so grant the app only the access the factory's work requires.
+:::
 
-## Context, follow-ups, and outputs
+## What happens during a run
 
-The first Rovo message gives the configured agent the assignment text and associated Jira work item. When the factory declares Jira as an integration, the agent can use the connected Jira context to read the issue, comments, and available workflow transitions.
+The agent starts with the assignment text and the work item it came from. When the factory declares Jira as an integration, the agent can also read the work item's details, comments, and available workflow transitions.
 
-Further messages in the same Rovo agent session continue the same run, including a follow-up after the previous turn completes. This continuity belongs to the Rovo session. Separate sessions for the same Jira issue are not automatically one factory workstream.
+Jira shows the task's status as it progresses: submitted, working, waiting for input, completed, failed, or canceled. Replies in the same Rovo session continue the same run, even after the agent finishes a turn, so you can answer questions or add direction mid-task. A new session on the same work item starts a separate run.
 
-Jira displays whether the task is submitted, working, waiting for input, completed, failed, or canceled. When the run finishes, the Rovo session receives the agent's text result instead of automatic issue comments.
+When the run finishes, the agent posts its result in the Rovo session. It doesn't comment on the work item unless you ask it to. The agent can act in Jira when asked: update the work item, post or edit comments, change workflow status, add or remove labels, or reassign it. State the actions you want in the automation instructions or the assignment; Jira permissions and valid workflow transitions apply to everything the agent does.
 
-While the run is active, the configured agent can perform authorized Jira actions such as reading or updating an issue, finding assignable users, assigning or unassigning an issue, posting or updating comments, changing workflow status, and adding or removing labels. Make those actions explicit in the automation instructions. Jira permissions and valid workflow transitions still apply. Pull request review and merge requirements remain repository or workflow policy.
+## Permissions and reliability
 
-## Permissions and delivery caveats
-
-Grant the Jira app only the site and project access required for the factory's work. Restrict Rovo intake separately with project and keyword filters. The run executes as the agent selected by the matching automation, not as the Jira user who started the session.
-
-Atlassian can retry a Rovo message. Warp associates repeated delivery of the same message with one factory admission. Keep issue mutations duplicate-safe anyway: check current state before posting a comment, changing status, or adding a label, and make repeated actions harmless.
+* **Runs act as the factory agent** - A run executes as the agent selected by the automation, not as the Jira user who started the session.
+* **Repeated deliveries don't repeat runs** - Atlassian occasionally redelivers a Rovo message, and Warp treats redelivered copies as one request. Prefer instructions that check state before writing anyway, such as looking for an existing comment or label before adding one.
+* **Code changes follow repository policy** - The Jira connection doesn't grant code access. Pull request review and merge requirements come from your repositories and factory workflow.
 
 ## Troubleshooting
 
-* **Warp is unavailable in Jira** - Confirm the Warp app is installed on the Jira Cloud site. Open its **Configure** page and click **Connect to Warp** if the installation is not connected.
-* **No run starts** - Confirm an enabled `agent_session_created` automation exists, its agent is available, and its project and keyword filters match the Rovo assignment.
-* **The session has no result** - Check the matching automation's run to determine whether the configured agent is still working, waiting for input, or failed.
-* **A Jira update fails** - Confirm the app can access the work item's project and perform the requested action or workflow transition.
+* **Warp is unavailable in Jira** - Confirm the Warp app is installed on the Jira Cloud site. On the app's **Configure** page, click **Connect to Warp** if the installation isn't connected to a workspace.
+* **No run starts** - Confirm an enabled `agent_session_created` automation exists, its agent is available, and its project and keyword filters match the assignment.
+* **The session shows no result** - Open the matching automation's run to see whether the agent is still working, waiting for input, or failed.
+* **A Jira update fails** - Confirm the app can access the work item's project and that the requested action or workflow transition is valid.
 
-For other intake paths and provider boundaries, see [connecting your factory](../connect-your-factory).
+For the other ways to route work into a factory, see [connecting your factory](../connect-your-factory).

--- a/src/content/docs/factories/integrations/jira.mdx
+++ b/src/content/docs/factories/integrations/jira.mdx
@@ -26,13 +26,13 @@ Connect Jira Cloud to your factory so your team can start factory work without l
 
    The [Jira integration setup](/platform/integrations/jira/#setup) covers installation in more detail. The `warp-agent` label flow on that page starts standalone cloud agent runs; factories skip the label and start runs through an automation instead.
 
-3. Connect Jira to your factory. Connecting the workspace in step 2 makes Jira available to every factory in it, but each factory still needs its own connection: in the factory's **Settings** tab, find **Jira** and click **Connect** (or **Install** if the workspace itself isn't connected yet). Select the Jira projects that should trigger this factory, then click **Enable**. This declares the `jira` integration for the factory — without it, **Jira** in the automation editor's **Add trigger** menu stays a disabled "not connected" entry that only links back to this step.
+3. Connect Jira to your factory. Connecting the workspace in step 2 makes Jira available to every factory in it, but each factory still needs its own connection: in the factory's **Settings** tab, find **Jira** and click **Connect** (or **Install** if the workspace itself isn't connected yet). Select the Jira projects that should trigger this factory, then click **Enable**. This declares the `jira` integration for the factory. Without it, **Jira** in the automation editor's **Add trigger** menu stays a disabled "not connected" entry that links back to this step.
 
 4. Add a Jira trigger to an automation. In the control room, open the factory's **Automations** tab, then open an automation (or create a new one). Click **Add trigger**, choose **Jira**, and select **Agent session created**. Set **Projects** and, optionally, **Keywords** to scope which sessions start a run, then set the automation's agent to the one that should handle matching requests.
 
    If you selected Jira projects when you created the factory, Warp already added an automation scoped to those projects; edit that automation instead of creating a second one.
 
-   Prefer definitions as code? Declare the `jira` integration in the factory's `factory.yaml` (`integrations: [{type: jira}]`), then add a file under `automations/` — for example `automations/jira-assignment/automation.md` — with an `agent_session_created` trigger:
+   Prefer definitions as code? Declare the `jira` integration in the factory's `factory.yaml` (`integrations: [{type: jira}]`), then add a file under `automations/`, such as `automations/jira-assignment/automation.md`, with an `agent_session_created` trigger:
 
    ```markdown title="automations/jira-assignment/automation.md"
    ---
@@ -51,7 +51,7 @@ Connect Jira Cloud to your factory so your team can start factory work without l
 
    With this automation, the agent named `foreman` handles sessions for work items in the `ENG` project whose assignment text contains `investigate` or `fix`. Commit and push the files to apply them; see [definitions as code](../factory-as-code) for the full syntax.
 
-5. Save the automation — or apply the definition if you used definitions as code — then test it: assign or mention **Warp** on a work item and include an instruction. Jira starts an agent session, and the run appears under the matching automation in your factory.
+5. Save the automation, or commit and push the definition if you used definitions as code. Then test it: assign or mention **Warp** on a work item and include an instruction. Jira starts an agent session, and the run appears under the matching automation in your factory.
 
 ## Filter which sessions start runs
 

--- a/src/content/docs/factories/integrations/jira.mdx
+++ b/src/content/docs/factories/integrations/jira.mdx
@@ -26,11 +26,13 @@ Connect Jira Cloud to your factory so your team can start factory work without l
 
    The [Jira integration setup](/platform/integrations/jira/#setup) covers installation in more detail. The `warp-agent` label flow on that page starts standalone cloud agent runs; factories skip the label and start runs through an automation instead.
 
-3. Add a Jira trigger to an automation. In the control room, open the factory's **Automations** tab, then open an automation (or create a new one). Click **Add trigger**, choose **Jira**, and select **Agent session created**. Set **Projects** and, optionally, **Keywords** to scope which sessions start a run, then set the automation's agent to the one that should handle matching requests.
+3. Connect Jira to your factory. Connecting the workspace in step 2 makes Jira available to every factory in it, but each factory still needs its own connection: in the factory's **Settings** tab, find **Jira** and click **Connect** (or **Install** if the workspace itself isn't connected yet). Select the Jira projects that should trigger this factory, then click **Enable**. This declares the `jira` integration for the factory — without it, **Jira** in the automation editor's **Add trigger** menu stays a disabled "not connected" entry that only links back to this step.
+
+4. Add a Jira trigger to an automation. In the control room, open the factory's **Automations** tab, then open an automation (or create a new one). Click **Add trigger**, choose **Jira**, and select **Agent session created**. Set **Projects** and, optionally, **Keywords** to scope which sessions start a run, then set the automation's agent to the one that should handle matching requests.
 
    If you selected Jira projects when you created the factory, Warp already added an automation scoped to those projects; edit that automation instead of creating a second one.
 
-   Prefer definitions as code? Declare the `jira` integration for the factory and add an `agent_session_created` trigger to the automation file directly; see [definitions as code](../factory-as-code) for the full syntax.
+   Prefer definitions as code? Declare the `jira` integration in the factory's `factory.yaml` (`integrations: [{type: jira}]`), then add a file under `automations/` — for example `automations/jira-assignment/automation.md` — with an `agent_session_created` trigger:
 
    ```markdown title="automations/jira-assignment/automation.md"
    ---
@@ -47,9 +49,9 @@ Connect Jira Cloud to your factory so your team can start factory work without l
    Handle the Jira assignment and return a concise result.
    ```
 
-   With this automation, the agent named `foreman` handles sessions for work items in the `ENG` project whose assignment text contains `investigate` or `fix`.
+   With this automation, the agent named `foreman` handles sessions for work items in the `ENG` project whose assignment text contains `investigate` or `fix`. Commit and push the files to apply them; see [definitions as code](../factory-as-code) for the full syntax.
 
-4. Save the automation — or apply the definition if you used definitions as code — then test it: assign or mention **Warp** on a work item and include an instruction. Jira starts an agent session, and the run appears under the matching automation in your factory.
+5. Save the automation — or apply the definition if you used definitions as code — then test it: assign or mention **Warp** on a work item and include an instruction. Jira starts an agent session, and the run appears under the matching automation in your factory.
 
 ## Filter which sessions start runs
 
@@ -61,7 +63,7 @@ All Jira work reaches the factory through a single event, `agent_session_created
 A session must match every field you set; within a field, any listed value is a match. Omit a field to match everything.
 
 :::caution
-Filters decide which sessions start runs; they don't limit access. The Warp app's authorization applies to your whole connected Jira site: every team in the workspace can trigger runs against any project the app can reach, regardless of a filter's `project_keys`. Warp doesn't yet offer a way to scope Jira access by team or project.
+Filters like `project_keys` decide whether *your* automation starts a run; they aren't an access boundary. A Jira event is evaluated against every team's automations in the connected workspace, so another team's automation with a broader or different filter can still start its own run on the same work item. Warp doesn't yet offer a way to scope Jira access by team or project.
 :::
 
 ## What happens during a run
@@ -76,7 +78,7 @@ When the run finishes, the result appears in the agent session. The agent doesn'
 
 ## Permissions
 
-* **The Jira user connects their own account first** - The person who assigns or mentions **Warp** must [connect their Jira account to Warp](/platform/integrations/jira/#connecting-your-jira-account-to-warp) before their session can start a run; an unconnected user gets a prompt to connect instead of a run starting. A run still executes as the agent selected by the automation, not as that Jira user.
+* **A bound Jira user becomes the run's creator, not its agent** - [Connect your Jira account to Warp](/platform/integrations/jira/#connecting-your-jira-account-to-warp) so a session you start is attributed to you; an unconnected account gets a prompt to connect instead of a run starting. Either way, the run executes as the agent selected by the automation, not as that Jira user.
 * **Jira access doesn't include code access** - Connecting Jira lets agents read and update Jira work items, nothing more. Agents get repository access from the factory itself, and pull requests they open go through your usual review and merge process.
 
 ## Troubleshooting

--- a/src/content/docs/factories/integrations/jira.mdx
+++ b/src/content/docs/factories/integrations/jira.mdx
@@ -1,21 +1,21 @@
 ---
 title: Connect Jira to your factory
 description: >-
-  Connect Jira Cloud to a factory so work items assigned to Warp in Rovo start
-  factory runs and return results in Jira.
+  Connect Jira Cloud to a factory so work items assigned to Warp start factory
+  runs and return results in Jira.
 sidebar:
   label: Jira
 topic: factories
 ---
 
-Connect Jira Cloud to your factory so your team can start factory work without leaving Jira. When someone assigns or mentions **Warp** on a work item, Jira starts a Rovo agent session, a factory automation routes the request to the agent you chose, and the same session shows progress and the final result.
+Connect Jira Cloud to your factory so your team can start factory work without leaving Jira. When someone assigns or mentions **Warp** on a work item, Jira starts an agent session, a factory automation routes the request to the agent you chose, and the same session shows progress and the final result.
 
 ## Prerequisites
 
 * **Jira Cloud** - The integration supports Jira Cloud only, not Jira Server or Data Center.
 * **A Jira site admin** - Installing the Warp app on a Jira site and connecting it to a Warp workspace requires site admin permissions.
 * **A factory** - You need a factory in the connected workspace and permission to edit its [definition](../factory-as-code).
-* **Rovo access** - The **Warp** agent must be available on your Jira site so people can assign or mention it on work items.
+* **The Warp agent in Jira** - The **Warp** agent must be available on your Jira site so people can assign or mention it on work items. Jira lists it among Atlassian's Rovo agents.
 
 ## Connect Jira and add an automation
 
@@ -61,14 +61,14 @@ Filters decide which sessions start runs; they don't limit access. The Warp app'
 
 The agent starts with the assignment text and the work item it came from. When the factory declares Jira as an integration, the agent can also read the work item's details, comments, and available workflow transitions.
 
-Jira shows the task's status as it progresses: submitted, working, waiting for input, completed, failed, or canceled. Replies in the same Rovo session continue the same run, even after the agent finishes a turn, so you can answer questions or add direction mid-task. A new session on the same work item starts a separate run.
+Jira shows the task's status as it progresses: submitted, working, waiting for input, completed, failed, or canceled. Replies in the same agent session continue the same run, even after the agent finishes a turn, so you can answer questions or add direction mid-task. A new session on the same work item starts a separate run.
 
-When the run finishes, the agent posts its result in the Rovo session. It doesn't comment on the work item unless you ask it to. The agent can act in Jira when asked: update the work item, post or edit comments, change workflow status, add or remove labels, or reassign it. State the actions you want in the automation instructions or the assignment; Jira permissions and valid workflow transitions apply to everything the agent does.
+When the run finishes, the result appears in the agent session. The agent doesn't comment on the work item unless you ask it to. The agent can act in Jira when asked: update the work item, post or edit comments, change workflow status, add or remove labels, or reassign it. State the actions you want in the automation instructions or the assignment; Jira permissions and valid workflow transitions apply to everything the agent does.
 
 ## Permissions and reliability
 
 * **Runs act as the factory agent** - A run executes as the agent selected by the automation, not as the Jira user who started the session.
-* **Repeated deliveries don't repeat runs** - Atlassian occasionally redelivers a Rovo message, and Warp treats redelivered copies as one request. Prefer instructions that check state before writing anyway, such as looking for an existing comment or label before adding one.
+* **Repeated deliveries don't repeat runs** - Jira occasionally delivers the same message more than once, and Warp treats the copies as one request. Prefer instructions that check state before writing anyway, such as looking for an existing comment or label before adding one.
 * **Code changes follow repository policy** - The Jira connection doesn't grant code access. Pull request review and merge requirements come from your repositories and factory workflow.
 
 ## Troubleshooting

--- a/src/content/docs/factories/integrations/jira.mdx
+++ b/src/content/docs/factories/integrations/jira.mdx
@@ -26,7 +26,11 @@ Connect Jira Cloud to your factory so your team can start factory work without l
 
    The [Jira integration setup](/platform/integrations/jira/#setup) covers installation in more detail. The `warp-agent` label flow on that page starts standalone cloud agent runs; factories skip the label and start runs through an automation instead.
 
-3. Add a Jira automation to your factory definition. The control room's automation editor doesn't include the Jira trigger, so configure it with [definitions as code](../factory-as-code): declare the `jira` integration for the factory, then create an automation that listens for the `agent_session_created` event. The `agent` field names the factory agent that handles matching requests.
+3. Add a Jira trigger to an automation. In the control room, open the factory's **Automations** tab, then open an automation (or create a new one). Click **Add trigger**, choose **Jira**, and select **Agent session created**. Set **Projects** and, optionally, **Keywords** to scope which sessions start a run, then set the automation's agent to the one that should handle matching requests.
+
+   If you selected Jira projects when you created the factory, Warp already added an automation scoped to those projects; edit that automation instead of creating a second one.
+
+   Prefer definitions as code? Declare the `jira` integration for the factory and add an `agent_session_created` trigger to the automation file directly; see [definitions as code](../factory-as-code) for the full syntax.
 
    ```markdown title="automations/jira-assignment/automation.md"
    ---
@@ -45,9 +49,7 @@ Connect Jira Cloud to your factory so your team can start factory work without l
 
    With this automation, the agent named `foreman` handles sessions for work items in the `ENG` project whose assignment text contains `investigate` or `fix`.
 
-   If you selected Jira projects when you created the factory, Warp already added this automation at `automations/jira-agent-sessions/automation.md`, scoped to those projects. Edit that file instead of creating a second automation.
-
-4. Apply the definition, then test it: assign or mention **Warp** on a work item and include an instruction. Jira starts an agent session, and the run appears under the matching automation in your factory.
+4. Save the automation — or apply the definition if you used definitions as code — then test it: assign or mention **Warp** on a work item and include an instruction. Jira starts an agent session, and the run appears under the matching automation in your factory.
 
 ## Filter which sessions start runs
 
@@ -59,7 +61,7 @@ All Jira work reaches the factory through a single event, `agent_session_created
 A session must match every field you set; within a field, any listed value is a match. Omit a field to match everything.
 
 :::caution
-Filters decide which sessions start runs; they don't limit access. The Warp app's authorization in Jira controls which site and projects agents can read and update, so grant the app only the access the factory's work requires.
+Filters decide which sessions start runs; they don't limit access. The Warp app's authorization applies to your whole connected Jira site: every team in the workspace can trigger runs against any project the app can reach, regardless of a filter's `project_keys`. Warp doesn't yet offer a way to scope Jira access by team or project.
 :::
 
 ## What happens during a run
@@ -68,13 +70,13 @@ The agent runs in the cloud and starts with the assignment text and the work ite
 
 Jira shows the task's status as it progresses: submitted, working, waiting for input, completed, failed, or canceled. For more than status updates, open the run under the matching automation in your factory: [cloud agent session sharing](/platform/viewing-cloud-agent-runs/) shows the full run, including every command, log, and output, in real time or after the run finishes.
 
-Replies in the same agent session continue the same run, even after the agent finishes a turn, so you can answer questions or add direction mid-task. A new session on the same work item starts a separate run.
+Replies in the same agent session continue the same run, even after the agent finishes a turn, so you can answer questions or add direction mid-task.
 
 When the run finishes, the result appears in the agent session. The agent doesn't comment on the work item unless you ask it to. The agent can act in Jira when asked: update the work item, post or edit comments, change workflow status, add or remove labels, or reassign it. State the actions you want in the automation instructions or the assignment; Jira permissions and valid workflow transitions apply to everything the agent does.
 
 ## Permissions
 
-* **Runs act as the factory agent** - A run executes as the agent selected by the automation, not as the Jira user who started the session.
+* **The Jira user connects their own account first** - The person who assigns or mentions **Warp** must [connect their Jira account to Warp](/platform/integrations/jira/#connecting-your-jira-account-to-warp) before their session can start a run; an unconnected user gets a prompt to connect instead of a run starting. A run still executes as the agent selected by the automation, not as that Jira user.
 * **Jira access doesn't include code access** - Connecting Jira lets agents read and update Jira work items, nothing more. Agents get repository access from the factory itself, and pull requests they open go through your usual review and merge process.
 
 ## Troubleshooting

--- a/src/content/docs/factories/integrations/jira.mdx
+++ b/src/content/docs/factories/integrations/jira.mdx
@@ -1,9 +1,82 @@
 ---
-title: Jira integration
+title: Connect a factory to Jira
 description: >-
-  Jira integration documentation for Warp Factories will be added in a follow-up PR.
+  Connect Jira Cloud to a factory so Rovo agent sessions route assignments to
+  the configured agent and return results in Jira.
 sidebar:
-  label: "Jira"
+  label: Jira
+topic: factories
 ---
 
-Jira integration documentation for Warp Factories will land in a follow-up PR.
+Connect Jira Cloud to a factory so people can assign Jira work items to **Warp** through Rovo. Jira starts an agent session, a factory automation routes the assignment to its configured agent, and Jira displays the task status and result in the same Rovo session.
+
+## Before you connect
+
+* **Jira Cloud** - The integration supports Jira Cloud, not Jira Server or Data Center.
+* **Jira site admin** - A site admin installs the Warp app on the Jira site and connects the installation to a Warp workspace.
+* **Factory access** - You need a factory in the connected workspace and permission to update its definition.
+* **Rovo agent access** - The **Warp** agent must be available for Jira work items on the connected site.
+
+The Jira app's authorization determines which site and projects Warp can access and what the configured agent can read or update. Automation filters only route assignments within that access. Project or keyword filters do not reduce the app's credential permissions.
+
+## Connect Jira and configure agent sessions
+
+1. Follow the [Jira integration setup](https://docs.warp.dev/platform/integrations/jira/#setup) through connecting Jira to your Warp workspace, then return to this page instead of following the label-triggered run steps. The Jira installation becomes available to factories in that Warp workspace.
+2. Review or add the Jira agent-session automation with [factory definitions as code](../factory-as-code). When you select Jira projects during a supported factory creation flow, Warp seeds an enabled `agent_session_created` automation scoped to those project keys. You can extend the seeded definition in `automations/jira-agent-sessions/automation.md`. Otherwise, declare Jira for the factory and add the trigger in `automations/<name>/automation.md`. The `agent` field selects the factory agent that handles matching Jira assignments.
+
+   The current control-room automation editor does not expose the Jira agent-session trigger. Configure this trigger in the version-controlled factory definition.
+
+```markdown title="automations/jira-assignment/automation.md"
+---
+enabled: true
+agent: foreman
+triggers:
+  - provider: jira
+    event: agent_session_created
+    filter:
+      project_keys: [ENG]
+      keywords: [investigate, fix]
+---
+
+Handle the Jira assignment and return a concise result.
+```
+
+`ENG` is a Jira project key. The keyword values match assignment text without regard to letter case. `foreman` is the name of the declared factory agent that receives the work.
+
+3. Apply the factory definition, then assign or mention **Warp** on a Jira work item and include an instruction. Confirm that Jira creates the agent session and that the matching run appears for the automation.
+
+## The agent session trigger and filters
+
+Jira intake uses a single event, `agent_session_created`. It fires when someone assigns or mentions **Warp** on a Jira work item, and a matching factory automation routes that assignment to its configured agent.
+
+The `agent_session_created` filter accepts two fields:
+
+* **`project_keys`** - Match the work item's Jira project key.
+* **`keywords`** - Match the assignment text, without regard to letter case.
+
+Both fields combine together, and multiple values in one field act as alternatives. Leave a field empty to match any value the connected installation can deliver.
+
+## Context, follow-ups, and outputs
+
+The first Rovo message gives the configured agent the assignment text and associated Jira work item. When the factory declares Jira as an integration, the agent can use the connected Jira context to read the issue, comments, and available workflow transitions.
+
+Further messages in the same Rovo agent session continue the same run, including a follow-up after the previous turn completes. This continuity belongs to the Rovo session. Separate sessions for the same Jira issue are not automatically one factory workstream.
+
+Jira displays whether the task is submitted, working, waiting for input, completed, failed, or canceled. When the run finishes, the Rovo session receives the agent's text result instead of automatic issue comments.
+
+While the run is active, the configured agent can perform authorized Jira actions such as reading or updating an issue, finding assignable users, assigning or unassigning an issue, posting or updating comments, changing workflow status, and adding or removing labels. Make those actions explicit in the automation instructions. Jira permissions and valid workflow transitions still apply. Pull request review and merge requirements remain repository or workflow policy.
+
+## Permissions and delivery caveats
+
+Grant the Jira app only the site and project access required for the factory's work. Restrict Rovo intake separately with project and keyword filters. The run executes as the agent selected by the matching automation, not as the Jira user who started the session.
+
+Atlassian can retry a Rovo message. Warp associates repeated delivery of the same message with one factory admission. Keep issue mutations duplicate-safe anyway: check current state before posting a comment, changing status, or adding a label, and make repeated actions harmless.
+
+## Troubleshooting
+
+* **Warp is unavailable in Jira** - Confirm the Warp app is installed on the Jira Cloud site. Open its **Configure** page and click **Connect to Warp** if the installation is not connected.
+* **No run starts** - Confirm an enabled `agent_session_created` automation exists, its agent is available, and its project and keyword filters match the Rovo assignment.
+* **The session has no result** - Check the matching automation's run to determine whether the configured agent is still working, waiting for input, or failed.
+* **A Jira update fails** - Confirm the app can access the work item's project and perform the requested action or workflow transition.
+
+For other intake paths and provider boundaries, see [connecting your factory](../connect-your-factory).


### PR DESCRIPTION
## Summary
Adds factory-specific Jira documentation covering app installation and workspace connection, editor and definitions-as-code trigger paths, issue continuity, routing filters, writeback, duplicate-safe repeated delivery, permissions, and troubleshooting.

**Final size:** 769 prose words. Generic provider installation details remain in the existing platform integration page; this PR focuses only on factory-specific behavior.

## Foundation
Shared navigation, route placeholders, Early Access badge support, and guide migrations are merged in #537. This PR now contains only its feature-owned files and passes CI independently.

## Validation
- Integrated `npm run typecheck`: 0 errors
- Integrated `npm run build`: 377 pages built
- Integrated link check: 3,566 internal links, 0 broken
- Provider-specific source assertions and style/guardrail checks passed
- Senior editorial, product-accuracy, and security reviews completed; all blocker and important findings resolved

## Latest source refresh
Rewrites Jira around the working Rovo agent-session model and documents only the emitted agent_session_created event.

Verified against Warp `e72fd7aac` and warp-server `9be39e484b`. Broken, placeholder, partial, and spec-only surfaces remain excluded.

## Proposed reviewers
Based on the **Warp Factories Soft Launch (August 18th)** tracker. For planning only; no review requests have been sent.
- `@jasonkeung`
- `@liliwilson`
- `@captainsafia`

## Screenshots
Not included. The page uses a compact trigger/context/output table and links to the existing provider setup page; no approved factory-specific UI assets exist yet.

## Unverified claims
None — UI labels, event classes, filters, authorization boundaries, continuity, and writeback behavior were verified against source.

_Conversation: https://staging.warp.dev/conversation/5ff89820-2d80-4518-981e-178845029de1_
_Plans: https://staging.warp.dev/drive/notebook/7ZPKWz7hM5I59o4Gg2ptYi and https://staging.warp.dev/drive/notebook/DpRWhMQ0DLCajPPMggXw5e_

Co-Authored-By: Warp Agent <agent@warp.dev>