### PR TITLE
fix: collapse 742 trailing-slash redirect pairs to reclaim Vercel route headroom

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -118,12 +118,7 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/capabilities/computer-use",
-      "destination": "/agents/capabilities/computer-use/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/capabilities/computer-use/",
+      "source": "/agent-platform/capabilities/computer-use(/?)",
       "destination": "/agents/capabilities/computer-use/",
       "statusCode": 308
     },
@@ -378,182 +373,182 @@
       "statusCode": 308
     },
     {
-      "source": "/advanced/command-line-flags",
+      "source": "/advanced/command-line-flags(/?)",
       "destination": "/terminal/sessions/launch-configurations/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts",
+      "source": "/agent-platform/agent-concepts(/?)",
       "destination": "/agent-platform/capabilities/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/agent-profiles-permissions",
+      "source": "/agent-platform/agent-concepts/agent-profiles-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/codebase-context",
+      "source": "/agent-platform/agent-concepts/codebase-context(/?)",
       "destination": "/agent-platform/capabilities/codebase-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/full-terminal-use",
+      "source": "/agent-platform/agent-concepts/full-terminal-use(/?)",
       "destination": "/agent-platform/capabilities/full-terminal-use/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/mcp",
+      "source": "/agent-platform/agent-concepts/mcp(/?)",
       "destination": "/agent-platform/capabilities/mcp/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/model-choice",
+      "source": "/agent-platform/agent-concepts/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/planning",
+      "source": "/agent-platform/agent-concepts/planning(/?)",
       "destination": "/agent-platform/capabilities/planning/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/rules",
+      "source": "/agent-platform/agent-concepts/rules(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/skills",
+      "source": "/agent-platform/agent-concepts/skills(/?)",
       "destination": "/agent-platform/capabilities/skills/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/slash-commands",
+      "source": "/agent-platform/agent-concepts/slash-commands(/?)",
       "destination": "/agent-platform/capabilities/slash-commands/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/task-lists",
+      "source": "/agent-platform/agent-concepts/task-lists(/?)",
       "destination": "/agent-platform/capabilities/task-lists/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-concepts/web-search",
+      "source": "/agent-platform/agent-concepts/web-search(/?)",
       "destination": "/agent-platform/capabilities/web-search/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode",
+      "source": "/agent-platform/agent-mode(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/active-ai",
+      "source": "/agent-platform/agent-mode/active-ai(/?)",
       "destination": "/agent-platform/local-agents/active-ai/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/agent-context",
+      "source": "/agent-platform/agent-mode/agent-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/agent-context/blocks-as-context",
+      "source": "/agent-platform/agent-mode/agent-context/blocks-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/agent-context/images-as-context",
+      "source": "/agent-platform/agent-mode/agent-context/images-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/agent-context/selection-as-context",
+      "source": "/agent-platform/agent-mode/agent-context/selection-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/selection-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/agent-context/urls-as-context",
+      "source": "/agent-platform/agent-mode/agent-context/urls-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/agent-context/using-to-add-context",
+      "source": "/agent-platform/agent-mode/agent-context/using-to-add-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/agents-overview",
+      "source": "/agent-platform/agent-mode/agents-overview(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/ambient-agents-session-sharing",
+      "source": "/agent-platform/agent-mode/ambient-agents-session-sharing(/?)",
       "destination": "/platform/viewing-cloud-agent-runs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/code-diffs-in-agent-conversations",
+      "source": "/agent-platform/agent-mode/code-diffs-in-agent-conversations(/?)",
       "destination": "/agent-platform/local-agents/code-diffs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/full-terminal-use",
+      "source": "/agent-platform/agent-mode/full-terminal-use(/?)",
       "destination": "/agent-platform/capabilities/full-terminal-use/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/generate",
+      "source": "/agent-platform/agent-mode/generate(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/interacting-with-agents",
+      "source": "/agent-platform/agent-mode/interacting-with-agents(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/interacting-with-agents/agent-modality-beta",
+      "source": "/agent-platform/agent-mode/interacting-with-agents/agent-modality-beta(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/interacting-with-agents/conversation-forking",
+      "source": "/agent-platform/agent-mode/interacting-with-agents/conversation-forking(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/interacting-with-agents/voice",
+      "source": "/agent-platform/agent-mode/interacting-with-agents/voice(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/interactive-code-review",
+      "source": "/agent-platform/agent-mode/interactive-code-review(/?)",
       "destination": "/agent-platform/local-agents/interactive-code-review/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/model-choice",
+      "source": "/agent-platform/agent-mode/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/task-lists",
+      "source": "/agent-platform/agent-mode/task-lists(/?)",
       "destination": "/agent-platform/capabilities/task-lists/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/third-party-cli-agents",
+      "source": "/agent-platform/agent-mode/third-party-cli-agents(/?)",
       "destination": "/agent-platform/cli-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-mode/web-search",
+      "source": "/agent-platform/agent-mode/web-search(/?)",
       "destination": "/agent-platform/capabilities/web-search/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/active-ai",
+      "source": "/agent-platform/agent-platform/active-ai(/?)",
       "destination": "/agent-platform/local-agents/active-ai/",
       "statusCode": 308
     },
@@ -568,37 +563,37 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/agent-modality-beta",
+      "source": "/agent-platform/agent-platform/agent-modality-beta(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/agent/agents-overview",
+      "source": "/agent-platform/agent-platform/agent/agents-overview(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/agent/using-agents/agent-profiles-permissions",
+      "source": "/agent-platform/agent-platform/agent/using-agents/agent-profiles-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/agents-md",
+      "source": "/agent-platform/agent-platform/agents-md(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/agents-overview",
+      "source": "/agent-platform/agent-platform/agents-overview(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/ai",
+      "source": "/agent-platform/agent-platform/ai(/?)",
       "destination": "/agent-platform/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/ai-faqs",
+      "source": "/agent-platform/agent-platform/ai-faqs(/?)",
       "destination": "/agent-platform/getting-started/faqs/",
       "statusCode": 308
     },
@@ -608,47 +603,47 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/ai-model-choice",
+      "source": "/agent-platform/agent-platform/ai-model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/ambient-agents/ambient-agents-overview",
+      "source": "/agent-platform/agent-platform/ambient-agents/ambient-agents-overview(/?)",
       "destination": "/platform/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/autonomy",
+      "source": "/agent-platform/agent-platform/autonomy(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/autonomy/agent-permissions",
+      "source": "/agent-platform/agent-platform/autonomy/agent-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/autonomy/run-to-completion",
+      "source": "/agent-platform/agent-platform/autonomy/run-to-completion(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/cloud-agents/cloud-agents-platform",
+      "source": "/agent-platform/agent-platform/cloud-agents/cloud-agents-platform(/?)",
       "destination": "/platform/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/cloud-agents/warp-platform",
+      "source": "/agent-platform/agent-platform/cloud-agents/warp-platform(/?)",
       "destination": "/platform/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/conversation-forking",
+      "source": "/agent-platform/agent-platform/conversation-forking(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/full-terminal-use",
+      "source": "/agent-platform/agent-platform/full-terminal-use(/?)",
       "destination": "/agent-platform/capabilities/full-terminal-use/",
       "statusCode": 308
     },
@@ -658,32 +653,32 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/generate",
+      "source": "/agent-platform/agent-platform/generate(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/integrations/github-actions/readme",
+      "source": "/agent-platform/agent-platform/integrations/github-actions/readme(/?)",
       "destination": "/platform/integrations/github-actions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/integrations/integrations-overview",
+      "source": "/agent-platform/agent-platform/integrations/integrations-overview(/?)",
       "destination": "/platform/integrations/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/model-choice",
+      "source": "/agent-platform/agent-platform/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/slash-commands",
+      "source": "/agent-platform/agent-platform/slash-commands(/?)",
       "destination": "/agent-platform/capabilities/slash-commands/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents",
+      "source": "/agent-platform/agent-platform/using-agents(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
@@ -698,7 +693,7 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context",
+      "source": "/agent-platform/agent-platform/using-agents/agent-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/",
       "statusCode": 308
     },
@@ -708,7 +703,7 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/blocks-as-context",
+      "source": "/agent-platform/agent-platform/using-agents/agent-context/blocks-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
       "statusCode": 308
     },
@@ -718,42 +713,42 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/images-as-context",
+      "source": "/agent-platform/agent-platform/using-agents/agent-context/images-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/selection-as-context",
+      "source": "/agent-platform/agent-platform/using-agents/agent-context/selection-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/selection-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/urls-as-context",
+      "source": "/agent-platform/agent-platform/using-agents/agent-context/urls-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/using-to-add-context",
+      "source": "/agent-platform/agent-platform/using-agents/agent-context/using-to-add-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-conversations",
+      "source": "/agent-platform/agent-platform/using-agents/agent-conversations(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-conversations/conversation-forking",
+      "source": "/agent-platform/agent-platform/using-agents/agent-conversations/conversation-forking(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-permissions",
+      "source": "/agent-platform/agent-platform/using-agents/agent-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-profiles-permissions",
+      "source": "/agent-platform/agent-platform/using-agents/agent-profiles-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
@@ -768,12 +763,12 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/agent-tasklists",
+      "source": "/agent-platform/agent-platform/using-agents/agent-tasklists(/?)",
       "destination": "/agent-platform/capabilities/task-lists/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/managing-agents",
+      "source": "/agent-platform/agent-platform/using-agents/managing-agents(/?)",
       "destination": "/platform/managing-cloud-agents/",
       "statusCode": 308
     },
@@ -783,7 +778,7 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/model-choice",
+      "source": "/agent-platform/agent-platform/using-agents/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
@@ -803,567 +798,567 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/planning",
+      "source": "/agent-platform/agent-platform/using-agents/planning(/?)",
       "destination": "/agent-platform/capabilities/planning/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/third-party-cli-agents",
+      "source": "/agent-platform/agent-platform/using-agents/third-party-cli-agents(/?)",
       "destination": "/agent-platform/cli-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/using-agents/web-search",
+      "source": "/agent-platform/agent-platform/using-agents/web-search(/?)",
       "destination": "/agent-platform/capabilities/web-search/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/voice",
+      "source": "/agent-platform/agent-platform/voice(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agent-platform/warp-ai",
+      "source": "/agent-platform/agent-platform/warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/active-ai",
+      "source": "/agent-platform/agents/active-ai(/?)",
       "destination": "/agent-platform/local-agents/active-ai/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/agent-modality-beta",
+      "source": "/agent-platform/agents/agent-modality-beta(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/agents-md",
+      "source": "/agent-platform/agents/agents-md(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/agents-overview",
+      "source": "/agent-platform/agents/agents-overview(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/ai",
+      "source": "/agent-platform/agents/ai(/?)",
       "destination": "/agent-platform/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/ai-commander",
+      "source": "/agent-platform/agents/ai-commander(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/ai-commands",
+      "source": "/agent-platform/agents/ai-commands(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/ai-faqs",
+      "source": "/agent-platform/agents/ai-faqs(/?)",
       "destination": "/agent-platform/getting-started/faqs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/ai-getting-started",
+      "source": "/agent-platform/agents/ai-getting-started(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/autonomy",
+      "source": "/agent-platform/agents/autonomy(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/autonomy/agent-permissions",
+      "source": "/agent-platform/agents/autonomy/agent-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/autonomy/run-to-completion",
+      "source": "/agent-platform/agents/autonomy/run-to-completion(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/full-terminal-use",
+      "source": "/agent-platform/agents/full-terminal-use(/?)",
       "destination": "/agent-platform/capabilities/full-terminal-use/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/generate",
+      "source": "/agent-platform/agents/generate(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/model-choice",
+      "source": "/agent-platform/agents/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/slash-commands",
+      "source": "/agent-platform/agents/slash-commands(/?)",
       "destination": "/agent-platform/capabilities/slash-commands/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents",
+      "source": "/agent-platform/agents/using-agents(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-context",
+      "source": "/agent-platform/agents/using-agents/agent-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-context/blocks-as-context",
+      "source": "/agent-platform/agents/using-agents/agent-context/blocks-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-context/images-as-context",
+      "source": "/agent-platform/agents/using-agents/agent-context/images-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-context/selection-as-context",
+      "source": "/agent-platform/agents/using-agents/agent-context/selection-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/selection-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-context/urls-as-context",
+      "source": "/agent-platform/agents/using-agents/agent-context/urls-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-context/using-to-add-context",
+      "source": "/agent-platform/agents/using-agents/agent-context/using-to-add-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-conversations",
+      "source": "/agent-platform/agents/using-agents/agent-conversations(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-conversations/conversation-forking",
+      "source": "/agent-platform/agents/using-agents/agent-conversations/conversation-forking(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-profiles-permissions",
+      "source": "/agent-platform/agents/using-agents/agent-profiles-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/agent-tasklists",
+      "source": "/agent-platform/agents/using-agents/agent-tasklists(/?)",
       "destination": "/agent-platform/capabilities/task-lists/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/managing-agents",
+      "source": "/agent-platform/agents/using-agents/managing-agents(/?)",
       "destination": "/platform/managing-cloud-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/model-choice",
+      "source": "/agent-platform/agents/using-agents/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/planning",
+      "source": "/agent-platform/agents/using-agents/planning(/?)",
       "destination": "/agent-platform/capabilities/planning/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/profiles",
+      "source": "/agent-platform/agents/using-agents/profiles(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/third-party-cli-agents",
+      "source": "/agent-platform/agents/using-agents/third-party-cli-agents(/?)",
       "destination": "/agent-platform/cli-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/using-agents/web-search",
+      "source": "/agent-platform/agents/using-agents/web-search(/?)",
       "destination": "/agent-platform/capabilities/web-search/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/voice",
+      "source": "/agent-platform/agents/voice(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/warp-ai",
+      "source": "/agent-platform/agents/warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/agents/warp-ai/agent-mode",
+      "source": "/agent-platform/agents/warp-ai/agent-mode(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/ai",
+      "source": "/agent-platform/ai(/?)",
       "destination": "/agent-platform/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/ai-features/ai-commands",
+      "source": "/agent-platform/ai-features/ai-commands(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/ai-features/model-choice",
+      "source": "/agent-platform/ai-features/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/ai/warp-ai",
+      "source": "/agent-platform/ai/warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/ambient-agents",
+      "source": "/agent-platform/ambient-agents(/?)",
       "destination": "/platform/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/ambient-agents/agent-secrets",
+      "source": "/agent-platform/ambient-agents/agent-secrets(/?)",
       "destination": "/platform/secrets/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/ambient-agents/ambient-agents-overview",
+      "source": "/agent-platform/ambient-agents/ambient-agents-overview(/?)",
       "destination": "/platform/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/ambient-agents/managing-ambient-agents",
+      "source": "/agent-platform/ambient-agents/managing-ambient-agents(/?)",
       "destination": "/platform/managing-cloud-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/ambient-agents/managing-ambient-agents/scheduled-agents",
+      "source": "/agent-platform/ambient-agents/managing-ambient-agents/scheduled-agents(/?)",
       "destination": "/platform/triggers/scheduled-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/agent-session-sharing",
+      "source": "/agent-platform/cloud-agents/agent-session-sharing(/?)",
       "destination": "/agent-platform/local-agents/session-sharing/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/cloud-agent-secrets",
+      "source": "/agent-platform/cloud-agents/cloud-agent-secrets(/?)",
       "destination": "/platform/secrets/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/cloud-agents-faqs",
+      "source": "/agent-platform/cloud-agents/cloud-agents-faqs(/?)",
       "destination": "/platform/faqs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/cloud-agents-overview",
+      "source": "/agent-platform/cloud-agents/cloud-agents-overview(/?)",
       "destination": "/platform/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/cloud-agents-platform",
+      "source": "/agent-platform/cloud-agents/cloud-agents-platform(/?)",
       "destination": "/platform/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/cloud-agents-session-sharing",
+      "source": "/agent-platform/cloud-agents/cloud-agents-session-sharing(/?)",
       "destination": "/platform/viewing-cloud-agent-runs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference",
+      "source": "/agent-platform/cloud-agents/managed-worker-reference(/?)",
       "destination": "/platform/self-hosting/reference/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/direct-backend",
+      "source": "/agent-platform/cloud-agents/managed-worker-reference/direct-backend(/?)",
       "destination": "/platform/self-hosting/managed-direct/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/docker-connectivity",
+      "source": "/agent-platform/cloud-agents/managed-worker-reference/docker-connectivity(/?)",
       "destination": "/platform/self-hosting/managed-docker/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/helm-chart",
+      "source": "/agent-platform/cloud-agents/managed-worker-reference/helm-chart(/?)",
       "destination": "/platform/self-hosting/managed-kubernetes/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/kubernetes-backend",
+      "source": "/agent-platform/cloud-agents/managed-worker-reference/kubernetes-backend(/?)",
       "destination": "/platform/self-hosting/managed-kubernetes/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/private-docker-registries",
+      "source": "/agent-platform/cloud-agents/managed-worker-reference/private-docker-registries(/?)",
       "destination": "/platform/self-hosting/managed-docker/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/warp-platform",
+      "source": "/agent-platform/cloud-agents/warp-platform(/?)",
       "destination": "/platform/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/code/code-review/interactive-code-review",
+      "source": "/agent-platform/code/code-review/interactive-code-review(/?)",
       "destination": "/agent-platform/local-agents/interactive-code-review/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/code/codebase-context",
+      "source": "/agent-platform/code/codebase-context(/?)",
       "destination": "/agent-platform/capabilities/codebase-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/code/reviewing-code",
+      "source": "/agent-platform/code/reviewing-code(/?)",
       "destination": "/agent-platform/local-agents/code-diffs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/agent-mode",
+      "source": "/agent-platform/features/agent-mode(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/agent-mode/agents-md",
+      "source": "/agent-platform/features/agent-mode/agents-md(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/agents",
+      "source": "/agent-platform/features/agents(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai",
+      "source": "/agent-platform/features/ai(/?)",
       "destination": "/agent-platform/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-agents",
+      "source": "/agent-platform/features/ai-agents(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-and-agents",
+      "source": "/agent-platform/features/ai-and-agents(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-and-agents/agents",
+      "source": "/agent-platform/features/ai-and-agents/agents(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-and-ask-warp",
+      "source": "/agent-platform/features/ai-and-ask-warp(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-and-ask-warp-ai",
+      "source": "/agent-platform/features/ai-and-ask-warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-and-session-history/warp-ai",
+      "source": "/agent-platform/features/ai-and-session-history/warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-and-stack-overflow/agent-mode",
+      "source": "/agent-platform/features/ai-and-stack-overflow/agent-mode(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-and-warpdrive/warp-ai",
+      "source": "/agent-platform/features/ai-and-warpdrive/warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-command",
+      "source": "/agent-platform/features/ai-command(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-command-search",
+      "source": "/agent-platform/features/ai-command-search(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-command-search/limits",
+      "source": "/agent-platform/features/ai-command-search/limits(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-command-search/model-choice",
+      "source": "/agent-platform/features/ai-command-search/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-command-suggestions",
+      "source": "/agent-platform/features/ai-command-suggestions(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-command/model-choice",
+      "source": "/agent-platform/features/ai-command/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-commands",
+      "source": "/agent-platform/features/ai-commands(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-features",
+      "source": "/agent-platform/features/ai-features(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai-features/ai-chat",
+      "source": "/agent-platform/features/ai-features/ai-chat(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/agent",
+      "source": "/agent-platform/features/ai/agent(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/agent-mode",
+      "source": "/agent-platform/features/ai/agent-mode(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/agents",
+      "source": "/agent-platform/features/ai/agents(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/ai-models-and-providers",
+      "source": "/agent-platform/features/ai/ai-models-and-providers(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/ai-setup",
+      "source": "/agent-platform/features/ai/ai-setup(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/assistant",
+      "source": "/agent-platform/features/ai/assistant(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/commands",
+      "source": "/agent-platform/features/ai/commands(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/commands-and-agents",
+      "source": "/agent-platform/features/ai/commands-and-agents(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/commands/agent-mode",
+      "source": "/agent-platform/features/ai/commands/agent-mode(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/commands/agents",
+      "source": "/agent-platform/features/ai/commands/agents(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/commands/ai-agent",
+      "source": "/agent-platform/features/ai/commands/ai-agent(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/commands/ai-commands-overview",
+      "source": "/agent-platform/features/ai/commands/ai-commands-overview(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/get-started-with-warp-ai",
+      "source": "/agent-platform/features/ai/get-started-with-warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/model-choice",
+      "source": "/agent-platform/features/ai/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/using-ai",
+      "source": "/agent-platform/features/ai/using-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/ai/using-warp-ai",
+      "source": "/agent-platform/features/ai/using-warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/generate",
+      "source": "/agent-platform/features/generate(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/integrations/mcp",
+      "source": "/agent-platform/features/integrations/mcp(/?)",
       "destination": "/agent-platform/capabilities/mcp/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/knowledge",
+      "source": "/agent-platform/features/knowledge(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/model-choice",
+      "source": "/agent-platform/features/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/terminal-ai",
+      "source": "/agent-platform/features/terminal-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/terminal-ai/ai-models",
+      "source": "/agent-platform/features/terminal-ai/ai-models(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/voice",
+      "source": "/agent-platform/features/voice(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai",
+      "source": "/agent-platform/features/warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/active-ai",
+      "source": "/agent-platform/features/warp-ai/active-ai(/?)",
       "destination": "/agent-platform/local-agents/active-ai/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/agent-mode",
+      "source": "/agent-platform/features/warp-ai/agent-mode(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
@@ -1373,142 +1368,142 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/agent-modea",
+      "source": "/agent-platform/features/warp-ai/agent-modea(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/ai-command-search",
+      "source": "/agent-platform/features/warp-ai/ai-command-search(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/ai-command-suggestions",
+      "source": "/agent-platform/features/warp-ai/ai-command-suggestions(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/generate",
+      "source": "/agent-platform/features/warp-ai/generate(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/knowledge",
+      "source": "/agent-platform/features/warp-ai/knowledge(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/mcp",
+      "source": "/agent-platform/features/warp-ai/mcp(/?)",
       "destination": "/agent-platform/capabilities/mcp/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/rules",
+      "source": "/agent-platform/features/warp-ai/rules(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/features/warp-ai/voice",
+      "source": "/agent-platform/features/warp-ai/voice(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/getting-started/quickstart-guide/agents-in-warp",
+      "source": "/agent-platform/getting-started/quickstart-guide/agents-in-warp(/?)",
       "destination": "/agent-platform/getting-started/agents-in-warp/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/integrations",
+      "source": "/agent-platform/integrations(/?)",
       "destination": "/platform/integrations/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/integrations-overview",
+      "source": "/agent-platform/integrations-overview(/?)",
       "destination": "/platform/integrations/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/integrations/github-actions",
+      "source": "/agent-platform/integrations/github-actions(/?)",
       "destination": "/platform/integrations/github-actions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/integrations/github-actions/demo-issue-triage-bot",
+      "source": "/agent-platform/integrations/github-actions/demo-issue-triage-bot(/?)",
       "destination": "/platform/integrations/quickstart-github-actions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/integrations/demo-issue-triage-bot",
+      "source": "/agent-platform/cloud-agents/integrations/demo-issue-triage-bot(/?)",
       "destination": "/platform/integrations/quickstart-github-actions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/integrations/integrations-overview",
+      "source": "/agent-platform/integrations/integrations-overview(/?)",
       "destination": "/platform/integrations/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/integrations/integrations-overview/team-access-billing-and-identity-permissions",
+      "source": "/agent-platform/integrations/integrations-overview/team-access-billing-and-identity-permissions(/?)",
       "destination": "/platform/team-access-billing-and-identity/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/integrations/linear",
+      "source": "/agent-platform/integrations/linear(/?)",
       "destination": "/platform/integrations/linear/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/integrations/slack",
+      "source": "/agent-platform/integrations/slack(/?)",
       "destination": "/platform/integrations/slack/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/knowledge-and-collaboration/mcp",
+      "source": "/agent-platform/knowledge-and-collaboration/mcp(/?)",
       "destination": "/agent-platform/capabilities/mcp/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/knowledge-and-collaboration/rules",
+      "source": "/agent-platform/knowledge-and-collaboration/rules(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/knowledge-and-collaboration/session-sharing/agent-session-sharing",
+      "source": "/agent-platform/knowledge-and-collaboration/session-sharing/agent-session-sharing(/?)",
       "destination": "/agent-platform/local-agents/session-sharing/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/knowledge-and-collaboration/session-sharing/ambient-agents-session-sharing",
+      "source": "/agent-platform/knowledge-and-collaboration/session-sharing/ambient-agents-session-sharing(/?)",
       "destination": "/platform/viewing-cloud-agent-runs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/knowledge-and-collaboration/warp-drive/model-context-protocol-mcp",
+      "source": "/agent-platform/knowledge-and-collaboration/warp-drive/model-context-protocol-mcp(/?)",
       "destination": "/agent-platform/capabilities/mcp/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/local-agents",
+      "source": "/agent-platform/local-agents(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/local-agents/agent-notifications",
+      "source": "/agent-platform/local-agents/agent-notifications(/?)",
       "destination": "/agent-platform/capabilities/agent-notifications/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/local-agents/agents-overview",
+      "source": "/agent-platform/local-agents/agents-overview(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/local-agents/ambient-agents-session-sharing",
+      "source": "/agent-platform/local-agents/ambient-agents-session-sharing(/?)",
       "destination": "/platform/viewing-cloud-agent-runs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/local-agents/code-diffs-in-agent-conversations",
+      "source": "/agent-platform/local-agents/code-diffs-in-agent-conversations(/?)",
       "destination": "/agent-platform/local-agents/code-diffs/",
       "statusCode": 308
     },
@@ -1518,282 +1513,282 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/local-agents/interacting-with-agents/agent-modality",
+      "source": "/agent-platform/local-agents/interacting-with-agents/agent-modality(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/local-agents/interacting-with-agents/agent-modality-beta",
+      "source": "/agent-platform/local-agents/interacting-with-agents/agent-modality-beta(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/local-agents/third-party-cli-agents",
+      "source": "/agent-platform/local-agents/third-party-cli-agents(/?)",
       "destination": "/agent-platform/cli-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/platform",
+      "source": "/agent-platform/platform(/?)",
       "destination": "/platform/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/platform/deployment-patterns",
+      "source": "/agent-platform/platform/deployment-patterns(/?)",
       "destination": "/platform/deployment-patterns/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/platform/environments",
+      "source": "/agent-platform/platform/environments(/?)",
       "destination": "/platform/environments/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/platform/integrations/integrations-overview",
+      "source": "/agent-platform/platform/integrations/integrations-overview(/?)",
       "destination": "/platform/integrations/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/platform/team-access-billing-and-identity-permissions",
+      "source": "/agent-platform/platform/team-access-billing-and-identity-permissions(/?)",
       "destination": "/platform/team-access-billing-and-identity/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/platform/warp-platform",
+      "source": "/agent-platform/platform/warp-platform(/?)",
       "destination": "/platform/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/settings/ai-agents",
+      "source": "/agent-platform/settings/ai-agents(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/terminal-ai/getting-started",
+      "source": "/agent-platform/terminal-ai/getting-started(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/terminal/ai",
+      "source": "/agent-platform/terminal/ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/terminal/ai/agent-mode",
+      "source": "/agent-platform/terminal/ai/agent-mode(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/terminal/warp-ai",
+      "source": "/agent-platform/terminal/warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/third-party-agents/claude-code",
+      "source": "/agent-platform/third-party-agents/claude-code(/?)",
       "destination": "/agent-platform/cli-agents/claude-code/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/third-party-agents/codex",
+      "source": "/agent-platform/third-party-agents/codex(/?)",
       "destination": "/agent-platform/cli-agents/codex/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/third-party-agents/opencode",
+      "source": "/agent-platform/third-party-agents/opencode(/?)",
       "destination": "/agent-platform/cli-agents/opencode/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/third-party-agents/overview",
+      "source": "/agent-platform/third-party-agents/overview(/?)",
       "destination": "/agent-platform/cli-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/third-party-agents/remote-control",
+      "source": "/agent-platform/third-party-agents/remote-control(/?)",
       "destination": "/agent-platform/cli-agents/remote-control/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/third-party-agents/rich-input",
+      "source": "/agent-platform/third-party-agents/rich-input(/?)",
       "destination": "/agent-platform/cli-agents/rich-input/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/using-agents/managing-agents",
+      "source": "/agent-platform/using-agents/managing-agents(/?)",
       "destination": "/platform/managing-cloud-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/active-ai",
+      "source": "/agent-platform/warp-agents/active-ai(/?)",
       "destination": "/agent-platform/local-agents/active-ai/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/agent-context/blocks-as-context",
+      "source": "/agent-platform/warp-agents/agent-context/blocks-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/agent-context/images-as-context",
+      "source": "/agent-platform/warp-agents/agent-context/images-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/agent-context/selection-as-context",
+      "source": "/agent-platform/warp-agents/agent-context/selection-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/selection-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/agent-context/urls-as-context",
+      "source": "/agent-platform/warp-agents/agent-context/urls-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/agent-context/using-to-add-context",
+      "source": "/agent-platform/warp-agents/agent-context/using-to-add-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/agent-notifications",
+      "source": "/agent-platform/warp-agents/agent-notifications(/?)",
       "destination": "/agent-platform/capabilities/agent-notifications/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/agent-profiles-permissions",
+      "source": "/agent-platform/warp-agents/agent-profiles-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview",
+      "source": "/agent-platform/warp-agents/capabilities-overview(/?)",
       "destination": "/agent-platform/capabilities/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/cloud-conversations",
+      "source": "/agent-platform/warp-agents/cloud-conversations(/?)",
       "destination": "/agent-platform/local-agents/cloud-conversations/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/code-diffs",
+      "source": "/agent-platform/warp-agents/code-diffs(/?)",
       "destination": "/agent-platform/local-agents/code-diffs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/codebase-context",
+      "source": "/agent-platform/warp-agents/codebase-context(/?)",
       "destination": "/agent-platform/capabilities/codebase-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/computer-use",
+      "source": "/agent-platform/warp-agents/computer-use(/?)",
       "destination": "/agent-platform/capabilities/computer-use/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/full-terminal-use",
+      "source": "/agent-platform/warp-agents/full-terminal-use(/?)",
       "destination": "/agent-platform/capabilities/full-terminal-use/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/interacting-with-agents/conversation-forking",
+      "source": "/agent-platform/warp-agents/interacting-with-agents/conversation-forking(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/interacting-with-agents/terminal-and-agent-modes",
+      "source": "/agent-platform/warp-agents/interacting-with-agents/terminal-and-agent-modes(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/interacting-with-agents/voice",
+      "source": "/agent-platform/warp-agents/interacting-with-agents/voice(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/interactive-code-review",
+      "source": "/agent-platform/warp-agents/interactive-code-review(/?)",
       "destination": "/agent-platform/local-agents/interactive-code-review/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/mcp",
+      "source": "/agent-platform/warp-agents/mcp(/?)",
       "destination": "/agent-platform/capabilities/mcp/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/model-choice",
+      "source": "/agent-platform/warp-agents/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/planning",
+      "source": "/agent-platform/warp-agents/planning(/?)",
       "destination": "/agent-platform/capabilities/planning/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/rules",
+      "source": "/agent-platform/warp-agents/rules(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/session-sharing",
+      "source": "/agent-platform/warp-agents/session-sharing(/?)",
       "destination": "/agent-platform/local-agents/session-sharing/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/skills",
+      "source": "/agent-platform/warp-agents/skills(/?)",
       "destination": "/agent-platform/capabilities/skills/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/slash-commands",
+      "source": "/agent-platform/warp-agents/slash-commands(/?)",
       "destination": "/agent-platform/capabilities/slash-commands/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/task-lists",
+      "source": "/agent-platform/warp-agents/task-lists(/?)",
       "destination": "/agent-platform/capabilities/task-lists/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/web-search",
+      "source": "/agent-platform/warp-agents/web-search(/?)",
       "destination": "/agent-platform/capabilities/web-search/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-ai",
+      "source": "/agent-platform/warp-ai(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-ai/assistant",
+      "source": "/agent-platform/warp-ai/assistant(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-ai/get-started",
+      "source": "/agent-platform/warp-ai/get-started(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-platform",
+      "source": "/agent-platform/warp-platform(/?)",
       "destination": "/platform/overview/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/app-icons",
+      "source": "/appearance/app-icons(/?)",
       "destination": "/terminal/appearance/app-icons/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/blocks-behavior",
+      "source": "/appearance/blocks-behavior(/?)",
       "destination": "/terminal/appearance/blocks-behavior/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/compact-mode",
+      "source": "/appearance/compact-mode(/?)",
       "destination": "/terminal/appearance/blocks-behavior/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/custom-themes",
+      "source": "/appearance/custom-themes(/?)",
       "destination": "/terminal/appearance/custom-themes/",
       "statusCode": 308
     },
@@ -1803,17 +1798,17 @@
       "statusCode": 308
     },
     {
-      "source": "/appearance/input-position",
+      "source": "/appearance/input-position(/?)",
       "destination": "/terminal/appearance/input-position/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/pane-dimming",
+      "source": "/appearance/pane-dimming(/?)",
       "destination": "/terminal/appearance/pane-dimming/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/prompt",
+      "source": "/appearance/prompt(/?)",
       "destination": "/terminal/appearance/prompt/",
       "statusCode": 308
     },
@@ -1823,92 +1818,92 @@
       "statusCode": 308
     },
     {
-      "source": "/appearance/size-opacity-blurring",
+      "source": "/appearance/size-opacity-blurring(/?)",
       "destination": "/terminal/appearance/size-opacity-blurring/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/tab-indicators",
+      "source": "/appearance/tab-indicators(/?)",
       "destination": "/terminal/appearance/tabs-behavior/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/tabs-behavior",
+      "source": "/appearance/tabs-behavior(/?)",
       "destination": "/terminal/appearance/tabs-behavior/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/text-fonts-cursor",
+      "source": "/appearance/text-fonts-cursor(/?)",
       "destination": "/terminal/appearance/text-fonts-cursor/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/themes",
+      "source": "/appearance/themes(/?)",
       "destination": "/terminal/appearance/themes/",
       "statusCode": 308
     },
     {
-      "source": "/appearance/transparency-and-blurring",
+      "source": "/appearance/transparency-and-blurring(/?)",
       "destination": "/terminal/appearance/size-opacity-blurring/",
       "statusCode": 308
     },
     {
-      "source": "/changelog/changelog/rss",
+      "source": "/changelog/changelog/rss(/?)",
       "destination": "/changelog/rss.xml",
       "statusCode": 308
     },
     {
-      "source": "/changelog/getting-started/changelog",
+      "source": "/changelog/getting-started/changelog(/?)",
       "destination": "/changelog/",
       "statusCode": 308
     },
     {
-      "source": "/changelog/help/changelog",
+      "source": "/changelog/help/changelog(/?)",
       "destination": "/changelog/",
       "statusCode": 308
     },
     {
-      "source": "/changelog/release-notes",
+      "source": "/changelog/release-notes(/?)",
       "destination": "/changelog/",
       "statusCode": 308
     },
     {
-      "source": "/changelog/rss",
+      "source": "/changelog/rss(/?)",
       "destination": "/changelog/rss.xml",
       "statusCode": 308
     },
     {
-      "source": "/changelog/url/docs.warp.dev/getting-started/changelog",
+      "source": "/changelog/url/docs.warp.dev/getting-started/changelog(/?)",
       "destination": "/changelog/",
       "statusCode": 308
     },
     {
-      "source": "/changelog/warp/getting-started/changelog",
+      "source": "/changelog/warp/getting-started/changelog(/?)",
       "destination": "/changelog/",
       "statusCode": 308
     },
     {
-      "source": "/code-editor",
+      "source": "/code-editor(/?)",
       "destination": "/code/code-editor/",
       "statusCode": 308
     },
     {
-      "source": "/code/code-overview",
+      "source": "/code/code-overview(/?)",
       "destination": "/code/overview/",
       "statusCode": 308
     },
     {
-      "source": "/code/code-review/interactive-code-review",
+      "source": "/code/code-review/interactive-code-review(/?)",
       "destination": "/code/code-review/",
       "statusCode": 308
     },
     {
-      "source": "/code/reviewing-code",
+      "source": "/code/reviewing-code(/?)",
       "destination": "/code/code-review/",
       "statusCode": 308
     },
     {
-      "source": "/configuration",
+      "source": "/configuration(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
@@ -1923,122 +1918,122 @@
       "statusCode": 308
     },
     {
-      "source": "/features",
+      "source": "/features(/?)",
       "destination": "/",
       "statusCode": 308
     },
     {
-      "source": "/features/accessibility",
+      "source": "/features/accessibility(/?)",
       "destination": "/terminal/more-features/accessibility/",
       "statusCode": 308
     },
     {
-      "source": "/features/advanced/settings",
+      "source": "/features/advanced/settings(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/features/appearance",
+      "source": "/features/appearance(/?)",
       "destination": "/terminal/appearance/",
       "statusCode": 308
     },
     {
-      "source": "/features/appearance/compact-mode",
+      "source": "/features/appearance/compact-mode(/?)",
       "destination": "/terminal/appearance/blocks-behavior/",
       "statusCode": 308
     },
     {
-      "source": "/features/appearance/custom-themes",
+      "source": "/features/appearance/custom-themes(/?)",
       "destination": "/terminal/appearance/custom-themes/",
       "statusCode": 308
     },
     {
-      "source": "/features/appearance/prompt",
+      "source": "/features/appearance/prompt(/?)",
       "destination": "/terminal/appearance/prompt/",
       "statusCode": 308
     },
     {
-      "source": "/features/appearance/themes",
+      "source": "/features/appearance/themes(/?)",
       "destination": "/terminal/appearance/themes/",
       "statusCode": 308
     },
     {
-      "source": "/features/blocks",
+      "source": "/features/blocks(/?)",
       "destination": "/terminal/blocks/",
       "statusCode": 308
     },
     {
-      "source": "/features/blocks/background-blocks",
+      "source": "/features/blocks/background-blocks(/?)",
       "destination": "/terminal/blocks/background-blocks/",
       "statusCode": 308
     },
     {
-      "source": "/features/blocks/block-actions",
+      "source": "/features/blocks/block-actions(/?)",
       "destination": "/terminal/blocks/block-actions/",
       "statusCode": 308
     },
     {
-      "source": "/features/blocks/block-basics",
+      "source": "/features/blocks/block-basics(/?)",
       "destination": "/terminal/blocks/block-basics/",
       "statusCode": 308
     },
     {
-      "source": "/features/blocks/block-filtering",
+      "source": "/features/blocks/block-filtering(/?)",
       "destination": "/terminal/blocks/block-filtering/",
       "statusCode": 308
     },
     {
-      "source": "/features/blocks/block-sharing",
+      "source": "/features/blocks/block-sharing(/?)",
       "destination": "/terminal/blocks/block-sharing/",
       "statusCode": 308
     },
     {
-      "source": "/features/blocks/sticky-command-header",
+      "source": "/features/blocks/sticky-command-header(/?)",
       "destination": "/terminal/blocks/sticky-command-header/",
       "statusCode": 308
     },
     {
-      "source": "/features/command-completions",
+      "source": "/features/command-completions(/?)",
       "destination": "/terminal/command-completions/",
       "statusCode": 308
     },
     {
-      "source": "/features/command-completions/autosuggestions",
+      "source": "/features/command-completions/autosuggestions(/?)",
       "destination": "/terminal/command-completions/autosuggestions/",
       "statusCode": 308
     },
     {
-      "source": "/features/command-completions/completions",
+      "source": "/features/command-completions/completions(/?)",
       "destination": "/terminal/command-completions/completions/",
       "statusCode": 308
     },
     {
-      "source": "/features/command-history",
+      "source": "/features/command-history(/?)",
       "destination": "/terminal/entry/command-history/",
       "statusCode": 308
     },
     {
-      "source": "/features/command-inspector",
+      "source": "/features/command-inspector(/?)",
       "destination": "/terminal/editor/command-inspector/",
       "statusCode": 308
     },
     {
-      "source": "/features/command-palette",
+      "source": "/features/command-palette(/?)",
       "destination": "/terminal/command-palette/",
       "statusCode": 308
     },
     {
-      "source": "/features/command-search",
+      "source": "/features/command-search(/?)",
       "destination": "/terminal/entry/command-search/",
       "statusCode": 308
     },
     {
-      "source": "/features/compact-mode",
+      "source": "/features/compact-mode(/?)",
       "destination": "/terminal/appearance/blocks-behavior/",
       "statusCode": 308
     },
     {
-      "source": "/features/completions",
+      "source": "/features/completions(/?)",
       "destination": "/terminal/command-completions/completions/",
       "statusCode": 308
     },
@@ -2053,162 +2048,162 @@
       "statusCode": 308
     },
     {
-      "source": "/features/customize/custom-keyboard-shortcuts",
+      "source": "/features/customize/custom-keyboard-shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/features/editor",
+      "source": "/features/editor(/?)",
       "destination": "/terminal/editor/",
       "statusCode": 308
     },
     {
-      "source": "/features/editor/alias-expansion",
+      "source": "/features/editor/alias-expansion(/?)",
       "destination": "/terminal/editor/alias-expansion/",
       "statusCode": 308
     },
     {
-      "source": "/features/editor/command-corrections",
+      "source": "/features/editor/command-corrections(/?)",
       "destination": "/terminal/entry/command-corrections/",
       "statusCode": 308
     },
     {
-      "source": "/features/editor/command-inspector",
+      "source": "/features/editor/command-inspector(/?)",
       "destination": "/terminal/editor/command-inspector/",
       "statusCode": 308
     },
     {
-      "source": "/features/editor/syntax-error-highlighting",
+      "source": "/features/editor/syntax-error-highlighting(/?)",
       "destination": "/terminal/editor/syntax-error-highlighting/",
       "statusCode": 308
     },
     {
-      "source": "/features/editor/vim",
+      "source": "/features/editor/vim(/?)",
       "destination": "/terminal/editor/vim/",
       "statusCode": 308
     },
     {
-      "source": "/features/entry",
+      "source": "/features/entry(/?)",
       "destination": "/terminal/entry/",
       "statusCode": 308
     },
     {
-      "source": "/features/entry/command-corrections",
+      "source": "/features/entry/command-corrections(/?)",
       "destination": "/terminal/entry/command-corrections/",
       "statusCode": 308
     },
     {
-      "source": "/features/entry/command-history",
+      "source": "/features/entry/command-history(/?)",
       "destination": "/terminal/entry/command-history/",
       "statusCode": 308
     },
     {
-      "source": "/features/entry/command-search",
+      "source": "/features/entry/command-search(/?)",
       "destination": "/terminal/entry/command-search/",
       "statusCode": 308
     },
     {
-      "source": "/features/entry/synchronized-inputs",
+      "source": "/features/entry/synchronized-inputs(/?)",
       "destination": "/terminal/entry/synchronized-inputs/",
       "statusCode": 308
     },
     {
-      "source": "/features/entry/workflows",
+      "source": "/features/entry/workflows(/?)",
       "destination": "/terminal/entry/yaml-workflows/",
       "statusCode": 308
     },
     {
-      "source": "/features/entry/yaml-workflows",
+      "source": "/features/entry/yaml-workflows(/?)",
       "destination": "/terminal/entry/yaml-workflows/",
       "statusCode": 308
     },
     {
-      "source": "/features/files-and-links",
+      "source": "/features/files-and-links(/?)",
       "destination": "/terminal/more-features/files-and-links/",
       "statusCode": 308
     },
     {
-      "source": "/features/find",
+      "source": "/features/find(/?)",
       "destination": "/terminal/blocks/find/",
       "statusCode": 308
     },
     {
-      "source": "/features/full-screen-apps",
+      "source": "/features/full-screen-apps(/?)",
       "destination": "/terminal/more-features/full-screen-apps/",
       "statusCode": 308
     },
     {
-      "source": "/features/global-hotkey",
+      "source": "/features/global-hotkey(/?)",
       "destination": "/terminal/windows/global-hotkey/",
       "statusCode": 308
     },
     {
-      "source": "/features/hotkey-window",
+      "source": "/features/hotkey-window(/?)",
       "destination": "/terminal/windows/global-hotkey/",
       "statusCode": 308
     },
     {
-      "source": "/features/integrations",
+      "source": "/features/integrations(/?)",
       "destination": "/terminal/integrations-and-plugins/",
       "statusCode": 308
     },
     {
-      "source": "/features/integrations-and-plugins",
+      "source": "/features/integrations-and-plugins(/?)",
       "destination": "/terminal/integrations-and-plugins/",
       "statusCode": 308
     },
     {
-      "source": "/features/integrations/urls-and-deep-links",
+      "source": "/features/integrations/urls-and-deep-links(/?)",
       "destination": "/terminal/more-features/uri-scheme/",
       "statusCode": 308
     },
     {
-      "source": "/features/keybindings",
+      "source": "/features/keybindings(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/features/keyboard-input",
+      "source": "/features/keyboard-input(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/features/keyboard-shortcuts",
+      "source": "/features/keyboard-shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/features/knowledge",
+      "source": "/features/knowledge(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/features/launch-configurations",
+      "source": "/features/launch-configurations(/?)",
       "destination": "/terminal/sessions/launch-configurations/",
       "statusCode": 308
     },
     {
-      "source": "/features/linux",
+      "source": "/features/linux(/?)",
       "destination": "/terminal/more-features/linux/",
       "statusCode": 308
     },
     {
-      "source": "/features/markdown-viewer",
+      "source": "/features/markdown-viewer(/?)",
       "destination": "/terminal/more-features/markdown-viewer/",
       "statusCode": 308
     },
     {
-      "source": "/features/notifications",
+      "source": "/features/notifications(/?)",
       "destination": "/terminal/more-features/notifications/",
       "statusCode": 308
     },
     {
-      "source": "/features/overview",
+      "source": "/features/overview(/?)",
       "destination": "/",
       "statusCode": 308
     },
     {
-      "source": "/features/prompt",
+      "source": "/features/prompt(/?)",
       "destination": "/terminal/appearance/prompt/",
       "statusCode": 308
     },
@@ -2233,227 +2228,227 @@
       "statusCode": 308
     },
     {
-      "source": "/features/quit-warning",
+      "source": "/features/quit-warning(/?)",
       "destination": "/terminal/more-features/quit-warning/",
       "statusCode": 308
     },
     {
-      "source": "/features/session-management-and-restoration",
+      "source": "/features/session-management-and-restoration(/?)",
       "destination": "/terminal/sessions/",
       "statusCode": 308
     },
     {
-      "source": "/features/session-management/launch-configurations",
+      "source": "/features/session-management/launch-configurations(/?)",
       "destination": "/terminal/sessions/launch-configurations/",
       "statusCode": 308
     },
     {
-      "source": "/features/session-management/session-navigation",
+      "source": "/features/session-management/session-navigation(/?)",
       "destination": "/terminal/sessions/session-navigation/",
       "statusCode": 308
     },
     {
-      "source": "/features/session-management/session-restoration",
+      "source": "/features/session-management/session-restoration(/?)",
       "destination": "/terminal/sessions/session-restoration/",
       "statusCode": 308
     },
     {
-      "source": "/features/session-sharing",
+      "source": "/features/session-sharing(/?)",
       "destination": "/knowledge-and-collaboration/session-sharing/",
       "statusCode": 308
     },
     {
-      "source": "/features/sessions",
+      "source": "/features/sessions(/?)",
       "destination": "/terminal/sessions/",
       "statusCode": 308
     },
     {
-      "source": "/features/sessions/README",
+      "source": "/features/sessions/README(/?)",
       "destination": "/terminal/sessions/",
       "statusCode": 308
     },
     {
-      "source": "/features/sessions/launch-configurations",
+      "source": "/features/sessions/launch-configurations(/?)",
       "destination": "/terminal/sessions/launch-configurations/",
       "statusCode": 308
     },
     {
-      "source": "/features/sessions/quit-warning-modal",
+      "source": "/features/sessions/quit-warning-modal(/?)",
       "destination": "/terminal/more-features/quit-warning/",
       "statusCode": 308
     },
     {
-      "source": "/features/sessions/session-navigation",
+      "source": "/features/sessions/session-navigation(/?)",
       "destination": "/terminal/sessions/session-navigation/",
       "statusCode": 308
     },
     {
-      "source": "/features/sessions/session-restoration",
+      "source": "/features/sessions/session-restoration(/?)",
       "destination": "/terminal/sessions/session-restoration/",
       "statusCode": 308
     },
     {
-      "source": "/features/sessions/sharing-sessions",
+      "source": "/features/sessions/sharing-sessions(/?)",
       "destination": "/knowledge-and-collaboration/session-sharing/",
       "statusCode": 308
     },
     {
-      "source": "/features/settings",
+      "source": "/features/settings(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/features/settings-sync",
+      "source": "/features/settings-sync(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/features/settings/configuration-files",
+      "source": "/features/settings/configuration-files(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/features/smart-select",
+      "source": "/features/smart-select(/?)",
       "destination": "/terminal/more-features/text-selection/",
       "statusCode": 308
     },
     {
-      "source": "/features/split-panes",
+      "source": "/features/split-panes(/?)",
       "destination": "/terminal/windows/split-panes/",
       "statusCode": 308
     },
     {
-      "source": "/features/ssh",
+      "source": "/features/ssh(/?)",
       "destination": "/terminal/warpify/ssh-legacy/",
       "statusCode": 308
     },
     {
-      "source": "/features/subshells",
+      "source": "/features/subshells(/?)",
       "destination": "/terminal/warpify/subshells/",
       "statusCode": 308
     },
     {
-      "source": "/features/system-settings",
+      "source": "/features/system-settings(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/features/tabs",
+      "source": "/features/tabs(/?)",
       "destination": "/terminal/windows/tabs/",
       "statusCode": 308
     },
     {
-      "source": "/features/teams",
+      "source": "/features/teams(/?)",
       "destination": "/knowledge-and-collaboration/teams/",
       "statusCode": 308
     },
     {
-      "source": "/features/terminal-features",
+      "source": "/features/terminal-features(/?)",
       "destination": "/terminal/blocks/",
       "statusCode": 308
     },
     {
-      "source": "/features/the-input-editor",
+      "source": "/features/the-input-editor(/?)",
       "destination": "/terminal/editor/",
       "statusCode": 308
     },
     {
-      "source": "/features/themes",
+      "source": "/features/themes(/?)",
       "destination": "/terminal/appearance/themes/",
       "statusCode": 308
     },
     {
-      "source": "/features/themes/custom-themes",
+      "source": "/features/themes/custom-themes(/?)",
       "destination": "/terminal/appearance/custom-themes/",
       "statusCode": 308
     },
     {
-      "source": "/features/uri-scheme",
+      "source": "/features/uri-scheme(/?)",
       "destination": "/terminal/more-features/uri-scheme/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-ai/code",
+      "source": "/features/warp-ai/code(/?)",
       "destination": "/code/overview/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-ai/knowledge",
+      "source": "/features/warp-ai/knowledge(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-ai/mcp",
+      "source": "/features/warp-ai/mcp(/?)",
       "destination": "/agent-platform/capabilities/mcp/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-ai/rules",
+      "source": "/features/warp-ai/rules(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-drive",
+      "source": "/features/warp-drive(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-drive/environment-variables",
+      "source": "/features/warp-drive/environment-variables(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/environment-variables/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-drive/notebooks",
+      "source": "/features/warp-drive/notebooks(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/notebooks/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-drive/prompts",
+      "source": "/features/warp-drive/prompts(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/prompts/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-drive/warp-drive-on-the-web",
+      "source": "/features/warp-drive/warp-drive-on-the-web(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/web/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-drive/warp-drive-on-the-web-beta",
+      "source": "/features/warp-drive/warp-drive-on-the-web-beta(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/web/",
       "statusCode": 308
     },
     {
-      "source": "/features/warp-drive/workflows",
+      "source": "/features/warp-drive/workflows(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/workflows/",
       "statusCode": 308
     },
     {
-      "source": "/features/warpify",
+      "source": "/features/warpify(/?)",
       "destination": "/terminal/warpify/",
       "statusCode": 308
     },
     {
-      "source": "/features/warpify/ssh",
+      "source": "/features/warpify/ssh(/?)",
       "destination": "/terminal/warpify/ssh/",
       "statusCode": 308
     },
     {
-      "source": "/features/warpify/ssh-legacy",
+      "source": "/features/warpify/ssh-legacy(/?)",
       "destination": "/terminal/warpify/ssh-legacy/",
       "statusCode": 308
     },
     {
-      "source": "/features/warpify/subshells",
+      "source": "/features/warpify/subshells(/?)",
       "destination": "/terminal/warpify/subshells/",
       "statusCode": 308
     },
     {
-      "source": "/features/windows",
+      "source": "/features/windows(/?)",
       "destination": "/terminal/windows/",
       "statusCode": 308
     },
     {
-      "source": "/features/windows/global-hotkey",
+      "source": "/features/windows/global-hotkey(/?)",
       "destination": "/terminal/windows/global-hotkey/",
       "statusCode": 308
     },
@@ -2463,37 +2458,37 @@
       "statusCode": 308
     },
     {
-      "source": "/features/windows/split-panes",
+      "source": "/features/windows/split-panes(/?)",
       "destination": "/terminal/windows/split-panes/",
       "statusCode": 308
     },
     {
-      "source": "/features/windows/tabs",
+      "source": "/features/windows/tabs(/?)",
       "destination": "/terminal/windows/tabs/",
       "statusCode": 308
     },
     {
-      "source": "/features/windows/~",
+      "source": "/features/windows/~(/?)",
       "destination": "/terminal/windows/",
       "statusCode": 308
     },
     {
-      "source": "/features/workflows",
+      "source": "/features/workflows(/?)",
       "destination": "/terminal/entry/yaml-workflows/",
       "statusCode": 308
     },
     {
-      "source": "/features/workflows/block-metrics/shortcuts",
+      "source": "/features/workflows/block-metrics/shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/features/working-directory",
+      "source": "/features/working-directory(/?)",
       "destination": "/terminal/more-features/working-directory/",
       "statusCode": 308
     },
     {
-      "source": "/features/workspaces",
+      "source": "/features/workspaces(/?)",
       "destination": "/terminal/sessions/",
       "statusCode": 308
     },
@@ -2503,37 +2498,37 @@
       "statusCode": 308
     },
     {
-      "source": "/getting-started/account-and-login",
+      "source": "/getting-started/account-and-login(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/coding-in-warp",
+      "source": "/getting-started/coding-in-warp(/?)",
       "destination": "/getting-started/quickstart/coding-in-warp/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/customizing-warp",
+      "source": "/getting-started/customizing-warp(/?)",
       "destination": "/getting-started/quickstart/customizing-warp/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/customizing-warp/settings",
+      "source": "/getting-started/customizing-warp/settings(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/download-and-install",
+      "source": "/getting-started/download-and-install(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/downloading-warp",
+      "source": "/getting-started/downloading-warp(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/getting-started-with-warp",
+      "source": "/getting-started/getting-started-with-warp(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
@@ -2558,132 +2553,132 @@
       "statusCode": 308
     },
     {
-      "source": "/getting-started/getting-started-with-warp-on-linux",
+      "source": "/getting-started/getting-started-with-warp-on-linux(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/guides/shortcuts",
+      "source": "/getting-started/guides/shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/how-to-use-warp",
+      "source": "/getting-started/how-to-use-warp(/?)",
       "destination": "/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/installation",
+      "source": "/getting-started/installation(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/installation-and-setup",
+      "source": "/getting-started/installation-and-setup(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/installation/linux",
+      "source": "/getting-started/installation/linux(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/installing-warp",
+      "source": "/getting-started/installing-warp(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/installing-warp-on-linux",
+      "source": "/getting-started/installing-warp-on-linux(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/launch-configurations",
+      "source": "/getting-started/launch-configurations(/?)",
       "destination": "/terminal/sessions/launch-configurations/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/launching-warp",
+      "source": "/getting-started/launching-warp(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/linux",
+      "source": "/getting-started/linux(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/linux-installation",
+      "source": "/getting-started/linux-installation(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/mac-permissions",
+      "source": "/getting-started/mac-permissions(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/quickstart-guide",
+      "source": "/getting-started/quickstart-guide(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/quickstart-guide/README",
+      "source": "/getting-started/quickstart-guide/README(/?)",
       "destination": "/quickstart/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/quickstart-guide/agents-in-warp",
+      "source": "/getting-started/quickstart-guide/agents-in-warp(/?)",
       "destination": "/agent-platform/getting-started/agents-in-warp/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/quickstart-guide/coding-in-warp",
+      "source": "/getting-started/quickstart-guide/coding-in-warp(/?)",
       "destination": "/getting-started/quickstart/coding-in-warp/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/quickstart-guide/customizing-warp",
+      "source": "/getting-started/quickstart-guide/customizing-warp(/?)",
       "destination": "/getting-started/quickstart/customizing-warp/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/quickstart-guide/installation-and-setup",
+      "source": "/getting-started/quickstart-guide/installation-and-setup(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/settings",
+      "source": "/getting-started/settings(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/syncing-your-terminal",
+      "source": "/getting-started/syncing-your-terminal(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/terminal",
+      "source": "/getting-started/terminal(/?)",
       "destination": "/terminal/blocks/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/using-warp-with-shells",
+      "source": "/getting-started/using-warp-with-shells(/?)",
       "destination": "/getting-started/supported-shells/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/what-is-warp",
+      "source": "/getting-started/what-is-warp(/?)",
       "destination": "/",
       "statusCode": 308
     },
     {
-      "source": "/guide/ssh-guide",
+      "source": "/guide/ssh-guide(/?)",
       "destination": "/terminal/warpify/ssh/",
       "statusCode": 308
     },
     {
-      "source": "/guides/ssh-quickstart",
+      "source": "/guides/ssh-quickstart(/?)",
       "destination": "/terminal/warpify/ssh/",
       "statusCode": 308
     },
@@ -2693,162 +2688,162 @@
       "statusCode": 308
     },
     {
-      "source": "/how-does-warp-compare/performance",
+      "source": "/how-does-warp-compare/performance(/?)",
       "destination": "/terminal/comparisons/performance/",
       "statusCode": 308
     },
     {
-      "source": "/how-does-warp-compare/terminal-features",
+      "source": "/how-does-warp-compare/terminal-features(/?)",
       "destination": "/terminal/comparisons/terminal-features/",
       "statusCode": 308
     },
     {
-      "source": "/installation",
+      "source": "/installation(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/installation/linux",
+      "source": "/installation/linux(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/keyboard-shortcuts",
+      "source": "/keyboard-shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/knowledge-and-collaboration/warp-drive/warp-drive-as-agent-mode-context",
+      "source": "/knowledge-and-collaboration/warp-drive/warp-drive-as-agent-mode-context(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/agent-mode-context/",
       "statusCode": 308
     },
     {
-      "source": "/knowledge-and-collaboration/warp-drive/warp-drive-on-the-web",
+      "source": "/knowledge-and-collaboration/warp-drive/warp-drive-on-the-web(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/web/",
       "statusCode": 308
     },
     {
-      "source": "/knowledge-and-collaboration/workflows",
+      "source": "/knowledge-and-collaboration/workflows(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/workflows/",
       "statusCode": 308
     },
     {
-      "source": "/quick-start",
+      "source": "/quick-start(/?)",
       "destination": "/quickstart/",
       "statusCode": 308
     },
     {
-      "source": "/readme",
+      "source": "/readme(/?)",
       "destination": "/",
       "statusCode": 308
     },
     {
-      "source": "/reference/agent-api-and-sdk",
+      "source": "/reference/agent-api-and-sdk(/?)",
       "destination": "/reference/api-and-sdk/",
       "statusCode": 308
     },
     {
-      "source": "/reference/ambient-agents/mcp-servers-for-agents",
+      "source": "/reference/ambient-agents/mcp-servers-for-agents(/?)",
       "destination": "/reference/cli/mcp-servers/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/agent",
+      "source": "/reference/api-and-sdk/agent(/?)",
       "destination": "/api#tag/agent",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/agent-1",
+      "source": "/reference/api-and-sdk/agent-1(/?)",
       "destination": "/api",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/schedules",
+      "source": "/reference/api-and-sdk/schedules(/?)",
       "destination": "/api#tag/schedules",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/authentication_required",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/authentication_required(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/authentication-required/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/budget_exceeded",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/budget_exceeded(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/budget-exceeded/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/content_policy_violation",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/content_policy_violation(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/content-policy-violation/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/environment_setup_failed",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/environment_setup_failed(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/environment-setup-failed/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/external_authentication_required",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/external_authentication_required(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/external-authentication-required/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/agent_process_failed",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/agent_process_failed(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/agent-process-failed/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/feature_not_available",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/feature_not_available(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/feature-not-available/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/infrastructure_timeout",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/infrastructure_timeout(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/insufficient_credits",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/insufficient_credits(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/insufficient-credits/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/integration_disabled",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/integration_disabled(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/integration-disabled/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/integration_not_configured",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/integration_not_configured(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/integration-not-configured/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/internal_error",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/internal_error(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/internal-error/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/invalid_request",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/invalid_request(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/invalid-request/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/not_authorized",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/not_authorized(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/not-authorized/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/operation_not_supported",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/operation_not_supported(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/operation-not-supported/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/resource_not_found",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/resource_not_found(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/resource-not-found/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/resource_unavailable",
+      "source": "/reference/api-and-sdk/troubleshooting/errors/resource_unavailable(/?)",
       "destination": "/reference/api-and-sdk/troubleshooting/errors/resource-unavailable/",
       "statusCode": 308
     },
@@ -2868,22 +2863,22 @@
       "statusCode": 308
     },
     {
-      "source": "/reference/cli/integrations-and-environments",
+      "source": "/reference/cli/integrations-and-environments(/?)",
       "destination": "/reference/cli/integration-setup/",
       "statusCode": 308
     },
     {
-      "source": "/reference/cli/mcp-for-cloud-agents",
+      "source": "/reference/cli/mcp-for-cloud-agents(/?)",
       "destination": "/reference/cli/mcp-servers/",
       "statusCode": 308
     },
     {
-      "source": "/reference/cli/mcp-servers-for-cloud-agents",
+      "source": "/reference/cli/mcp-servers-for-cloud-agents(/?)",
       "destination": "/reference/cli/mcp-servers/",
       "statusCode": 308
     },
     {
-      "source": "/reference/developers/cli",
+      "source": "/reference/developers/cli(/?)",
       "destination": "/reference/cli/",
       "statusCode": 308
     },
@@ -2903,7 +2898,7 @@
       "statusCode": 308
     },
     {
-      "source": "/reference/integrations/integrations-overview/integrations-and-environments",
+      "source": "/reference/integrations/integrations-overview/integrations-and-environments(/?)",
       "destination": "/reference/cli/integration-setup/",
       "statusCode": 308
     },
@@ -2913,17 +2908,17 @@
       "statusCode": 308
     },
     {
-      "source": "/reference/keybindings",
+      "source": "/reference/keybindings(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/reference/keyboard-shortcuts",
+      "source": "/reference/keyboard-shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/reference/platform/agent-api-and-sdk",
+      "source": "/reference/platform/agent-api-and-sdk(/?)",
       "destination": "/reference/api-and-sdk/",
       "statusCode": 308
     },
@@ -2933,22 +2928,22 @@
       "statusCode": 308
     },
     {
-      "source": "/reference/platform/agent-api-and-sdk/agent",
+      "source": "/reference/platform/agent-api-and-sdk/agent(/?)",
       "destination": "/reference/api-and-sdk/",
       "statusCode": 308
     },
     {
-      "source": "/reference/platform/agent-api-and-sdk/agent-1",
+      "source": "/reference/platform/agent-api-and-sdk/agent-1(/?)",
       "destination": "/reference/api-and-sdk/",
       "statusCode": 308
     },
     {
-      "source": "/reference/platform/agent-api-and-sdk/demo-sentry-monitoring-with-sdk",
+      "source": "/reference/platform/agent-api-and-sdk/demo-sentry-monitoring-with-sdk(/?)",
       "destination": "/reference/api-and-sdk/demo-sentry-monitoring-with-sdk/",
       "statusCode": 308
     },
     {
-      "source": "/reference/platform/cli",
+      "source": "/reference/platform/cli(/?)",
       "destination": "/reference/cli/",
       "statusCode": 308
     },
@@ -2958,62 +2953,62 @@
       "statusCode": 308
     },
     {
-      "source": "/reference/platform/cli/api-keys",
+      "source": "/reference/platform/cli/api-keys(/?)",
       "destination": "/reference/cli/api-keys/",
       "statusCode": 308
     },
     {
-      "source": "/reference/platform/cli/integrations-and-environments",
+      "source": "/reference/platform/cli/integrations-and-environments(/?)",
       "destination": "/reference/cli/integration-setup/",
       "statusCode": 308
     },
     {
-      "source": "/reference/platform/cli/troubleshooting",
+      "source": "/reference/platform/cli/troubleshooting(/?)",
       "destination": "/reference/cli/troubleshooting/",
       "statusCode": 308
     },
     {
-      "source": "/reference/platform/warp-platform",
+      "source": "/reference/platform/warp-platform(/?)",
       "destination": "/reference/",
       "statusCode": 308
     },
     {
-      "source": "/reference/settings",
+      "source": "/reference/settings(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/session-sharing",
+      "source": "/session-sharing(/?)",
       "destination": "/knowledge-and-collaboration/session-sharing/",
       "statusCode": 308
     },
     {
-      "source": "/settings",
+      "source": "/settings(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/settings-menu/overview",
+      "source": "/settings-menu/overview(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/settings-overview",
+      "source": "/settings-overview(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/settings/features",
+      "source": "/settings/features(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/settings/keyboard-shortcuts",
+      "source": "/settings/keyboard-shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/shortcuts",
+      "source": "/shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
@@ -3023,47 +3018,47 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/features/network-log",
+      "source": "/support-and-community/features/network-log(/?)",
       "destination": "/support-and-community/privacy-and-security/network-log/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/features/secret-redaction",
+      "source": "/support-and-community/features/secret-redaction(/?)",
       "destination": "/support-and-community/privacy-and-security/secret-redaction/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/getting-started/privacy",
+      "source": "/support-and-community/getting-started/privacy(/?)",
       "destination": "/support-and-community/privacy-and-security/privacy/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/getting-started/refer-a-friend",
+      "source": "/support-and-community/getting-started/refer-a-friend(/?)",
       "destination": "/support-and-community/community/refer-a-friend/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/getting-started/warp-preview-and-alpha-program",
+      "source": "/support-and-community/getting-started/warp-preview-and-alpha-program(/?)",
       "destination": "/support-and-community/community/warp-preview-and-alpha-program/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help",
+      "source": "/support-and-community/help(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/ai-features/bring-your-own-llm",
+      "source": "/support-and-community/help/ai-features/bring-your-own-llm(/?)",
       "destination": "/agent-platform/inference/bring-your-own-api-key/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/faq/billing-and-payments",
+      "source": "/support-and-community/help/faq/billing-and-payments(/?)",
       "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/known-issues",
+      "source": "/support-and-community/help/known-issues(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
       "statusCode": 308
     },
@@ -3093,22 +3088,22 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/licenses",
+      "source": "/support-and-community/help/licenses(/?)",
       "destination": "/support-and-community/community/open-source-licenses/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/plans-subscriptions-and-pricing",
+      "source": "/support-and-community/help/plans-subscriptions-and-pricing(/?)",
       "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/releasing-and-updating",
+      "source": "/support-and-community/help/releasing-and-updating(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/sending-us-feedback",
+      "source": "/support-and-community/help/sending-us-feedback(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/sending-us-feedback/",
       "statusCode": 308
     },
@@ -3118,7 +3113,7 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/troubleshooting-login-issues",
+      "source": "/support-and-community/help/troubleshooting-login-issues(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/troubleshooting-login-issues/",
       "statusCode": 308
     },
@@ -3128,7 +3123,7 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/uninstalling-warp",
+      "source": "/support-and-community/help/uninstalling-warp(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/logging-out-and-uninstalling/",
       "statusCode": 308
     },
@@ -3138,7 +3133,7 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/updating-warp",
+      "source": "/support-and-community/help/updating-warp(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
       "statusCode": 308
     },
@@ -3148,67 +3143,67 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/help/using-warp-offline",
+      "source": "/support-and-community/help/using-warp-offline(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/using-warp-offline/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/known-issues",
+      "source": "/support-and-community/known-issues(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/plans-and-billing/overages-legacy",
+      "source": "/support-and-community/plans-and-billing/overages-legacy(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/plans-pricing-and-billing",
+      "source": "/support-and-community/plans-pricing-and-billing(/?)",
       "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/plans-pricing-and-billing/add-on-credits",
+      "source": "/support-and-community/plans-pricing-and-billing/add-on-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/plans-pricing-and-billing/ai-credits",
+      "source": "/support-and-community/plans-pricing-and-billing/ai-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/plans-pricing-and-billing/bring-your-own-api-key",
+      "source": "/support-and-community/plans-pricing-and-billing/bring-your-own-api-key(/?)",
       "destination": "/agent-platform/inference/bring-your-own-api-key/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/plans-pricing-and-billing/overages-legacy",
+      "source": "/support-and-community/plans-pricing-and-billing/overages-legacy(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/plans-pricing-and-billing/pricing-faqs",
+      "source": "/support-and-community/plans-pricing-and-billing/pricing-faqs(/?)",
       "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/privacy",
+      "source": "/support-and-community/privacy(/?)",
       "destination": "/support-and-community/privacy-and-security/privacy/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/privacy-and-security",
+      "source": "/support-and-community/privacy-and-security(/?)",
       "destination": "/support-and-community/privacy-and-security/privacy/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/privacy/network-log",
+      "source": "/support-and-community/privacy/network-log(/?)",
       "destination": "/support-and-community/privacy-and-security/network-log/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/privacy/privacy",
+      "source": "/support-and-community/privacy/privacy(/?)",
       "destination": "/support-and-community/privacy-and-security/privacy/",
       "statusCode": 308
     },
@@ -3223,27 +3218,27 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/privacy/secret-redaction",
+      "source": "/support-and-community/privacy/secret-redaction(/?)",
       "destination": "/support-and-community/privacy-and-security/secret-redaction/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/security-and-privacy/data-handling",
+      "source": "/support-and-community/security-and-privacy/data-handling(/?)",
       "destination": "/support-and-community/privacy-and-security/privacy/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/security-and-privacy/data-ownership",
+      "source": "/support-and-community/security-and-privacy/data-ownership(/?)",
       "destination": "/support-and-community/privacy-and-security/privacy/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing",
+      "source": "/support-and-community/support-and-billing(/?)",
       "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/known-issues",
+      "source": "/support-and-community/support-and-billing/known-issues(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
       "statusCode": 308
     },
@@ -3278,27 +3273,27 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/licenses",
+      "source": "/support-and-community/support-and-billing/licenses(/?)",
       "destination": "/support-and-community/community/open-source-licenses/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/licenses-intro",
+      "source": "/support-and-community/support-and-billing/licenses-intro(/?)",
       "destination": "/support-and-community/community/open-source-licenses/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-billing/bring-your-own-api-key",
+      "source": "/support-and-community/support-and-billing/plans-and-billing/bring-your-own-api-key(/?)",
       "destination": "/agent-platform/inference/bring-your-own-api-key/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing",
+      "source": "/support-and-community/support-and-billing/plans-and-pricing(/?)",
       "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/add-on-credits",
+      "source": "/support-and-community/support-and-billing/plans-and-pricing/add-on-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
@@ -3308,12 +3303,12 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/ai-credits",
+      "source": "/support-and-community/support-and-billing/plans-and-pricing/ai-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/ai-requests",
+      "source": "/support-and-community/support-and-billing/plans-and-pricing/ai-requests(/?)",
       "destination": "/support-and-community/plans-and-billing/credits/",
       "statusCode": 308
     },
@@ -3328,7 +3323,7 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/bring-your-own-api-key",
+      "source": "/support-and-community/support-and-billing/plans-and-pricing/bring-your-own-api-key(/?)",
       "destination": "/agent-platform/inference/bring-your-own-api-key/",
       "statusCode": 308
     },
@@ -3343,7 +3338,7 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/pricing-faqs",
+      "source": "/support-and-community/support-and-billing/plans-and-pricing/pricing-faqs(/?)",
       "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
       "statusCode": 308
     },
@@ -3358,27 +3353,27 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/reload-credits-add-on-credits",
+      "source": "/support-and-community/support-and-billing/plans-and-pricing/reload-credits-add-on-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/usage-overages",
+      "source": "/support-and-community/support-and-billing/plans-and-pricing/usage-overages(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/plans-and-prilling/bring-your-own-api-key",
+      "source": "/support-and-community/support-and-billing/plans-and-prilling/bring-your-own-api-key(/?)",
       "destination": "/agent-platform/inference/bring-your-own-api-key/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/pricing-faqs",
+      "source": "/support-and-community/support-and-billing/pricing-faqs(/?)",
       "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/sending-us-feedback",
+      "source": "/support-and-community/support-and-billing/sending-us-feedback(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/sending-us-feedback/",
       "statusCode": 308
     },
@@ -3398,12 +3393,12 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/subscription-management",
+      "source": "/support-and-community/support-and-billing/subscription-management(/?)",
       "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/troubleshooting-login-issues",
+      "source": "/support-and-community/support-and-billing/troubleshooting-login-issues(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/troubleshooting-login-issues/",
       "statusCode": 308
     },
@@ -3423,77 +3418,77 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/uninstalling-warp",
+      "source": "/support-and-community/support-and-billing/uninstalling-warp(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/logging-out-and-uninstalling/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/updating-warp",
+      "source": "/support-and-community/support-and-billing/updating-warp(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-billing/using-warp-offline",
+      "source": "/support-and-community/support-and-billing/using-warp-offline(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/using-warp-offline/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-community/plans-and-billing/ai-credits",
+      "source": "/support-and-community/support-and-community/plans-and-billing/ai-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing",
+      "source": "/support-and-community/support-and-community/plans-pricing-and-billing(/?)",
       "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/add-on-credits",
+      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/add-on-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/ai-credits",
+      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/ai-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/bring-your-own-api-key",
+      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/bring-your-own-api-key(/?)",
       "destination": "/agent-platform/inference/bring-your-own-api-key/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/overages-legacy",
+      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/overages-legacy(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/pricing-faqs",
+      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/pricing-faqs(/?)",
       "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/support-and-community/privacy-and-security/privacy",
+      "source": "/support-and-community/support-and-community/privacy-and-security/privacy(/?)",
       "destination": "/support-and-community/privacy-and-security/privacy/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/troubleshooting",
+      "source": "/support-and-community/troubleshooting(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/troubleshooting-and-support/uninstalling-warp",
+      "source": "/support-and-community/troubleshooting-and-support/uninstalling-warp(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/logging-out-and-uninstalling/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/troubleshooting/common-issues",
+      "source": "/support-and-community/troubleshooting/common-issues(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/troubleshooting/general-troubleshooting",
+      "source": "/support-and-community/troubleshooting/general-troubleshooting(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
       "statusCode": 308
     },
@@ -3503,7 +3498,7 @@
       "statusCode": 308
     },
     {
-      "source": "/terminal/command-input/command-suggestions",
+      "source": "/terminal/command-input/command-suggestions(/?)",
       "destination": "/terminal/command-completions/completions/",
       "statusCode": 308
     },
@@ -3513,462 +3508,462 @@
       "statusCode": 308
     },
     {
-      "source": "/terminal/keybindings",
+      "source": "/terminal/keybindings(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/keyboard-shortcuts",
+      "source": "/terminal/keyboard-shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/sessions/tab-configs",
+      "source": "/terminal/sessions/tab-configs(/?)",
       "destination": "/terminal/windows/tab-configs/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/shortcuts",
+      "source": "/terminal/shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/universal-input",
+      "source": "/terminal/universal-input(/?)",
       "destination": "/terminal/input/classic-input/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/universal-input/classic-input",
+      "source": "/terminal/universal-input/classic-input(/?)",
       "destination": "/terminal/input/classic-input/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/windows/keyboard-shortcuts",
+      "source": "/terminal/windows/keyboard-shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/windows/keyboard-shortcuts-windows",
+      "source": "/terminal/windows/keyboard-shortcuts-windows(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/windows/windows-shortcuts",
+      "source": "/terminal/windows/windows-shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/warp-quickstart",
+      "source": "/warp-quickstart(/?)",
       "destination": "/quickstart/",
       "statusCode": 308
     },
     {
-      "source": "/warp-terminal-101/settings",
+      "source": "/warp-terminal-101/settings(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/warp/code/code-editor/code-editor-vim-keybindings",
+      "source": "/warp/code/code-editor/code-editor-vim-keybindings(/?)",
       "destination": "/code/code-editor/code-editor-vim-keybindings/",
       "statusCode": 308
     },
     {
-      "source": "/warp/code/code-editor/file-tree",
+      "source": "/warp/code/code-editor/file-tree(/?)",
       "destination": "/code/code-editor/file-tree/",
       "statusCode": 308
     },
     {
-      "source": "/warp/code/code-editor/find-and-replace",
+      "source": "/warp/code/code-editor/find-and-replace(/?)",
       "destination": "/code/code-editor/find-and-replace/",
       "statusCode": 308
     },
     {
-      "source": "/warp/code/code-editor/language-server-protocol",
+      "source": "/warp/code/code-editor/language-server-protocol(/?)",
       "destination": "/code/code-editor/language-server-protocol/",
       "statusCode": 308
     },
     {
-      "source": "/warp/code/code-review",
+      "source": "/warp/code/code-review(/?)",
       "destination": "/code/code-review/",
       "statusCode": 308
     },
     {
-      "source": "/warp/code/git-worktrees",
+      "source": "/warp/code/git-worktrees(/?)",
       "destination": "/code/git-worktrees/",
       "statusCode": 308
     },
     {
-      "source": "/warp/code/overview",
+      "source": "/warp/code/overview(/?)",
       "destination": "/code/overview/",
       "statusCode": 308
     },
     {
-      "source": "/warp/code/ssh-feature-support",
+      "source": "/warp/code/ssh-feature-support(/?)",
       "destination": "/code/ssh-feature-support/",
       "statusCode": 308
     },
     {
-      "source": "/warp/getting-started/coding-in-warp",
+      "source": "/warp/getting-started/coding-in-warp(/?)",
       "destination": "/getting-started/quickstart/coding-in-warp/",
       "statusCode": 308
     },
     {
-      "source": "/warp/getting-started/customizing-warp",
+      "source": "/warp/getting-started/customizing-warp(/?)",
       "destination": "/getting-started/quickstart/customizing-warp/",
       "statusCode": 308
     },
     {
-      "source": "/warp/getting-started/installation-and-setup",
+      "source": "/warp/getting-started/installation-and-setup(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/warp/getting-started/keyboard-shortcuts",
+      "source": "/warp/getting-started/keyboard-shortcuts(/?)",
       "destination": "/getting-started/keyboard-shortcuts/",
       "statusCode": 308
     },
     {
-      "source": "/warp/getting-started/migrate-to-warp",
+      "source": "/warp/getting-started/migrate-to-warp(/?)",
       "destination": "/getting-started/migrate-to-warp/",
       "statusCode": 308
     },
     {
-      "source": "/warp/getting-started/quickstart",
+      "source": "/warp/getting-started/quickstart(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/warp/getting-started/supported-shells",
+      "source": "/warp/getting-started/supported-shells(/?)",
       "destination": "/getting-started/supported-shells/",
       "statusCode": 308
     },
     {
-      "source": "/warp/knowledge-and-collaboration/admin-panel",
+      "source": "/warp/knowledge-and-collaboration/admin-panel(/?)",
       "destination": "/knowledge-and-collaboration/admin-panel/",
       "statusCode": 308
     },
     {
-      "source": "/warp/knowledge-and-collaboration/teams",
+      "source": "/warp/knowledge-and-collaboration/teams(/?)",
       "destination": "/knowledge-and-collaboration/teams/",
       "statusCode": 308
     },
     {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/agent-mode-context",
+      "source": "/warp/knowledge-and-collaboration/warp-drive/agent-mode-context(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/agent-mode-context/",
       "statusCode": 308
     },
     {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/ai-objects",
+      "source": "/warp/knowledge-and-collaboration/warp-drive/ai-objects(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/ai-objects/",
       "statusCode": 308
     },
     {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/environment-variables",
+      "source": "/warp/knowledge-and-collaboration/warp-drive/environment-variables(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/environment-variables/",
       "statusCode": 308
     },
     {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/notebooks",
+      "source": "/warp/knowledge-and-collaboration/warp-drive/notebooks(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/notebooks/",
       "statusCode": 308
     },
     {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/prompts",
+      "source": "/warp/knowledge-and-collaboration/warp-drive/prompts(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/prompts/",
       "statusCode": 308
     },
     {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/web",
+      "source": "/warp/knowledge-and-collaboration/warp-drive/web(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/web/",
       "statusCode": 308
     },
     {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/workflows",
+      "source": "/warp/knowledge-and-collaboration/warp-drive/workflows(/?)",
       "destination": "/knowledge-and-collaboration/warp-drive/workflows/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/app-icons",
+      "source": "/warp/terminal/appearance/app-icons(/?)",
       "destination": "/terminal/appearance/app-icons/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/blocks-behavior",
+      "source": "/warp/terminal/appearance/blocks-behavior(/?)",
       "destination": "/terminal/appearance/blocks-behavior/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/custom-themes",
+      "source": "/warp/terminal/appearance/custom-themes(/?)",
       "destination": "/terminal/appearance/custom-themes/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/input-position",
+      "source": "/warp/terminal/appearance/input-position(/?)",
       "destination": "/terminal/appearance/input-position/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/pane-dimming",
+      "source": "/warp/terminal/appearance/pane-dimming(/?)",
       "destination": "/terminal/appearance/pane-dimming/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/prompt",
+      "source": "/warp/terminal/appearance/prompt(/?)",
       "destination": "/terminal/appearance/prompt/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/size-opacity-blurring",
+      "source": "/warp/terminal/appearance/size-opacity-blurring(/?)",
       "destination": "/terminal/appearance/size-opacity-blurring/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/tabs-behavior",
+      "source": "/warp/terminal/appearance/tabs-behavior(/?)",
       "destination": "/terminal/appearance/tabs-behavior/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/text-fonts-cursor",
+      "source": "/warp/terminal/appearance/text-fonts-cursor(/?)",
       "destination": "/terminal/appearance/text-fonts-cursor/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/appearance/themes",
+      "source": "/warp/terminal/appearance/themes(/?)",
       "destination": "/terminal/appearance/themes/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/blocks/background-blocks",
+      "source": "/warp/terminal/blocks/background-blocks(/?)",
       "destination": "/terminal/blocks/background-blocks/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/blocks/block-actions",
+      "source": "/warp/terminal/blocks/block-actions(/?)",
       "destination": "/terminal/blocks/block-actions/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/blocks/block-basics",
+      "source": "/warp/terminal/blocks/block-basics(/?)",
       "destination": "/terminal/blocks/block-basics/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/blocks/block-filtering",
+      "source": "/warp/terminal/blocks/block-filtering(/?)",
       "destination": "/terminal/blocks/block-filtering/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/blocks/block-sharing",
+      "source": "/warp/terminal/blocks/block-sharing(/?)",
       "destination": "/terminal/blocks/block-sharing/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/blocks/find",
+      "source": "/warp/terminal/blocks/find(/?)",
       "destination": "/terminal/blocks/find/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/blocks/sticky-command-header",
+      "source": "/warp/terminal/blocks/sticky-command-header(/?)",
       "destination": "/terminal/blocks/sticky-command-header/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/command-completions/autosuggestions",
+      "source": "/warp/terminal/command-completions/autosuggestions(/?)",
       "destination": "/terminal/command-completions/autosuggestions/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/command-completions/completions",
+      "source": "/warp/terminal/command-completions/completions(/?)",
       "destination": "/terminal/command-completions/completions/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/command-palette",
+      "source": "/warp/terminal/command-palette(/?)",
       "destination": "/terminal/command-palette/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/comparisons/performance",
+      "source": "/warp/terminal/comparisons/performance(/?)",
       "destination": "/terminal/comparisons/performance/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/comparisons/terminal-features",
+      "source": "/warp/terminal/comparisons/terminal-features(/?)",
       "destination": "/terminal/comparisons/terminal-features/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/editor/alias-expansion",
+      "source": "/warp/terminal/editor/alias-expansion(/?)",
       "destination": "/terminal/editor/alias-expansion/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/editor/command-inspector",
+      "source": "/warp/terminal/editor/command-inspector(/?)",
       "destination": "/terminal/editor/command-inspector/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/editor/syntax-error-highlighting",
+      "source": "/warp/terminal/editor/syntax-error-highlighting(/?)",
       "destination": "/terminal/editor/syntax-error-highlighting/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/editor/vim",
+      "source": "/warp/terminal/editor/vim(/?)",
       "destination": "/terminal/editor/vim/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/entry/command-corrections",
+      "source": "/warp/terminal/entry/command-corrections(/?)",
       "destination": "/terminal/entry/command-corrections/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/entry/command-history",
+      "source": "/warp/terminal/entry/command-history(/?)",
       "destination": "/terminal/entry/command-history/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/entry/command-search",
+      "source": "/warp/terminal/entry/command-search(/?)",
       "destination": "/terminal/entry/command-search/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/entry/synchronized-inputs",
+      "source": "/warp/terminal/entry/synchronized-inputs(/?)",
       "destination": "/terminal/entry/synchronized-inputs/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/entry/yaml-workflows",
+      "source": "/warp/terminal/entry/yaml-workflows(/?)",
       "destination": "/terminal/entry/yaml-workflows/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/input/classic-input",
+      "source": "/warp/terminal/input/classic-input(/?)",
       "destination": "/terminal/input/classic-input/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/integrations-and-plugins",
+      "source": "/warp/terminal/integrations-and-plugins(/?)",
       "destination": "/terminal/integrations-and-plugins/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/accessibility",
+      "source": "/warp/terminal/more-features/accessibility(/?)",
       "destination": "/terminal/more-features/accessibility/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/audible-bell",
+      "source": "/warp/terminal/more-features/audible-bell(/?)",
       "destination": "/terminal/more-features/audible-bell/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/files-and-links",
+      "source": "/warp/terminal/more-features/files-and-links(/?)",
       "destination": "/terminal/more-features/files-and-links/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/full-screen-apps",
+      "source": "/warp/terminal/more-features/full-screen-apps(/?)",
       "destination": "/terminal/more-features/full-screen-apps/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/linux",
+      "source": "/warp/terminal/more-features/linux(/?)",
       "destination": "/terminal/more-features/linux/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/markdown-viewer",
+      "source": "/warp/terminal/more-features/markdown-viewer(/?)",
       "destination": "/terminal/more-features/markdown-viewer/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/notifications",
+      "source": "/warp/terminal/more-features/notifications(/?)",
       "destination": "/terminal/more-features/notifications/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/quit-warning",
+      "source": "/warp/terminal/more-features/quit-warning(/?)",
       "destination": "/terminal/more-features/quit-warning/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/settings-sync",
+      "source": "/warp/terminal/more-features/settings-sync(/?)",
       "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/text-selection",
+      "source": "/warp/terminal/more-features/text-selection(/?)",
       "destination": "/terminal/more-features/text-selection/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/uri-scheme",
+      "source": "/warp/terminal/more-features/uri-scheme(/?)",
       "destination": "/terminal/more-features/uri-scheme/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/more-features/working-directory",
+      "source": "/warp/terminal/more-features/working-directory(/?)",
       "destination": "/terminal/more-features/working-directory/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/sessions/launch-configurations",
+      "source": "/warp/terminal/sessions/launch-configurations(/?)",
       "destination": "/terminal/sessions/launch-configurations/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/sessions/session-navigation",
+      "source": "/warp/terminal/sessions/session-navigation(/?)",
       "destination": "/terminal/sessions/session-navigation/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/sessions/session-restoration",
+      "source": "/warp/terminal/sessions/session-restoration(/?)",
       "destination": "/terminal/sessions/session-restoration/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/settings/all-settings",
+      "source": "/warp/terminal/settings/all-settings(/?)",
       "destination": "/getting-started/quickstart/customizing-warp/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/warpify/ssh",
+      "source": "/warp/terminal/warpify/ssh(/?)",
       "destination": "/terminal/warpify/ssh/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/warpify/ssh-legacy",
+      "source": "/warp/terminal/warpify/ssh-legacy(/?)",
       "destination": "/terminal/warpify/ssh-legacy/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/warpify/subshells",
+      "source": "/warp/terminal/warpify/subshells(/?)",
       "destination": "/terminal/warpify/subshells/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/windows/global-hotkey",
+      "source": "/warp/terminal/windows/global-hotkey(/?)",
       "destination": "/terminal/windows/global-hotkey/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/windows/split-panes",
+      "source": "/warp/terminal/windows/split-panes(/?)",
       "destination": "/terminal/windows/split-panes/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/windows/tab-configs",
+      "source": "/warp/terminal/windows/tab-configs(/?)",
       "destination": "/terminal/windows/tab-configs/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/windows/tabs",
+      "source": "/warp/terminal/windows/tabs(/?)",
       "destination": "/terminal/windows/tabs/",
       "statusCode": 308
     },
     {
-      "source": "/warp/terminal/windows/vertical-tabs",
+      "source": "/warp/terminal/windows/vertical-tabs(/?)",
       "destination": "/terminal/windows/vertical-tabs/",
       "statusCode": 308
     },
@@ -4308,112 +4303,112 @@
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/integrations/github-actions/quickstart-github-actions",
+      "source": "/agent-platform/cloud-agents/integrations/github-actions/quickstart-github-actions(/?)",
       "destination": "/platform/integrations/github-actions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/agent-context",
+      "source": "/agent-platform/warp-agents/agent-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/agent-context/mcp",
+      "source": "/agent-platform/warp-agents/agent-context/mcp(/?)",
       "destination": "/agent-platform/capabilities/mcp/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/agent-notifications",
+      "source": "/agent-platform/warp-agents/capabilities-overview/agent-notifications(/?)",
       "destination": "/agent-platform/capabilities/agent-notifications/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/agent-profiles-permissions",
+      "source": "/agent-platform/warp-agents/capabilities-overview/agent-profiles-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/cloud-conversations",
+      "source": "/agent-platform/warp-agents/capabilities-overview/cloud-conversations(/?)",
       "destination": "/agent-platform/local-agents/cloud-conversations/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/codebase-context",
+      "source": "/agent-platform/warp-agents/capabilities-overview/codebase-context(/?)",
       "destination": "/agent-platform/capabilities/codebase-context/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/computer-use",
+      "source": "/agent-platform/warp-agents/capabilities-overview/computer-use(/?)",
       "destination": "/agent-platform/capabilities/computer-use/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/full-terminal-use",
+      "source": "/agent-platform/warp-agents/capabilities-overview/full-terminal-use(/?)",
       "destination": "/agent-platform/capabilities/full-terminal-use/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/model-choice",
+      "source": "/agent-platform/warp-agents/capabilities-overview/model-choice(/?)",
       "destination": "/agent-platform/inference/model-choice/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/planning",
+      "source": "/agent-platform/warp-agents/capabilities-overview/planning(/?)",
       "destination": "/agent-platform/capabilities/planning/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/rules",
+      "source": "/agent-platform/warp-agents/capabilities-overview/rules(/?)",
       "destination": "/agent-platform/capabilities/rules/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/session-sharing",
+      "source": "/agent-platform/warp-agents/capabilities-overview/session-sharing(/?)",
       "destination": "/agent-platform/local-agents/session-sharing/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/skills",
+      "source": "/agent-platform/warp-agents/capabilities-overview/skills(/?)",
       "destination": "/agent-platform/capabilities/skills/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/slash-commands",
+      "source": "/agent-platform/warp-agents/capabilities-overview/slash-commands(/?)",
       "destination": "/agent-platform/capabilities/slash-commands/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/task-lists",
+      "source": "/agent-platform/warp-agents/capabilities-overview/task-lists(/?)",
       "destination": "/agent-platform/capabilities/task-lists/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/capabilities-overview/web-search",
+      "source": "/agent-platform/warp-agents/capabilities-overview/web-search(/?)",
       "destination": "/agent-platform/capabilities/web-search/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/interacting-with-agents",
+      "source": "/agent-platform/warp-agents/interacting-with-agents(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/interacting-with-agents/code-diffs",
+      "source": "/agent-platform/warp-agents/interacting-with-agents/code-diffs(/?)",
       "destination": "/agent-platform/local-agents/code-diffs/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/warp-agents/warp-agents",
+      "source": "/agent-platform/warp-agents/warp-agents(/?)",
       "destination": "/agent-platform/local-agents/overview/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/quickstart",
+      "source": "/getting-started/quickstart(/?)",
       "destination": "/quickstart/",
       "statusCode": 308
     },
     {
-      "source": "/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-\\+-analyze-pr-\\+-modify-ui",
+      "source": "/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-\\+-analyze-pr-\\+-modify-ui(/?)",
       "destination": "/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-analyze-pr-modify-ui/",
       "statusCode": 308
     },
@@ -4423,1628 +4418,338 @@
       "statusCode": 308
     },
     {
-      "source": "/guides/build-an-app-in-warp/building-a-slackbot",
+      "source": "/guides/build-an-app-in-warp/building-a-slackbot(/?)",
       "destination": "/platform/integrations/slack/",
       "statusCode": 308
     },
     {
-      "source": "/guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-\\+-railway",
+      "source": "/guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-\\+-railway(/?)",
       "destination": "/guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-railway/",
       "statusCode": 308
     },
     {
-      "source": "/guides/configuration/how-to-create-project-rules-for-an-existing-project-astro-\\+-typescript-\\+-tailwind",
+      "source": "/guides/configuration/how-to-create-project-rules-for-an-existing-project-astro-\\+-typescript-\\+-tailwind(/?)",
       "destination": "/guides/configuration/how-to-create-project-rules-for-an-existing-project-astro-typescript-tailwind/",
       "statusCode": 308
     },
     {
-      "source": "/guides/devops-and-infrastructure/how-to-analyze-cloud-run-logs-gcloud",
+      "source": "/guides/devops-and-infrastructure/how-to-analyze-cloud-run-logs-gcloud(/?)",
       "destination": "/guides/devops/how-to-analyze-cloud-run-logs-gcloud/",
       "statusCode": 308
     },
     {
-      "source": "/guides/devops-and-infrastructure/how-to-create-a-production-ready-docker-setup",
+      "source": "/guides/devops-and-infrastructure/how-to-create-a-production-ready-docker-setup(/?)",
       "destination": "/guides/devops/how-to-create-a-production-ready-docker-setup/",
       "statusCode": 308
     },
     {
-      "source": "/guides/devops-and-infrastructure/how-to-create-priority-matrix-for-database-optimization",
+      "source": "/guides/devops-and-infrastructure/how-to-create-priority-matrix-for-database-optimization(/?)",
       "destination": "/guides/devops/how-to-create-priority-matrix-for-database-optimization/",
       "statusCode": 308
     },
     {
-      "source": "/guides/devops-and-infrastructure/how-to-generate-unit-and-security-tests-to-debug-faster",
+      "source": "/guides/devops-and-infrastructure/how-to-generate-unit-and-security-tests-to-debug-faster(/?)",
       "destination": "/guides/devops/how-to-generate-unit-and-security-tests-to-debug-faster/",
       "statusCode": 308
     },
     {
-      "source": "/guides/devops-and-infrastructure/how-to-prevent-secrets-from-leaking",
+      "source": "/guides/devops-and-infrastructure/how-to-prevent-secrets-from-leaking(/?)",
       "destination": "/guides/devops/how-to-prevent-secrets-from-leaking/",
       "statusCode": 308
     },
     {
-      "source": "/guides/devops-and-infrastructure/how-to-write-sql-commands-inside-a-postgres-repl",
+      "source": "/guides/devops-and-infrastructure/how-to-write-sql-commands-inside-a-postgres-repl(/?)",
       "destination": "/guides/devops/how-to-write-sql-commands-inside-a-postgres-repl/",
       "statusCode": 308
     },
     {
-      "source": "/guides/devops-and-infrastructure/improve-your-kubernetes-workflow-kubectl-\\+-helm",
+      "source": "/guides/devops-and-infrastructure/improve-your-kubernetes-workflow-kubectl-\\+-helm(/?)",
       "destination": "/guides/devops/improve-your-kubernetes-workflow-kubectl-helm/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/context7-mcp-update-astro-project-with-best-practices",
+      "source": "/guides/external-tools-and-integrations/context7-mcp-update-astro-project-with-best-practices(/?)",
       "destination": "/guides/external-tools/context7-mcp-update-astro-project-with-best-practices/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/figma-remote-mcp-create-a-website-from-a-figma-file-from-scratch",
+      "source": "/guides/external-tools-and-integrations/figma-remote-mcp-create-a-website-from-a-figma-file-from-scratch(/?)",
       "destination": "/guides/external-tools/figma-remote-mcp-create-a-website-from-a-figma-file-from-scratch/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/github-mcp-summarizing-open-prs-and-creating-gh-issues",
+      "source": "/guides/external-tools-and-integrations/github-mcp-summarizing-open-prs-and-creating-gh-issues(/?)",
       "destination": "/guides/external-tools/github-mcp-summarizing-open-prs-and-creating-gh-issues/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-claude-code",
+      "source": "/guides/external-tools-and-integrations/how-to-set-up-claude-code(/?)",
       "destination": "/guides/external-tools/how-to-set-up-claude-code/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-codex-cli",
+      "source": "/guides/external-tools-and-integrations/how-to-set-up-codex-cli(/?)",
       "destination": "/guides/external-tools/how-to-set-up-codex-cli/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-gemini-cli",
+      "source": "/guides/external-tools-and-integrations/how-to-set-up-gemini-cli(/?)",
       "destination": "/guides/external-tools/how-to-set-up-gemini-cli/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-ollama",
+      "source": "/guides/external-tools-and-integrations/how-to-set-up-ollama(/?)",
       "destination": "/guides/external-tools/how-to-set-up-ollama/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-opencode",
+      "source": "/guides/external-tools-and-integrations/how-to-set-up-opencode(/?)",
       "destination": "/guides/external-tools/how-to-set-up-opencode/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/linear-mcp-retrieve-issue-data",
+      "source": "/guides/external-tools-and-integrations/linear-mcp-retrieve-issue-data(/?)",
       "destination": "/guides/external-tools/linear-mcp-retrieve-issue-data/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/linear-mcp-updating-tickets-with-a-lean-build-approach",
+      "source": "/guides/external-tools-and-integrations/linear-mcp-updating-tickets-with-a-lean-build-approach(/?)",
       "destination": "/guides/external-tools/linear-mcp-updating-tickets-with-a-lean-build-approach/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/puppeteer-mcp-scraping-amazon-web-reviews",
+      "source": "/guides/external-tools-and-integrations/puppeteer-mcp-scraping-amazon-web-reviews(/?)",
       "destination": "/guides/external-tools/puppeteer-mcp-scraping-amazon-web-reviews/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/sentry-mcp-fix-sentry-error-in-empower-website",
+      "source": "/guides/external-tools-and-integrations/sentry-mcp-fix-sentry-error-in-empower-website(/?)",
       "destination": "/guides/external-tools/sentry-mcp-fix-sentry-error-in-empower-website/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/sqlite-and-stripe-mcp-basic-queries-you-can-make-after-set-up",
+      "source": "/guides/external-tools-and-integrations/sqlite-and-stripe-mcp-basic-queries-you-can-make-after-set-up(/?)",
       "destination": "/guides/external-tools/sqlite-and-stripe-mcp-basic-queries-you-can-make-after-set-up/",
       "statusCode": 308
     },
     {
-      "source": "/guides/external-tools-and-integrations/using-mcp-servers-with-warp",
+      "source": "/guides/external-tools-and-integrations/using-mcp-servers-with-warp(/?)",
       "destination": "/guides/external-tools/using-mcp-servers-with-warp/",
       "statusCode": 308
     },
     {
-      "source": "/guides/frontend-and-ui/how-to-actually-code-ui-that-matches-your-mockup-react-\\+-tailwind",
+      "source": "/guides/frontend-and-ui/how-to-actually-code-ui-that-matches-your-mockup-react-\\+-tailwind(/?)",
       "destination": "/guides/frontend/how-to-actually-code-ui-that-matches-your-mockup-react-tailwind/",
       "statusCode": 308
     },
     {
-      "source": "/guides/frontend-and-ui/how-to-replace-a-ui-element-in-warp-rust-codebase",
+      "source": "/guides/frontend-and-ui/how-to-replace-a-ui-element-in-warp-rust-codebase(/?)",
       "destination": "/guides/frontend/how-to-replace-a-ui-element-in-warp-rust-codebase/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/api-and-sdk",
+      "source": "/reference/api-and-sdk/api-and-sdk(/?)",
       "destination": "/reference/api-and-sdk/",
       "statusCode": 308
     },
     {
-      "source": "/reference/api-and-sdk/models",
+      "source": "/reference/api-and-sdk/models(/?)",
       "destination": "/reference/api-and-sdk/",
       "statusCode": 308
     },
     {
-      "source": "/reference/cli/cli",
+      "source": "/reference/cli/cli(/?)",
       "destination": "/reference/cli/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/privacy-security-and-licensing/network-log",
+      "source": "/support-and-community/privacy-security-and-licensing/network-log(/?)",
       "destination": "/support-and-community/privacy-and-security/network-log/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/privacy-security-and-licensing/open-source-licenses",
+      "source": "/support-and-community/privacy-security-and-licensing/open-source-licenses(/?)",
       "destination": "/support-and-community/community/open-source-licenses/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/privacy-security-and-licensing/privacy",
+      "source": "/support-and-community/privacy-security-and-licensing/privacy(/?)",
       "destination": "/support-and-community/privacy-and-security/privacy/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/privacy-security-and-licensing/secret-redaction",
+      "source": "/support-and-community/privacy-security-and-licensing/secret-redaction(/?)",
       "destination": "/support-and-community/privacy-and-security/secret-redaction/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/classic-input",
+      "source": "/terminal/classic-input(/?)",
       "destination": "/terminal/input/classic-input/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/terminal-features",
+      "source": "/terminal/terminal-features(/?)",
       "destination": "/terminal/comparisons/terminal-features/",
       "statusCode": 308
     },
     {
-      "source": "/terminal/windows/launch-configurations",
+      "source": "/terminal/windows/launch-configurations(/?)",
       "destination": "/terminal/sessions/launch-configurations/",
       "statusCode": 308
     },
     {
-      "source": "/agents/agents-overview",
+      "source": "/agents/agents-overview(/?)",
       "destination": "/agent-platform/",
       "statusCode": 308
     },
     {
-      "source": "/agents/ai",
+      "source": "/agents/ai(/?)",
       "destination": "/agent-platform/",
       "statusCode": 308
     },
     {
-      "source": "/agents/ai-faqs",
+      "source": "/agents/ai-faqs(/?)",
       "destination": "/agent-platform/getting-started/faqs/",
       "statusCode": 308
     },
     {
-      "source": "/agents/autonomy",
+      "source": "/agents/autonomy(/?)",
       "destination": "/agent-platform/getting-started/agents-in-warp/",
       "statusCode": 308
     },
     {
-      "source": "/agents/using-agents/agent-context/blocks-as-context",
+      "source": "/agents/using-agents/agent-context/blocks-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agents/using-agents/agent-context/images-as-context",
+      "source": "/agents/using-agents/agent-context/images-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agents/using-agents/agent-context/urls-as-context",
+      "source": "/agents/using-agents/agent-context/urls-as-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
       "statusCode": 308
     },
     {
-      "source": "/agents/using-agents/agent-context/using-to-add-context",
+      "source": "/agents/using-agents/agent-context/using-to-add-context(/?)",
       "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
       "statusCode": 308
     },
     {
-      "source": "/agents/using-agents/agent-conversations/conversation-forking",
+      "source": "/agents/using-agents/agent-conversations/conversation-forking(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
       "statusCode": 308
     },
     {
-      "source": "/agents/using-agents/managing-agents",
+      "source": "/agents/using-agents/managing-agents(/?)",
       "destination": "/platform/managing-cloud-agents/",
       "statusCode": 308
     },
     {
-      "source": "/agents/voice",
+      "source": "/agents/voice(/?)",
       "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
       "statusCode": 308
     },
     {
-      "source": "/ambient-agents/ambient-agents-overview",
+      "source": "/ambient-agents/ambient-agents-overview(/?)",
       "destination": "/platform/",
       "statusCode": 308
     },
     {
-      "source": "/ambient-agents/managing-ambient-agents",
+      "source": "/ambient-agents/managing-ambient-agents(/?)",
       "destination": "/platform/managing-cloud-agents/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/readme",
+      "source": "/getting-started/readme(/?)",
       "destination": "/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/readme-1/coding-in-warp",
+      "source": "/getting-started/readme-1/coding-in-warp(/?)",
       "destination": "/getting-started/quickstart/coding-in-warp/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/readme-1/customizing-warp",
+      "source": "/getting-started/readme-1/customizing-warp(/?)",
       "destination": "/getting-started/quickstart/customizing-warp/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/readme-1/installation-and-setup",
+      "source": "/getting-started/readme-1/installation-and-setup(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/readme/coding-in-warp",
+      "source": "/getting-started/readme/coding-in-warp(/?)",
       "destination": "/getting-started/quickstart/coding-in-warp/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/readme/customizing-warp",
+      "source": "/getting-started/readme/customizing-warp(/?)",
       "destination": "/getting-started/quickstart/customizing-warp/",
       "statusCode": 308
     },
     {
-      "source": "/getting-started/readme/installation-and-setup",
+      "source": "/getting-started/readme/installation-and-setup(/?)",
       "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
-      "source": "/platform/warp-platform",
+      "source": "/platform/warp-platform(/?)",
       "destination": "/reference/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/known-issues",
+      "source": "/support-and-billing/known-issues(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/plans-and-pricing",
+      "source": "/support-and-billing/plans-and-pricing(/?)",
       "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/plans-and-pricing/add-on-credits",
+      "source": "/support-and-billing/plans-and-pricing/add-on-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/plans-and-pricing/bring-your-own-api-key",
+      "source": "/support-and-billing/plans-and-pricing/bring-your-own-api-key(/?)",
       "destination": "/agent-platform/inference/bring-your-own-api-key/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/plans-and-pricing/pricing-faqs",
+      "source": "/support-and-billing/plans-and-pricing/pricing-faqs(/?)",
       "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/plans-and-pricing/reload-credits-add-on-credits",
+      "source": "/support-and-billing/plans-and-pricing/reload-credits-add-on-credits(/?)",
       "destination": "/support-and-community/plans-and-billing/add-on-credits/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/sending-us-feedback",
+      "source": "/support-and-billing/sending-us-feedback(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/sending-us-feedback/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/troubleshooting-login-issues",
+      "source": "/support-and-billing/troubleshooting-login-issues(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/troubleshooting-login-issues/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/uninstalling-warp",
+      "source": "/support-and-billing/uninstalling-warp(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/logging-out-and-uninstalling/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-billing/updating-warp",
+      "source": "/support-and-billing/updating-warp(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/agent/",
-      "destination": "/api#tag/agent",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/schedules/",
-      "destination": "/api#tag/schedules",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/agent-1/",
-      "destination": "/api",
-      "statusCode": 308
-    },
-    {
-      "source": "/advanced/command-line-flags/",
-      "destination": "/terminal/sessions/launch-configurations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/",
-      "destination": "/agent-platform/capabilities/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/agent-profiles-permissions/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/codebase-context/",
-      "destination": "/agent-platform/capabilities/codebase-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/full-terminal-use/",
-      "destination": "/agent-platform/capabilities/full-terminal-use/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/mcp/",
-      "destination": "/agent-platform/capabilities/mcp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/planning/",
-      "destination": "/agent-platform/capabilities/planning/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/rules/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/skills/",
-      "destination": "/agent-platform/capabilities/skills/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/slash-commands/",
-      "destination": "/agent-platform/capabilities/slash-commands/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/task-lists/",
-      "destination": "/agent-platform/capabilities/task-lists/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-concepts/web-search/",
-      "destination": "/agent-platform/capabilities/web-search/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/active-ai/",
-      "destination": "/agent-platform/local-agents/active-ai/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/agent-context/",
-      "destination": "/agent-platform/local-agents/agent-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/agent-context/blocks-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/agent-context/images-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/agent-context/selection-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/selection-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/agent-context/urls-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/agent-context/using-to-add-context/",
-      "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/agents-overview/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/ambient-agents-session-sharing/",
-      "destination": "/platform/viewing-cloud-agent-runs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/code-diffs-in-agent-conversations/",
-      "destination": "/agent-platform/local-agents/code-diffs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/full-terminal-use/",
-      "destination": "/agent-platform/capabilities/full-terminal-use/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/generate/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/interacting-with-agents/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/interacting-with-agents/agent-modality-beta/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/interacting-with-agents/conversation-forking/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/interacting-with-agents/voice/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/interactive-code-review/",
-      "destination": "/agent-platform/local-agents/interactive-code-review/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/task-lists/",
-      "destination": "/agent-platform/capabilities/task-lists/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/third-party-cli-agents/",
-      "destination": "/agent-platform/cli-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-mode/web-search/",
-      "destination": "/agent-platform/capabilities/web-search/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/active-ai/",
-      "destination": "/agent-platform/local-agents/active-ai/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/agent-modality-beta/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/agent/agents-overview/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/agent/using-agents/agent-profiles-permissions/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/agents-md/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/agents-overview/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/ai/",
-      "destination": "/agent-platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/ai-faqs/",
-      "destination": "/agent-platform/getting-started/faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/ai-model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/ambient-agents/ambient-agents-overview/",
-      "destination": "/platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/autonomy/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/autonomy/agent-permissions/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/autonomy/run-to-completion/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/cloud-agents/cloud-agents-platform/",
-      "destination": "/platform/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/cloud-agents/warp-platform/",
-      "destination": "/platform/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/conversation-forking/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/full-terminal-use/",
-      "destination": "/agent-platform/capabilities/full-terminal-use/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/generate/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/integrations/github-actions/readme/",
-      "destination": "/platform/integrations/github-actions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/integrations/integrations-overview/",
-      "destination": "/platform/integrations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/slash-commands/",
-      "destination": "/agent-platform/capabilities/slash-commands/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/",
-      "destination": "/agent-platform/local-agents/agent-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/blocks-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/images-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/selection-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/selection-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/urls-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-context/using-to-add-context/",
-      "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-conversations/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-conversations/conversation-forking/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-permissions/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-profiles-permissions/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/agent-tasklists/",
-      "destination": "/agent-platform/capabilities/task-lists/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/managing-agents/",
-      "destination": "/platform/managing-cloud-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/planning/",
-      "destination": "/agent-platform/capabilities/planning/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/third-party-cli-agents/",
-      "destination": "/agent-platform/cli-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/using-agents/web-search/",
-      "destination": "/agent-platform/capabilities/web-search/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/voice/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agent-platform/warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/active-ai/",
-      "destination": "/agent-platform/local-agents/active-ai/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/agent-modality-beta/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/agents-md/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/agents-overview/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/ai/",
-      "destination": "/agent-platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/ai-commander/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/ai-commands/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/ai-faqs/",
-      "destination": "/agent-platform/getting-started/faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/ai-getting-started/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/autonomy/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/autonomy/agent-permissions/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/autonomy/run-to-completion/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/full-terminal-use/",
-      "destination": "/agent-platform/capabilities/full-terminal-use/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/generate/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/slash-commands/",
-      "destination": "/agent-platform/capabilities/slash-commands/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-context/",
-      "destination": "/agent-platform/local-agents/agent-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-context/blocks-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-context/images-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-context/selection-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/selection-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-context/urls-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-context/using-to-add-context/",
-      "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-conversations/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-conversations/conversation-forking/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-profiles-permissions/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/agent-tasklists/",
-      "destination": "/agent-platform/capabilities/task-lists/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/managing-agents/",
-      "destination": "/platform/managing-cloud-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/planning/",
-      "destination": "/agent-platform/capabilities/planning/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/profiles/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/third-party-cli-agents/",
-      "destination": "/agent-platform/cli-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/using-agents/web-search/",
-      "destination": "/agent-platform/capabilities/web-search/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/voice/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/agents/warp-ai/agent-mode/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/ai/",
-      "destination": "/agent-platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/ai-features/ai-commands/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/ai-features/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/ai/warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/ambient-agents/",
-      "destination": "/platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/ambient-agents/agent-secrets/",
-      "destination": "/platform/secrets/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/ambient-agents/ambient-agents-overview/",
-      "destination": "/platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/ambient-agents/managing-ambient-agents/",
-      "destination": "/platform/managing-cloud-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/ambient-agents/managing-ambient-agents/scheduled-agents/",
-      "destination": "/platform/triggers/scheduled-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/agent-session-sharing/",
-      "destination": "/agent-platform/local-agents/session-sharing/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/cloud-agent-secrets/",
-      "destination": "/platform/secrets/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/cloud-agents-faqs/",
-      "destination": "/platform/faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/cloud-agents-overview/",
-      "destination": "/platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/cloud-agents-platform/",
-      "destination": "/platform/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/cloud-agents-session-sharing/",
-      "destination": "/platform/viewing-cloud-agent-runs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/warp-platform/",
-      "destination": "/platform/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/code/code-review/interactive-code-review/",
-      "destination": "/agent-platform/local-agents/interactive-code-review/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/code/codebase-context/",
-      "destination": "/agent-platform/capabilities/codebase-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/code/reviewing-code/",
-      "destination": "/agent-platform/local-agents/code-diffs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/agent-mode/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/agent-mode/agents-md/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/agents/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/",
-      "destination": "/agent-platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-agents/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-and-agents/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-and-agents/agents/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-and-ask-warp/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-and-ask-warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-and-session-history/warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-and-stack-overflow/agent-mode/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-and-warpdrive/warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-command/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-command-search/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-command-search/limits/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-command-search/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-command-suggestions/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-command/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-commands/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-features/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai-features/ai-chat/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/agent/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/agent-mode/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/agents/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/ai-models-and-providers/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/ai-setup/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/assistant/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/commands/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/commands-and-agents/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/commands/agent-mode/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/commands/agents/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/commands/ai-agent/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/commands/ai-commands-overview/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/get-started-with-warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/using-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/ai/using-warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/generate/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/integrations/mcp/",
-      "destination": "/agent-platform/capabilities/mcp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/knowledge/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/terminal-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/terminal-ai/ai-models/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/voice/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/active-ai/",
-      "destination": "/agent-platform/local-agents/active-ai/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/agent-mode/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/agent-modea/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/ai-command-search/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/ai-command-suggestions/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/generate/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/knowledge/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/mcp/",
-      "destination": "/agent-platform/capabilities/mcp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/rules/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/features/warp-ai/voice/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/getting-started/quickstart-guide/agents-in-warp/",
-      "destination": "/agent-platform/getting-started/agents-in-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/integrations/",
-      "destination": "/platform/integrations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/integrations-overview/",
-      "destination": "/platform/integrations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/integrations/github-actions/",
-      "destination": "/platform/integrations/github-actions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/integrations/github-actions/demo-issue-triage-bot/",
-      "destination": "/platform/integrations/quickstart-github-actions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/integrations/demo-issue-triage-bot/",
-      "destination": "/platform/integrations/quickstart-github-actions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/integrations/integrations-overview/",
-      "destination": "/platform/integrations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/integrations/integrations-overview/team-access-billing-and-identity-permissions/",
-      "destination": "/platform/team-access-billing-and-identity/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/integrations/linear/",
-      "destination": "/platform/integrations/linear/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/integrations/slack/",
-      "destination": "/platform/integrations/slack/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/knowledge-and-collaboration/mcp/",
-      "destination": "/agent-platform/capabilities/mcp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/knowledge-and-collaboration/rules/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/knowledge-and-collaboration/session-sharing/agent-session-sharing/",
-      "destination": "/agent-platform/local-agents/session-sharing/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/knowledge-and-collaboration/session-sharing/ambient-agents-session-sharing/",
-      "destination": "/platform/viewing-cloud-agent-runs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/knowledge-and-collaboration/warp-drive/model-context-protocol-mcp/",
-      "destination": "/agent-platform/capabilities/mcp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/local-agents/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/local-agents/agent-notifications/",
-      "destination": "/agent-platform/capabilities/agent-notifications/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/local-agents/agents-overview/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/local-agents/ambient-agents-session-sharing/",
-      "destination": "/platform/viewing-cloud-agent-runs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/local-agents/code-diffs-in-agent-conversations/",
-      "destination": "/agent-platform/local-agents/code-diffs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/local-agents/interacting-with-agents/agent-modality-beta/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/local-agents/third-party-cli-agents/",
-      "destination": "/agent-platform/cli-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/platform/",
-      "destination": "/platform/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/platform/deployment-patterns/",
-      "destination": "/platform/deployment-patterns/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/platform/environments/",
-      "destination": "/platform/environments/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/platform/integrations/integrations-overview/",
-      "destination": "/platform/integrations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/platform/team-access-billing-and-identity-permissions/",
-      "destination": "/platform/team-access-billing-and-identity/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/platform/warp-platform/",
-      "destination": "/platform/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/settings/ai-agents/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/terminal-ai/getting-started/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/terminal/ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/terminal/ai/agent-mode/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/terminal/warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/third-party-agents/claude-code/",
-      "destination": "/agent-platform/cli-agents/claude-code/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/third-party-agents/codex/",
-      "destination": "/agent-platform/cli-agents/codex/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/third-party-agents/opencode/",
-      "destination": "/agent-platform/cli-agents/opencode/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/third-party-agents/overview/",
-      "destination": "/agent-platform/cli-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/third-party-agents/remote-control/",
-      "destination": "/agent-platform/cli-agents/remote-control/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/third-party-agents/rich-input/",
-      "destination": "/agent-platform/cli-agents/rich-input/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/using-agents/managing-agents/",
-      "destination": "/platform/managing-cloud-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-ai/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-ai/assistant/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-ai/get-started/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-platform/",
-      "destination": "/platform/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/app-icons/",
-      "destination": "/terminal/appearance/app-icons/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/blocks-behavior/",
-      "destination": "/terminal/appearance/blocks-behavior/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/compact-mode/",
-      "destination": "/terminal/appearance/blocks-behavior/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/custom-themes/",
-      "destination": "/terminal/appearance/custom-themes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/input-position/",
-      "destination": "/terminal/appearance/input-position/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/pane-dimming/",
-      "destination": "/terminal/appearance/pane-dimming/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/prompt/",
-      "destination": "/terminal/appearance/prompt/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/size-opacity-blurring/",
-      "destination": "/terminal/appearance/size-opacity-blurring/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/tab-indicators/",
-      "destination": "/terminal/appearance/tabs-behavior/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/tabs-behavior/",
-      "destination": "/terminal/appearance/tabs-behavior/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/text-fonts-cursor/",
-      "destination": "/terminal/appearance/text-fonts-cursor/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/themes/",
-      "destination": "/terminal/appearance/themes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/appearance/transparency-and-blurring/",
-      "destination": "/terminal/appearance/size-opacity-blurring/",
-      "statusCode": 308
-    },
-    {
-      "source": "/changelog/changelog/rss/",
-      "destination": "/changelog/rss.xml",
-      "statusCode": 308
-    },
-    {
-      "source": "/changelog/getting-started/changelog/",
-      "destination": "/changelog/",
-      "statusCode": 308
-    },
-    {
-      "source": "/changelog/help/changelog/",
-      "destination": "/changelog/",
-      "statusCode": 308
-    },
-    {
-      "source": "/changelog/release-notes/",
-      "destination": "/changelog/",
-      "statusCode": 308
-    },
-    {
-      "source": "/changelog/rss/",
-      "destination": "/changelog/rss.xml",
-      "statusCode": 308
-    },
-    {
-      "source": "/changelog/url/docs.warp.dev/getting-started/changelog/",
-      "destination": "/changelog/",
-      "statusCode": 308
-    },
-    {
-      "source": "/changelog/warp/getting-started/changelog/",
-      "destination": "/changelog/",
-      "statusCode": 308
-    },
-    {
-      "source": "/code-editor/",
-      "destination": "/code/code-editor/",
-      "statusCode": 308
-    },
-    {
-      "source": "/code/code-overview/",
-      "destination": "/code/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/code/code-review/interactive-code-review/",
-      "destination": "/code/code-review/",
-      "statusCode": 308
-    },
-    {
-      "source": "/code/reviewing-code/",
-      "destination": "/code/code-review/",
-      "statusCode": 308
-    },
-    {
-      "source": "/configuration/",
-      "destination": "/terminal/more-features/settings-sync/",
       "statusCode": 308
     },
     {
@@ -6058,623 +4763,8 @@
       "statusCode": 308
     },
     {
-      "source": "/features/",
-      "destination": "/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/accessibility/",
-      "destination": "/terminal/more-features/accessibility/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/advanced/settings/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/appearance/",
-      "destination": "/terminal/appearance/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/appearance/compact-mode/",
-      "destination": "/terminal/appearance/blocks-behavior/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/appearance/custom-themes/",
-      "destination": "/terminal/appearance/custom-themes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/appearance/prompt/",
-      "destination": "/terminal/appearance/prompt/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/appearance/themes/",
-      "destination": "/terminal/appearance/themes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/blocks/",
-      "destination": "/terminal/blocks/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/blocks/background-blocks/",
-      "destination": "/terminal/blocks/background-blocks/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/blocks/block-actions/",
-      "destination": "/terminal/blocks/block-actions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/blocks/block-basics/",
-      "destination": "/terminal/blocks/block-basics/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/blocks/block-filtering/",
-      "destination": "/terminal/blocks/block-filtering/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/blocks/block-sharing/",
-      "destination": "/terminal/blocks/block-sharing/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/blocks/sticky-command-header/",
-      "destination": "/terminal/blocks/sticky-command-header/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/command-completions/",
-      "destination": "/terminal/command-completions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/command-completions/autosuggestions/",
-      "destination": "/terminal/command-completions/autosuggestions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/command-completions/completions/",
-      "destination": "/terminal/command-completions/completions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/command-history/",
-      "destination": "/terminal/entry/command-history/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/command-inspector/",
-      "destination": "/terminal/editor/command-inspector/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/command-palette/",
-      "destination": "/terminal/command-palette/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/command-search/",
-      "destination": "/terminal/entry/command-search/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/compact-mode/",
-      "destination": "/terminal/appearance/blocks-behavior/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/completions/",
-      "destination": "/terminal/command-completions/completions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/customize/custom-keyboard-shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/editor/",
-      "destination": "/terminal/editor/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/editor/alias-expansion/",
-      "destination": "/terminal/editor/alias-expansion/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/editor/command-corrections/",
-      "destination": "/terminal/entry/command-corrections/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/editor/command-inspector/",
-      "destination": "/terminal/editor/command-inspector/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/editor/syntax-error-highlighting/",
-      "destination": "/terminal/editor/syntax-error-highlighting/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/editor/vim/",
-      "destination": "/terminal/editor/vim/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/entry/",
-      "destination": "/terminal/entry/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/entry/command-corrections/",
-      "destination": "/terminal/entry/command-corrections/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/entry/command-history/",
-      "destination": "/terminal/entry/command-history/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/entry/command-search/",
-      "destination": "/terminal/entry/command-search/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/entry/synchronized-inputs/",
-      "destination": "/terminal/entry/synchronized-inputs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/entry/workflows/",
-      "destination": "/terminal/entry/yaml-workflows/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/entry/yaml-workflows/",
-      "destination": "/terminal/entry/yaml-workflows/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/files-and-links/",
-      "destination": "/terminal/more-features/files-and-links/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/find/",
-      "destination": "/terminal/blocks/find/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/full-screen-apps/",
-      "destination": "/terminal/more-features/full-screen-apps/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/global-hotkey/",
-      "destination": "/terminal/windows/global-hotkey/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/hotkey-window/",
-      "destination": "/terminal/windows/global-hotkey/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/integrations/",
-      "destination": "/terminal/integrations-and-plugins/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/integrations-and-plugins/",
-      "destination": "/terminal/integrations-and-plugins/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/integrations/urls-and-deep-links/",
-      "destination": "/terminal/more-features/uri-scheme/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/keybindings/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/keyboard-input/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/keyboard-shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/knowledge/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/launch-configurations/",
-      "destination": "/terminal/sessions/launch-configurations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/linux/",
-      "destination": "/terminal/more-features/linux/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/markdown-viewer/",
-      "destination": "/terminal/more-features/markdown-viewer/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/notifications/",
-      "destination": "/terminal/more-features/notifications/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/overview/",
-      "destination": "/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/prompt/",
-      "destination": "/terminal/appearance/prompt/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/quit-warning/",
-      "destination": "/terminal/more-features/quit-warning/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/session-management-and-restoration/",
-      "destination": "/terminal/sessions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/session-management/launch-configurations/",
-      "destination": "/terminal/sessions/launch-configurations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/session-management/session-navigation/",
-      "destination": "/terminal/sessions/session-navigation/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/session-management/session-restoration/",
-      "destination": "/terminal/sessions/session-restoration/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/session-sharing/",
-      "destination": "/knowledge-and-collaboration/session-sharing/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/sessions/",
-      "destination": "/terminal/sessions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/sessions/README/",
-      "destination": "/terminal/sessions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/sessions/launch-configurations/",
-      "destination": "/terminal/sessions/launch-configurations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/sessions/quit-warning-modal/",
-      "destination": "/terminal/more-features/quit-warning/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/sessions/session-navigation/",
-      "destination": "/terminal/sessions/session-navigation/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/sessions/session-restoration/",
-      "destination": "/terminal/sessions/session-restoration/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/sessions/sharing-sessions/",
-      "destination": "/knowledge-and-collaboration/session-sharing/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/settings/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/settings-sync/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/settings/configuration-files/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/smart-select/",
-      "destination": "/terminal/more-features/text-selection/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/split-panes/",
-      "destination": "/terminal/windows/split-panes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/ssh/",
-      "destination": "/terminal/warpify/ssh-legacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/subshells/",
-      "destination": "/terminal/warpify/subshells/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/system-settings/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/tabs/",
-      "destination": "/terminal/windows/tabs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/teams/",
-      "destination": "/knowledge-and-collaboration/teams/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/terminal-features/",
-      "destination": "/terminal/blocks/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/the-input-editor/",
-      "destination": "/terminal/editor/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/themes/",
-      "destination": "/terminal/appearance/themes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/themes/custom-themes/",
-      "destination": "/terminal/appearance/custom-themes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/uri-scheme/",
-      "destination": "/terminal/more-features/uri-scheme/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-ai/code/",
-      "destination": "/code/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-ai/knowledge/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-ai/mcp/",
-      "destination": "/agent-platform/capabilities/mcp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-ai/rules/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-drive/",
-      "destination": "/knowledge-and-collaboration/warp-drive/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-drive/environment-variables/",
-      "destination": "/knowledge-and-collaboration/warp-drive/environment-variables/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-drive/notebooks/",
-      "destination": "/knowledge-and-collaboration/warp-drive/notebooks/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-drive/prompts/",
-      "destination": "/knowledge-and-collaboration/warp-drive/prompts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-drive/warp-drive-on-the-web/",
-      "destination": "/knowledge-and-collaboration/warp-drive/web/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-drive/warp-drive-on-the-web-beta/",
-      "destination": "/knowledge-and-collaboration/warp-drive/web/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warp-drive/workflows/",
-      "destination": "/knowledge-and-collaboration/warp-drive/workflows/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warpify/",
-      "destination": "/terminal/warpify/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warpify/ssh/",
-      "destination": "/terminal/warpify/ssh/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warpify/ssh-legacy/",
-      "destination": "/terminal/warpify/ssh-legacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/warpify/subshells/",
-      "destination": "/terminal/warpify/subshells/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/windows/",
-      "destination": "/terminal/windows/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/windows/global-hotkey/",
-      "destination": "/terminal/windows/global-hotkey/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/windows/split-panes/",
-      "destination": "/terminal/windows/split-panes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/windows/tabs/",
-      "destination": "/terminal/windows/tabs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/windows/~/",
-      "destination": "/terminal/windows/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/workflows/",
-      "destination": "/terminal/entry/yaml-workflows/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/workflows/block-metrics/shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/working-directory/",
-      "destination": "/terminal/more-features/working-directory/",
-      "statusCode": 308
-    },
-    {
-      "source": "/features/workspaces/",
-      "destination": "/terminal/sessions/",
-      "statusCode": 308
-    },
-    {
       "source": "/getting-started/about-warps-ai/",
       "destination": "/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/account-and-login/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/coding-in-warp/",
-      "destination": "/getting-started/quickstart/coding-in-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/customizing-warp/",
-      "destination": "/getting-started/quickstart/customizing-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/customizing-warp/settings/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/download-and-install/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/downloading-warp/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/getting-started-with-warp/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/getting-started-with-warp-on-linux/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/guides/shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/how-to-use-warp/",
-      "destination": "/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/installation/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/installation-and-setup/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/installation/linux/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/installing-warp/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/installing-warp-on-linux/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
       "statusCode": 308
     },
     {
@@ -6683,1773 +4773,13 @@
       "statusCode": 308
     },
     {
-      "source": "/getting-started/launch-configurations/",
-      "destination": "/terminal/sessions/launch-configurations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/launching-warp/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/linux/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/linux-installation/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/mac-permissions/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/quickstart-guide/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/quickstart-guide/README/",
-      "destination": "/quickstart/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/quickstart-guide/agents-in-warp/",
-      "destination": "/agent-platform/getting-started/agents-in-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/quickstart-guide/coding-in-warp/",
-      "destination": "/getting-started/quickstart/coding-in-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/quickstart-guide/customizing-warp/",
-      "destination": "/getting-started/quickstart/customizing-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/quickstart-guide/installation-and-setup/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/settings/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/syncing-your-terminal/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/terminal/",
-      "destination": "/terminal/blocks/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/using-warp-with-shells/",
-      "destination": "/getting-started/supported-shells/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/what-is-warp/",
-      "destination": "/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guide/ssh-guide/",
-      "destination": "/terminal/warpify/ssh/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/ssh-quickstart/",
-      "destination": "/terminal/warpify/ssh/",
-      "statusCode": 308
-    },
-    {
-      "source": "/how-does-warp-compare/performance/",
-      "destination": "/terminal/comparisons/performance/",
-      "statusCode": 308
-    },
-    {
-      "source": "/how-does-warp-compare/terminal-features/",
-      "destination": "/terminal/comparisons/terminal-features/",
-      "statusCode": 308
-    },
-    {
-      "source": "/installation/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/installation/linux/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/keyboard-shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/knowledge-and-collaboration/warp-drive/warp-drive-as-agent-mode-context/",
-      "destination": "/knowledge-and-collaboration/warp-drive/agent-mode-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/knowledge-and-collaboration/warp-drive/warp-drive-on-the-web/",
-      "destination": "/knowledge-and-collaboration/warp-drive/web/",
-      "statusCode": 308
-    },
-    {
-      "source": "/knowledge-and-collaboration/workflows/",
-      "destination": "/knowledge-and-collaboration/warp-drive/workflows/",
-      "statusCode": 308
-    },
-    {
-      "source": "/quick-start/",
-      "destination": "/quickstart/",
-      "statusCode": 308
-    },
-    {
-      "source": "/readme/",
-      "destination": "/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/agent-api-and-sdk/",
-      "destination": "/reference/api-and-sdk/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/ambient-agents/mcp-servers-for-agents/",
-      "destination": "/reference/cli/mcp-servers/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/authentication_required/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/authentication-required/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/budget_exceeded/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/budget-exceeded/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/content_policy_violation/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/content-policy-violation/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/environment_setup_failed/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/environment-setup-failed/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/external_authentication_required/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/external-authentication-required/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/agent_process_failed/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/agent-process-failed/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/feature_not_available/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/feature-not-available/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/infrastructure_timeout/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/infrastructure-timeout/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/insufficient_credits/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/insufficient-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/integration_disabled/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/integration-disabled/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/integration_not_configured/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/integration-not-configured/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/internal_error/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/internal-error/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/invalid_request/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/invalid-request/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/not_authorized/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/not-authorized/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/operation_not_supported/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/operation-not-supported/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/resource_not_found/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/resource-not-found/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/troubleshooting/errors/resource_unavailable/",
-      "destination": "/reference/api-and-sdk/troubleshooting/errors/resource-unavailable/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/cli/integrations-and-environments/",
-      "destination": "/reference/cli/integration-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/cli/mcp-for-cloud-agents/",
-      "destination": "/reference/cli/mcp-servers/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/cli/mcp-servers-for-cloud-agents/",
-      "destination": "/reference/cli/mcp-servers/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/developers/cli/",
-      "destination": "/reference/cli/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/integrations/integrations-overview/integrations-and-environments/",
-      "destination": "/reference/cli/integration-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/keybindings/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/keyboard-shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/platform/agent-api-and-sdk/",
-      "destination": "/reference/api-and-sdk/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/platform/agent-api-and-sdk/agent/",
-      "destination": "/reference/api-and-sdk/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/platform/agent-api-and-sdk/agent-1/",
-      "destination": "/reference/api-and-sdk/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/platform/agent-api-and-sdk/demo-sentry-monitoring-with-sdk/",
-      "destination": "/reference/api-and-sdk/demo-sentry-monitoring-with-sdk/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/platform/cli/",
-      "destination": "/reference/cli/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/platform/cli/api-keys/",
-      "destination": "/reference/cli/api-keys/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/platform/cli/integrations-and-environments/",
-      "destination": "/reference/cli/integration-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/platform/cli/troubleshooting/",
-      "destination": "/reference/cli/troubleshooting/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/platform/warp-platform/",
-      "destination": "/reference/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/settings/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/session-sharing/",
-      "destination": "/knowledge-and-collaboration/session-sharing/",
-      "statusCode": 308
-    },
-    {
-      "source": "/settings/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/settings-menu/overview/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/settings-overview/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/settings/features/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/settings/keyboard-shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/features/network-log/",
-      "destination": "/support-and-community/privacy-and-security/network-log/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/features/secret-redaction/",
-      "destination": "/support-and-community/privacy-and-security/secret-redaction/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/getting-started/privacy/",
-      "destination": "/support-and-community/privacy-and-security/privacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/getting-started/refer-a-friend/",
-      "destination": "/support-and-community/community/refer-a-friend/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/getting-started/warp-preview-and-alpha-program/",
-      "destination": "/support-and-community/community/warp-preview-and-alpha-program/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/",
-      "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/ai-features/bring-your-own-llm/",
-      "destination": "/agent-platform/inference/bring-your-own-api-key/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/faq/billing-and-payments/",
-      "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/known-issues/",
-      "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/licenses/",
-      "destination": "/support-and-community/community/open-source-licenses/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/plans-subscriptions-and-pricing/",
-      "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/releasing-and-updating/",
-      "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/sending-us-feedback/",
-      "destination": "/support-and-community/troubleshooting-and-support/sending-us-feedback/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/troubleshooting-login-issues/",
-      "destination": "/support-and-community/troubleshooting-and-support/troubleshooting-login-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/uninstalling-warp/",
-      "destination": "/support-and-community/troubleshooting-and-support/logging-out-and-uninstalling/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/updating-warp/",
-      "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/help/using-warp-offline/",
-      "destination": "/support-and-community/troubleshooting-and-support/using-warp-offline/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/known-issues/",
-      "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/plans-and-billing/overages-legacy/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/plans-pricing-and-billing/",
-      "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/plans-pricing-and-billing/add-on-credits/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/plans-pricing-and-billing/ai-credits/",
-      "destination": "/support-and-community/plans-and-billing/credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/plans-pricing-and-billing/bring-your-own-api-key/",
-      "destination": "/agent-platform/inference/bring-your-own-api-key/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/plans-pricing-and-billing/overages-legacy/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/plans-pricing-and-billing/pricing-faqs/",
-      "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/privacy/",
-      "destination": "/support-and-community/privacy-and-security/privacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/privacy-and-security/",
-      "destination": "/support-and-community/privacy-and-security/privacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/privacy/network-log/",
-      "destination": "/support-and-community/privacy-and-security/network-log/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/privacy/privacy/",
-      "destination": "/support-and-community/privacy-and-security/privacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/privacy/secret-redaction/",
-      "destination": "/support-and-community/privacy-and-security/secret-redaction/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/security-and-privacy/data-handling/",
-      "destination": "/support-and-community/privacy-and-security/privacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/security-and-privacy/data-ownership/",
-      "destination": "/support-and-community/privacy-and-security/privacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/",
-      "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/known-issues/",
-      "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/licenses/",
-      "destination": "/support-and-community/community/open-source-licenses/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/licenses-intro/",
-      "destination": "/support-and-community/community/open-source-licenses/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-billing/bring-your-own-api-key/",
-      "destination": "/agent-platform/inference/bring-your-own-api-key/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/",
-      "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/add-on-credits/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/ai-credits/",
-      "destination": "/support-and-community/plans-and-billing/credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/ai-requests/",
-      "destination": "/support-and-community/plans-and-billing/credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/bring-your-own-api-key/",
-      "destination": "/agent-platform/inference/bring-your-own-api-key/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/pricing-faqs/",
-      "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/reload-credits-add-on-credits/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-pricing/usage-overages/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/plans-and-prilling/bring-your-own-api-key/",
-      "destination": "/agent-platform/inference/bring-your-own-api-key/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/pricing-faqs/",
-      "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/sending-us-feedback/",
-      "destination": "/support-and-community/troubleshooting-and-support/sending-us-feedback/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/subscription-management/",
-      "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/troubleshooting-login-issues/",
-      "destination": "/support-and-community/troubleshooting-and-support/troubleshooting-login-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/uninstalling-warp/",
-      "destination": "/support-and-community/troubleshooting-and-support/logging-out-and-uninstalling/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/updating-warp/",
-      "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-billing/using-warp-offline/",
-      "destination": "/support-and-community/troubleshooting-and-support/using-warp-offline/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-community/plans-and-billing/ai-credits/",
-      "destination": "/support-and-community/plans-and-billing/credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/",
-      "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/add-on-credits/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/ai-credits/",
-      "destination": "/support-and-community/plans-and-billing/credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/bring-your-own-api-key/",
-      "destination": "/agent-platform/inference/bring-your-own-api-key/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/overages-legacy/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-community/plans-pricing-and-billing/pricing-faqs/",
-      "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/support-and-community/privacy-and-security/privacy/",
-      "destination": "/support-and-community/privacy-and-security/privacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/troubleshooting/",
-      "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/troubleshooting/common-issues/",
-      "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/troubleshooting/general-troubleshooting/",
-      "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/command-input/command-suggestions/",
-      "destination": "/terminal/command-completions/completions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/keybindings/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/keyboard-shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/sessions/tab-configs/",
-      "destination": "/terminal/windows/tab-configs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/universal-input/",
-      "destination": "/terminal/input/classic-input/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/universal-input/classic-input/",
-      "destination": "/terminal/input/classic-input/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/windows/keyboard-shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/windows/keyboard-shortcuts-windows/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/windows/windows-shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp-quickstart/",
-      "destination": "/quickstart/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp-terminal-101/settings/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
       "source": "/what-is-warp/",
       "destination": "/",
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/troubleshooting-and-support/uninstalling-warp/",
-      "destination": "/support-and-community/troubleshooting-and-support/logging-out-and-uninstalling/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/active-ai/",
-      "destination": "/agent-platform/local-agents/active-ai/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/agent-context/blocks-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/agent-context/images-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/agent-context/selection-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/selection-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/agent-context/urls-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/agent-context/using-to-add-context/",
-      "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/agent-notifications/",
-      "destination": "/agent-platform/capabilities/agent-notifications/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/agent-profiles-permissions/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/",
-      "destination": "/agent-platform/capabilities/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/cloud-conversations/",
-      "destination": "/agent-platform/local-agents/cloud-conversations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/code-diffs/",
-      "destination": "/agent-platform/local-agents/code-diffs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/codebase-context/",
-      "destination": "/agent-platform/capabilities/codebase-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/computer-use/",
-      "destination": "/agent-platform/capabilities/computer-use/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/full-terminal-use/",
-      "destination": "/agent-platform/capabilities/full-terminal-use/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/interacting-with-agents/conversation-forking/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/interacting-with-agents/terminal-and-agent-modes/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/interacting-with-agents/voice/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/interactive-code-review/",
-      "destination": "/agent-platform/local-agents/interactive-code-review/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/mcp/",
-      "destination": "/agent-platform/capabilities/mcp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/planning/",
-      "destination": "/agent-platform/capabilities/planning/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/rules/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/session-sharing/",
-      "destination": "/agent-platform/local-agents/session-sharing/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/skills/",
-      "destination": "/agent-platform/capabilities/skills/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/slash-commands/",
-      "destination": "/agent-platform/capabilities/slash-commands/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/task-lists/",
-      "destination": "/agent-platform/capabilities/task-lists/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/web-search/",
-      "destination": "/agent-platform/capabilities/web-search/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/code/code-editor/code-editor-vim-keybindings/",
-      "destination": "/code/code-editor/code-editor-vim-keybindings/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/code/code-editor/file-tree/",
-      "destination": "/code/code-editor/file-tree/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/code/code-editor/find-and-replace/",
-      "destination": "/code/code-editor/find-and-replace/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/code/code-editor/language-server-protocol/",
-      "destination": "/code/code-editor/language-server-protocol/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/code/code-review/",
-      "destination": "/code/code-review/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/code/git-worktrees/",
-      "destination": "/code/git-worktrees/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/code/overview/",
-      "destination": "/code/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/code/ssh-feature-support/",
-      "destination": "/code/ssh-feature-support/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/getting-started/coding-in-warp/",
-      "destination": "/getting-started/quickstart/coding-in-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/getting-started/customizing-warp/",
-      "destination": "/getting-started/quickstart/customizing-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/getting-started/installation-and-setup/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/getting-started/keyboard-shortcuts/",
-      "destination": "/getting-started/keyboard-shortcuts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/getting-started/migrate-to-warp/",
-      "destination": "/getting-started/migrate-to-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/getting-started/quickstart/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/getting-started/supported-shells/",
-      "destination": "/getting-started/supported-shells/",
-      "statusCode": 308
-    },
-    {
       "source": "/warp/getting-started/what-is-warp/",
       "destination": "/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/knowledge-and-collaboration/admin-panel/",
-      "destination": "/knowledge-and-collaboration/admin-panel/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/knowledge-and-collaboration/teams/",
-      "destination": "/knowledge-and-collaboration/teams/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/agent-mode-context/",
-      "destination": "/knowledge-and-collaboration/warp-drive/agent-mode-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/ai-objects/",
-      "destination": "/knowledge-and-collaboration/warp-drive/ai-objects/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/environment-variables/",
-      "destination": "/knowledge-and-collaboration/warp-drive/environment-variables/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/notebooks/",
-      "destination": "/knowledge-and-collaboration/warp-drive/notebooks/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/prompts/",
-      "destination": "/knowledge-and-collaboration/warp-drive/prompts/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/web/",
-      "destination": "/knowledge-and-collaboration/warp-drive/web/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/knowledge-and-collaboration/warp-drive/workflows/",
-      "destination": "/knowledge-and-collaboration/warp-drive/workflows/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/app-icons/",
-      "destination": "/terminal/appearance/app-icons/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/blocks-behavior/",
-      "destination": "/terminal/appearance/blocks-behavior/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/custom-themes/",
-      "destination": "/terminal/appearance/custom-themes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/input-position/",
-      "destination": "/terminal/appearance/input-position/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/pane-dimming/",
-      "destination": "/terminal/appearance/pane-dimming/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/prompt/",
-      "destination": "/terminal/appearance/prompt/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/size-opacity-blurring/",
-      "destination": "/terminal/appearance/size-opacity-blurring/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/tabs-behavior/",
-      "destination": "/terminal/appearance/tabs-behavior/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/text-fonts-cursor/",
-      "destination": "/terminal/appearance/text-fonts-cursor/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/appearance/themes/",
-      "destination": "/terminal/appearance/themes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/blocks/background-blocks/",
-      "destination": "/terminal/blocks/background-blocks/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/blocks/block-actions/",
-      "destination": "/terminal/blocks/block-actions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/blocks/block-basics/",
-      "destination": "/terminal/blocks/block-basics/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/blocks/block-filtering/",
-      "destination": "/terminal/blocks/block-filtering/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/blocks/block-sharing/",
-      "destination": "/terminal/blocks/block-sharing/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/blocks/find/",
-      "destination": "/terminal/blocks/find/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/blocks/sticky-command-header/",
-      "destination": "/terminal/blocks/sticky-command-header/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/command-completions/autosuggestions/",
-      "destination": "/terminal/command-completions/autosuggestions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/command-completions/completions/",
-      "destination": "/terminal/command-completions/completions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/command-palette/",
-      "destination": "/terminal/command-palette/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/comparisons/performance/",
-      "destination": "/terminal/comparisons/performance/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/comparisons/terminal-features/",
-      "destination": "/terminal/comparisons/terminal-features/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/editor/alias-expansion/",
-      "destination": "/terminal/editor/alias-expansion/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/editor/command-inspector/",
-      "destination": "/terminal/editor/command-inspector/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/editor/syntax-error-highlighting/",
-      "destination": "/terminal/editor/syntax-error-highlighting/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/editor/vim/",
-      "destination": "/terminal/editor/vim/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/entry/command-corrections/",
-      "destination": "/terminal/entry/command-corrections/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/entry/command-history/",
-      "destination": "/terminal/entry/command-history/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/entry/command-search/",
-      "destination": "/terminal/entry/command-search/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/entry/synchronized-inputs/",
-      "destination": "/terminal/entry/synchronized-inputs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/entry/yaml-workflows/",
-      "destination": "/terminal/entry/yaml-workflows/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/input/classic-input/",
-      "destination": "/terminal/input/classic-input/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/integrations-and-plugins/",
-      "destination": "/terminal/integrations-and-plugins/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/accessibility/",
-      "destination": "/terminal/more-features/accessibility/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/audible-bell/",
-      "destination": "/terminal/more-features/audible-bell/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/files-and-links/",
-      "destination": "/terminal/more-features/files-and-links/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/full-screen-apps/",
-      "destination": "/terminal/more-features/full-screen-apps/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/linux/",
-      "destination": "/terminal/more-features/linux/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/markdown-viewer/",
-      "destination": "/terminal/more-features/markdown-viewer/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/notifications/",
-      "destination": "/terminal/more-features/notifications/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/quit-warning/",
-      "destination": "/terminal/more-features/quit-warning/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/settings-sync/",
-      "destination": "/terminal/more-features/settings-sync/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/text-selection/",
-      "destination": "/terminal/more-features/text-selection/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/uri-scheme/",
-      "destination": "/terminal/more-features/uri-scheme/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/more-features/working-directory/",
-      "destination": "/terminal/more-features/working-directory/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/sessions/launch-configurations/",
-      "destination": "/terminal/sessions/launch-configurations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/sessions/session-navigation/",
-      "destination": "/terminal/sessions/session-navigation/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/sessions/session-restoration/",
-      "destination": "/terminal/sessions/session-restoration/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/settings/all-settings/",
-      "destination": "/getting-started/quickstart/customizing-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/warpify/ssh/",
-      "destination": "/terminal/warpify/ssh/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/warpify/ssh-legacy/",
-      "destination": "/terminal/warpify/ssh-legacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/warpify/subshells/",
-      "destination": "/terminal/warpify/subshells/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/windows/global-hotkey/",
-      "destination": "/terminal/windows/global-hotkey/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/windows/split-panes/",
-      "destination": "/terminal/windows/split-panes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/windows/tab-configs/",
-      "destination": "/terminal/windows/tab-configs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/windows/tabs/",
-      "destination": "/terminal/windows/tabs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/warp/terminal/windows/vertical-tabs/",
-      "destination": "/terminal/windows/vertical-tabs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/integrations/github-actions/quickstart-github-actions/",
-      "destination": "/platform/integrations/github-actions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/agent-context/",
-      "destination": "/agent-platform/local-agents/agent-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/agent-context/mcp/",
-      "destination": "/agent-platform/capabilities/mcp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/agent-notifications/",
-      "destination": "/agent-platform/capabilities/agent-notifications/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/agent-profiles-permissions/",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/cloud-conversations/",
-      "destination": "/agent-platform/local-agents/cloud-conversations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/codebase-context/",
-      "destination": "/agent-platform/capabilities/codebase-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/computer-use/",
-      "destination": "/agent-platform/capabilities/computer-use/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/full-terminal-use/",
-      "destination": "/agent-platform/capabilities/full-terminal-use/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/model-choice/",
-      "destination": "/agent-platform/inference/model-choice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/planning/",
-      "destination": "/agent-platform/capabilities/planning/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/rules/",
-      "destination": "/agent-platform/capabilities/rules/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/session-sharing/",
-      "destination": "/agent-platform/local-agents/session-sharing/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/skills/",
-      "destination": "/agent-platform/capabilities/skills/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/slash-commands/",
-      "destination": "/agent-platform/capabilities/slash-commands/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/task-lists/",
-      "destination": "/agent-platform/capabilities/task-lists/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/capabilities-overview/web-search/",
-      "destination": "/agent-platform/capabilities/web-search/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/interacting-with-agents/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/interacting-with-agents/code-diffs/",
-      "destination": "/agent-platform/local-agents/code-diffs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/warp-agents/warp-agents/",
-      "destination": "/agent-platform/local-agents/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/quickstart/",
-      "destination": "/quickstart/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-\\+-analyze-pr-\\+-modify-ui/",
-      "destination": "/guides/agent-workflows/how-to-run-3-agents-in-parallel-summarize-logs-analyze-pr-modify-ui/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-\\+-railway/",
-      "destination": "/guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-railway/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/build-an-app-in-warp/building-a-slackbot/",
-      "destination": "/platform/integrations/slack/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/configuration/how-to-create-project-rules-for-an-existing-project-astro-\\+-typescript-\\+-tailwind/",
-      "destination": "/guides/configuration/how-to-create-project-rules-for-an-existing-project-astro-typescript-tailwind/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/devops-and-infrastructure/how-to-analyze-cloud-run-logs-gcloud/",
-      "destination": "/guides/devops/how-to-analyze-cloud-run-logs-gcloud/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/devops-and-infrastructure/how-to-create-a-production-ready-docker-setup/",
-      "destination": "/guides/devops/how-to-create-a-production-ready-docker-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/devops-and-infrastructure/how-to-create-priority-matrix-for-database-optimization/",
-      "destination": "/guides/devops/how-to-create-priority-matrix-for-database-optimization/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/devops-and-infrastructure/how-to-generate-unit-and-security-tests-to-debug-faster/",
-      "destination": "/guides/devops/how-to-generate-unit-and-security-tests-to-debug-faster/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/devops-and-infrastructure/how-to-prevent-secrets-from-leaking/",
-      "destination": "/guides/devops/how-to-prevent-secrets-from-leaking/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/devops-and-infrastructure/how-to-write-sql-commands-inside-a-postgres-repl/",
-      "destination": "/guides/devops/how-to-write-sql-commands-inside-a-postgres-repl/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/devops-and-infrastructure/improve-your-kubernetes-workflow-kubectl-\\+-helm/",
-      "destination": "/guides/devops/improve-your-kubernetes-workflow-kubectl-helm/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/context7-mcp-update-astro-project-with-best-practices/",
-      "destination": "/guides/external-tools/context7-mcp-update-astro-project-with-best-practices/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/figma-remote-mcp-create-a-website-from-a-figma-file-from-scratch/",
-      "destination": "/guides/external-tools/figma-remote-mcp-create-a-website-from-a-figma-file-from-scratch/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/github-mcp-summarizing-open-prs-and-creating-gh-issues/",
-      "destination": "/guides/external-tools/github-mcp-summarizing-open-prs-and-creating-gh-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-claude-code/",
-      "destination": "/guides/external-tools/how-to-set-up-claude-code/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-codex-cli/",
-      "destination": "/guides/external-tools/how-to-set-up-codex-cli/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-gemini-cli/",
-      "destination": "/guides/external-tools/how-to-set-up-gemini-cli/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-ollama/",
-      "destination": "/guides/external-tools/how-to-set-up-ollama/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/how-to-set-up-opencode/",
-      "destination": "/guides/external-tools/how-to-set-up-opencode/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/linear-mcp-retrieve-issue-data/",
-      "destination": "/guides/external-tools/linear-mcp-retrieve-issue-data/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/linear-mcp-updating-tickets-with-a-lean-build-approach/",
-      "destination": "/guides/external-tools/linear-mcp-updating-tickets-with-a-lean-build-approach/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/puppeteer-mcp-scraping-amazon-web-reviews/",
-      "destination": "/guides/external-tools/puppeteer-mcp-scraping-amazon-web-reviews/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/sentry-mcp-fix-sentry-error-in-empower-website/",
-      "destination": "/guides/external-tools/sentry-mcp-fix-sentry-error-in-empower-website/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/sqlite-and-stripe-mcp-basic-queries-you-can-make-after-set-up/",
-      "destination": "/guides/external-tools/sqlite-and-stripe-mcp-basic-queries-you-can-make-after-set-up/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/external-tools-and-integrations/using-mcp-servers-with-warp/",
-      "destination": "/guides/external-tools/using-mcp-servers-with-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/frontend-and-ui/how-to-actually-code-ui-that-matches-your-mockup-react-\\+-tailwind/",
-      "destination": "/guides/frontend/how-to-actually-code-ui-that-matches-your-mockup-react-tailwind/",
-      "statusCode": 308
-    },
-    {
-      "source": "/guides/frontend-and-ui/how-to-replace-a-ui-element-in-warp-rust-codebase/",
-      "destination": "/guides/frontend/how-to-replace-a-ui-element-in-warp-rust-codebase/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/api-and-sdk/",
-      "destination": "/reference/api-and-sdk/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/api-and-sdk/models/",
-      "destination": "/reference/api-and-sdk/",
-      "statusCode": 308
-    },
-    {
-      "source": "/reference/cli/cli/",
-      "destination": "/reference/cli/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/privacy-security-and-licensing/network-log/",
-      "destination": "/support-and-community/privacy-and-security/network-log/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/privacy-security-and-licensing/open-source-licenses/",
-      "destination": "/support-and-community/community/open-source-licenses/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/privacy-security-and-licensing/privacy/",
-      "destination": "/support-and-community/privacy-and-security/privacy/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-community/privacy-security-and-licensing/secret-redaction/",
-      "destination": "/support-and-community/privacy-and-security/secret-redaction/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/classic-input/",
-      "destination": "/terminal/input/classic-input/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/terminal-features/",
-      "destination": "/terminal/comparisons/terminal-features/",
-      "statusCode": 308
-    },
-    {
-      "source": "/terminal/windows/launch-configurations/",
-      "destination": "/terminal/sessions/launch-configurations/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/agents-overview/",
-      "destination": "/agent-platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/ai/",
-      "destination": "/agent-platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/ai-faqs/",
-      "destination": "/agent-platform/getting-started/faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/autonomy/",
-      "destination": "/agent-platform/getting-started/agents-in-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/using-agents/agent-context/blocks-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/blocks-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/using-agents/agent-context/images-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/images-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/using-agents/agent-context/urls-as-context/",
-      "destination": "/agent-platform/local-agents/agent-context/urls-as-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/using-agents/agent-context/using-to-add-context/",
-      "destination": "/agent-platform/local-agents/agent-context/using-to-add-context/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/using-agents/agent-conversations/conversation-forking/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/conversation-forking/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/using-agents/managing-agents/",
-      "destination": "/platform/managing-cloud-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/voice/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/voice/",
-      "statusCode": 308
-    },
-    {
-      "source": "/ambient-agents/ambient-agents-overview/",
-      "destination": "/platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/ambient-agents/managing-ambient-agents/",
-      "destination": "/platform/managing-cloud-agents/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/readme/",
-      "destination": "/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/readme-1/coding-in-warp/",
-      "destination": "/getting-started/quickstart/coding-in-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/readme-1/customizing-warp/",
-      "destination": "/getting-started/quickstart/customizing-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/readme-1/installation-and-setup/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/readme/coding-in-warp/",
-      "destination": "/getting-started/quickstart/coding-in-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/readme/customizing-warp/",
-      "destination": "/getting-started/quickstart/customizing-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/getting-started/readme/installation-and-setup/",
-      "destination": "/getting-started/quickstart/installation-and-setup/",
-      "statusCode": 308
-    },
-    {
-      "source": "/platform/warp-platform/",
-      "destination": "/reference/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/known-issues/",
-      "destination": "/support-and-community/troubleshooting-and-support/known-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/plans-and-pricing/",
-      "destination": "/support-and-community/plans-and-billing/plans-pricing-refunds/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/plans-and-pricing/add-on-credits/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/plans-and-pricing/bring-your-own-api-key/",
-      "destination": "/agent-platform/inference/bring-your-own-api-key/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/plans-and-pricing/pricing-faqs/",
-      "destination": "/support-and-community/plans-and-billing/pricing-faqs/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/plans-and-pricing/reload-credits-add-on-credits/",
-      "destination": "/support-and-community/plans-and-billing/add-on-credits/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/sending-us-feedback/",
-      "destination": "/support-and-community/troubleshooting-and-support/sending-us-feedback/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/troubleshooting-login-issues/",
-      "destination": "/support-and-community/troubleshooting-and-support/troubleshooting-login-issues/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/uninstalling-warp/",
-      "destination": "/support-and-community/troubleshooting-and-support/logging-out-and-uninstalling/",
-      "statusCode": 308
-    },
-    {
-      "source": "/support-and-billing/updating-warp/",
-      "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/",
-      "destination": "/platform/self-hosting/reference/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/direct-backend/",
-      "destination": "/platform/self-hosting/managed-direct/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/docker-connectivity/",
-      "destination": "/platform/self-hosting/managed-docker/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/helm-chart/",
-      "destination": "/platform/self-hosting/managed-kubernetes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/kubernetes-backend/",
-      "destination": "/platform/self-hosting/managed-kubernetes/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/managed-worker-reference/private-docker-registries/",
-      "destination": "/platform/self-hosting/managed-docker/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/local-agents/interacting-with-agents/agent-modality/",
-      "destination": "/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/",
       "statusCode": 308
     },
     {
@@ -9423,12 +5753,7 @@
       "statusCode": 308
     },
     {
-      "source": "/agents/using-agents/agent-permissions",
-      "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agents/using-agents/agent-permissions/",
+      "source": "/agents/using-agents/agent-permissions(/?)",
       "destination": "/agent-platform/capabilities/agent-profiles-permissions/",
       "statusCode": 308
     },
@@ -9953,7 +6278,7 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/plans-and-billing/bring-your-own-api-key",
+      "source": "/support-and-community/plans-and-billing/bring-your-own-api-key(/?)",
       "destination": "/agent-platform/inference/bring-your-own-api-key/",
       "statusCode": 308
     },
@@ -10143,57 +6468,27 @@
       "statusCode": 308
     },
     {
-      "source": "/support-and-community/plans-and-billing/bring-your-own-api-key/",
-      "destination": "/agent-platform/inference/bring-your-own-api-key/",
-      "statusCode": 308
-    },
-    {
-      "source": "/help/updating-warp",
+      "source": "/help/updating-warp(/?)",
       "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
       "statusCode": 308
     },
     {
-      "source": "/help/updating-warp/",
-      "destination": "/support-and-community/troubleshooting-and-support/updating-warp/",
-      "statusCode": 308
-    },
-    {
-      "source": "/help/licenses",
+      "source": "/help/licenses(/?)",
       "destination": "/support-and-community/community/open-source-licenses/",
       "statusCode": 308
     },
     {
-      "source": "/help/licenses/",
-      "destination": "/support-and-community/community/open-source-licenses/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/overview",
+      "source": "/agent-platform/cloud-agents/overview(/?)",
       "destination": "/platform/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/overview/",
-      "destination": "/platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/platform",
+      "source": "/agent-platform/cloud-agents/platform(/?)",
       "destination": "/platform/overview/",
       "statusCode": 308
     },
     {
-      "source": "/agent-platform/cloud-agents/platform/",
-      "destination": "/platform/overview/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents",
-      "destination": "/platform/",
-      "statusCode": 308
-    },
-    {
-      "source": "/agent-platform/cloud-agents/",
+      "source": "/agent-platform/cloud-agents(/?)",
       "destination": "/platform/",
       "statusCode": 308
     },
@@ -10213,12 +6508,7 @@
       "statusCode": 308
     },
     {
-      "source": "/team",
-      "destination": "/knowledge-and-collaboration/teams/",
-      "statusCode": 308
-    },
-    {
-      "source": "/team/",
+      "source": "/team(/?)",
       "destination": "/knowledge-and-collaboration/teams/",
       "statusCode": 308
     }


### PR DESCRIPTION
## Summary
`vercel.json` held **744 pairs** of redirects that were byte-identical apart from the trailing slash, with the same destination and status code. Each pair burns two of the 2048 routes Vercel allows per deployment.

That ceiling has been a recurring problem: `27380fdf` collapsed the `/cli` redirects to get under it, and [#503](https://github.com/warpdotdev/docs/pull/503) failed to deploy for the same reason and needed its own fix. main has been sitting close enough to the cap that ordinary PRs adding a redirect could not deploy.

Collapsing each pair into a single `(/?)` rule takes the file from **2034 to 1292** config routes.

```
redirects:     2029 -> 1287
config routes: 2034 -> 1292   (cap 2048)
```

## Why both forms need a rule today
Vercel matches redirect sources literally — there is no trailing-slash normalization. Verified against production:

| Rule that exists | Request | Result |
| --- | --- | --- |
| with-slash only (`/agent-platform/capabilities/web-search/`) | no-slash | **404** |
| no-slash only (`/agents/using-agents/model-choice`) | with-slash | **404** |

So the duplication is not redundant today. It is the only way to cover both forms — until one rule can do it.

## The pattern
`/path(/?)` matches both `/path` and `/path/`. This uses the same unnamed-regex-group support the repo already relies on for `/university/(.*)`.

Verified on a preview deployment, at small scale first and then on this branch:

```
/features/global-hotkey        308 -> /terminal/windows/global-hotkey/
/features/global-hotkey/       308 -> /terminal/windows/global-hotkey/
/features/global-hotkeyextra   404      (does not over-match adjacent paths)
/features/global-hotkey/deeper 404      (does not swallow descendants)
/prefix/features/global-hotkey 404      (anchored at the start)
```

## Safety
Two guards in the transform:

- **Only plain-literal pairs** with identical destination and status code are touched. Any source already containing a pattern is left alone.
- **Order is preserved.** Vercel evaluates redirects in array order, so hoisting the with-slash form up to the position of the no-slash form could jump it ahead of a wildcard that currently wins. Any pair with a rule between its two entries that could match either form is skipped. That caught **2 pairs** — `/errors` and `/university`, which sit around `/errors/:code` and `/university/(.*)` — and they are left uncollapsed.

## Validation
- **Equivalence proven, not assumed.** All **2019** literal sources in the original file were resolved against both the old and new rule lists; every one lands on the same destination. The transform aborts if any mismatch is found.
- **20 collapsed rules sampled and tested live**, both URL forms each, comparing the preview against production: **40/40 identical** status codes and `Location` headers.
- **Anchoring verified** on the preview, as shown above.
- `npm run build` — clean.
- Internal link check — **0 broken** across 3,490 links.
- 0 duplicate sources; self-redirect count unchanged from main (2 benign no-slash normalizers).
- The preview deploying at all is itself confirmation we are well under the route cap.

## Follow-up, not included here
There are **53 retired paths whose no-slash form 404s today** because only a with-slash rule was ever added. This PR does not change that behavior either way — collapsing only touches paths that already had both forms. Worth a separate pass now that there is headroom to add rules again.

## Unverified claims
None. This changes only redirect routing config; no page content, slugs, or navigation are touched. Every behavioral claim above was checked against a live deployment rather than inferred from the config.

Co-Authored-By: Warp Agent <agent@warp.dev>
