### PR TITLE
docs: surface support contacts on Support & Community landing page

### DIFF
--- a/src/content/docs/support-and-community/index.mdx
+++ b/src/content/docs/support-and-community/index.mdx
@@ -1,9 +1,19 @@
 ---
 title: Support & Community
 description: >-
-  Connect with the developers and engineers building with Warp. Share what
-  you've built, shape what we build next, and get help when you're stuck.
+  Contact Warp support, join the community, and find help for bugs, billing,
+  and enterprise issues.
 ---
+## Contact support
+
+### Subscribers and Enterprise
+
+* **Technical issues or questions** - For bugs, credits, and other technical issues, email [support@warp.dev](mailto:support@warp.dev).
+* **Billing issues or questions** - For refunds, cancellations, and other billing questions, email [billing@warp.dev](mailto:billing@warp.dev).
+* **Enterprise** - Direct all feedback and issues to your designated Slack channel.
+
+For other ways to send feedback, gather logs, or file a bug report, see [Sending feedback and logs](/support-and-community/troubleshooting-and-support/sending-us-feedback/).
+
 ## Find your space
 
 ### Join the community
@@ -51,9 +61,9 @@ We host [live events](https://luma.com/warpdotdev) year-round — product demos,
 We're building an Ambassador program for developers who want to lead and grow the Warp community. Join the [community Slack](https://go.warp.dev/join-preview) to hear when applications open.
 :::
 
-## Get help
+## More help
 
-* [Sending us feedback](/support-and-community/troubleshooting-and-support/sending-us-feedback/)
+* [Sending feedback and logs](/support-and-community/troubleshooting-and-support/sending-us-feedback/)
 * [Known issues](/support-and-community/troubleshooting-and-support/known-issues/)
 * [Plans, pricing, and refunds](/support-and-community/plans-and-billing/plans-pricing-refunds/)
 * [Privacy](/support-and-community/privacy-and-security/privacy/)


### PR DESCRIPTION
## Summary
Surface subscriber and enterprise support contacts at the top of the Support & Community landing page so users can find `support@warp.dev`, `billing@warp.dev`, and enterprise Slack guidance without navigating into Sending feedback first.

## Changes

### src/content/docs/support-and-community/index.mdx
- Added a top **Contact support** section with subscriber technical, billing, and enterprise channels
- Linked through to [Sending feedback and logs](/support-and-community/troubleshooting-and-support/sending-us-feedback/) for logs and other feedback paths
- Renamed the bottom help list to **More help**
- Updated the page description to lead with contact/help intent

## Testing
Checked in the preview link https://docs-c7qawnif5-warpdotdev.vercel.app/support-and-community/

<img width="1820" height="1198" alt="CleanShot 2026-08-14 at 14 19 29@2x" src="https://github.com/user-attachments/assets/68c5b75b-408b-4358-9298-aa697057930e" />

Co-Authored-By: Warp <agent@warp.dev>
