### PR TITLE
docs: add Warp Factories to docs landing pages

### DIFF
--- a/src/content/docs/agents/index.mdx
+++ b/src/content/docs/agents/index.mdx
@@ -36,7 +36,9 @@ Separately from the Warp Agent, Warp gives third-party CLI coding agents first-c
 
 [**{VARS.WARP_AUTOMATION_PLATFORM}**](/platform/overview/) is Warp's programmable system for running and coordinating agents at scale. It provides the environments, triggers, integrations, orchestration, and observability that cloud agents run on, along with a CLI, API, and SDK for driving agents programmatically.
 
-The {VARS.WARP_AUTOMATION_PLATFORM} tab covers it in full.
+For repeatable work that spans multiple agent roles, [Warp Factories](/factories/) coordinates specialized cloud agents across software development workflows, while {VARS.WARP_AUTOMATION_PLATFORM} provides the underlying cloud-run primitives.
+
+The {VARS.WARP_AUTOMATION_PLATFORM} tab covers the platform in full.
 
 ---
 

--- a/src/content/docs/agents/index.mdx
+++ b/src/content/docs/agents/index.mdx
@@ -36,7 +36,7 @@ Separately from the Warp Agent, Warp gives third-party CLI coding agents first-c
 
 [**{VARS.WARP_AUTOMATION_PLATFORM}**](/platform/overview/) is Warp's programmable system for running and coordinating agents at scale. It provides the environments, triggers, integrations, orchestration, and observability that cloud agents run on, along with a CLI, API, and SDK for driving agents programmatically.
 
-For repeatable work that spans multiple agent roles, [Warp Factories](/factories/) coordinates specialized cloud agents across software development workflows, while {VARS.WARP_AUTOMATION_PLATFORM} provides the underlying cloud-run primitives.
+To automate an entire workflow rather than a single task, use [Warp Factories](/factories/). Built on {VARS.WARP_AUTOMATION_PLATFORM}, a factory runs a team of cloud agents that triage, spec, implement, review, and verify work.
 
 The {VARS.WARP_AUTOMATION_PLATFORM} tab covers the platform in full.
 

--- a/src/content/docs/enterprise/index.mdx
+++ b/src/content/docs/enterprise/index.mdx
@@ -8,11 +8,11 @@ import { VARS } from '@data/vars';
 
 Warp Enterprise is built for organizations that want to accelerate software development with agents while maintaining security, compliance, and administrative control. It brings Warp's **Agentic Development Environment** to your entire engineering organization with the governance features IT and security teams require.
 
-Warp's products cover interactive development, cloud automation, and repeatable multi-agent workflows:
+Warp has three products:
 
 * **Warp Terminal** - A modern terminal designed for agentic development where developers run commands, collaborate with agents, and orchestrate autonomous work from the command line.
 * **{VARS.WARP_AUTOMATION_PLATFORM}** - Warp's programmable system for running and coordinating agents at scale. {VARS.WARP_AUTOMATION_PLATFORM} powers all agents in Warp, whether they run locally or in the cloud, and provides the orchestration, tracking, and control plane for scalable agent workflows.
-* [**Warp Factories**](/factories/) - Coordinates specialized cloud agents across persistent software development workflows, using {VARS.WARP_AUTOMATION_PLATFORM} primitives to move work through triage, implementation, review, and verification.
+* [**Warp Factories**](/factories/) - Warp's product for building and operating software factories, where cloud agents triage, spec, implement, review, and verify work, and humans approve key decisions.
 
 ## Who Warp Enterprise is for
 

--- a/src/content/docs/enterprise/index.mdx
+++ b/src/content/docs/enterprise/index.mdx
@@ -8,10 +8,11 @@ import { VARS } from '@data/vars';
 
 Warp Enterprise is built for organizations that want to accelerate software development with agents while maintaining security, compliance, and administrative control. It brings Warp's **Agentic Development Environment** to your entire engineering organization with the governance features IT and security teams require.
 
-Warp has two core products:
+Warp's products cover interactive development, cloud automation, and repeatable multi-agent workflows:
 
 * **Warp Terminal** - A modern terminal designed for agentic development where developers run commands, collaborate with agents, and orchestrate autonomous work from the command line.
 * **{VARS.WARP_AUTOMATION_PLATFORM}** - Warp's programmable system for running and coordinating agents at scale. {VARS.WARP_AUTOMATION_PLATFORM} powers all agents in Warp, whether they run locally or in the cloud, and provides the orchestration, tracking, and control plane for scalable agent workflows.
+* [**Warp Factories**](/factories/) - Coordinates specialized cloud agents across persistent software development workflows, using {VARS.WARP_AUTOMATION_PLATFORM} primitives to move work through triage, implementation, review, and verification.
 
 ## Who Warp Enterprise is for
 

--- a/src/content/docs/guides/index.mdx
+++ b/src/content/docs/guides/index.mdx
@@ -10,6 +10,8 @@ import GuidesLanding from '@components/GuidesLanding.astro';
 
 Practical, task-oriented walkthroughs that help you get productive with Warp's coding agents. Each guide walks through a real AI coding workflow with actual prompts, code, and reproducible results.
 
+When you're ready to turn a one-off coding workflow into a repeatable, multi-agent process, [Warp Factories](/factories/) coordinates specialized cloud agents across software development stages.
+
 :::note
 **New to Warp?** Start with [Welcome to Warp](/guides/getting-started/welcome-to-warp/), then explore [10 Warp Coding Features You Should Know](/guides/getting-started/10-coding-features-you-should-know/).
 :::

--- a/src/content/docs/guides/index.mdx
+++ b/src/content/docs/guides/index.mdx
@@ -10,7 +10,7 @@ import GuidesLanding from '@components/GuidesLanding.astro';
 
 Practical, task-oriented walkthroughs that help you get productive with Warp's coding agents. Each guide walks through a real AI coding workflow with actual prompts, code, and reproducible results.
 
-When you're ready to turn a one-off coding workflow into a repeatable, multi-agent process, [Warp Factories](/factories/) coordinates specialized cloud agents across software development stages.
+To turn a one-off workflow into a repeatable process run by a team of cloud agents, see [Warp Factories](/factories/).
 
 :::note
 **New to Warp?** Start with [Welcome to Warp](/guides/getting-started/welcome-to-warp/), then explore [10 Warp Coding Features You Should Know](/guides/getting-started/10-coding-features-you-should-know/).

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -75,6 +75,10 @@ Cloud agents are ideal for work that doesn't need your immediate attention, like
 
 → [Learn about the {VARS.WARP_AUTOMATION_PLATFORM}](/platform/overview/)
 
+## Repeatable software workflows with Warp Factories
+
+[**Warp Factories (Early Access)**](/factories/) coordinates specialized cloud agents across software development workflows, assembling {VARS.WARP_AUTOMATION_PLATFORM} primitives into repeatable processes such as triage, implementation, review, and verification.
+
 ---
 
 ## How they work together

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -75,9 +75,13 @@ Cloud agents are ideal for work that doesn't need your immediate attention, like
 
 → [Learn about the {VARS.WARP_AUTOMATION_PLATFORM}](/platform/overview/)
 
-## Repeatable software workflows with Warp Factories
+---
 
-[**Warp Factories (Early Access)**](/factories/) coordinates specialized cloud agents across software development workflows, assembling {VARS.WARP_AUTOMATION_PLATFORM} primitives into repeatable processes such as triage, implementation, review, and verification.
+## Repeatable development workflows with Warp Factories
+
+A single cloud agent handles one task. **Warp Factories**, now in Early Access, lets your team run a software factory: a repeatable process where cloud agents triage, spec, implement, review, and verify work, and humans approve key decisions.
+
+→ [Learn about Warp Factories](/factories/)
 
 ---
 


### PR DESCRIPTION
## Summary
Adds concise Warp Factories discovery links to four high-value entry points:

- Main docs landing page
- Agents overview
- Enterprise overview
- Guides landing page

The Automation Platform relationship remains owned and reviewed in #516 to avoid overlapping edits to `platform/overview.mdx`.

## Reader journeys
- Main docs visitors discover **Warp Factories (Early Access)** as the product for repeatable multi-agent development workflows.
- Agent users can move from individual agents to a software factory.
- Enterprise evaluators can find Factories alongside interactive development and cloud automation.
- Guide readers can move from one-off workflows to the managed Factory product.

## Coordination
Open #503 overlaps the root and Agents pages. Before merging this PR, update it onto the latest `hyc/factory-launch` and preserve #503’s final IA/content while retaining only the Factories-specific additions.

## Foundation
Shared navigation, route placeholders, Early Access badge support, and guide migrations are merged in #537. This PR now contains only its feature-owned files and passes CI independently.

## Validation
- `npm run typecheck`: 0 errors
- Internal links: 0 broken
- Scoped Factories link assertions: passed
- `git diff --check`: passed
- Full build currently hits a pre-existing `/_llms-txt/support.txt` recursion failure unrelated to these four files; the foundation and all feature PRs build green independently.

## Proposed reviewers
Based on the **Warp Factories Soft Launch (August 18th)** tracker. For planning only; no review requests have been sent.
- `@rachaelrenk`
- `@petradonka`
- `@johnturcoo`

