### PR TITLE
Expand Guides sidebar groups by default

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -689,7 +689,6 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 				{ slug: 'guides', label: 'Guides' },
 				{
 					label: 'Getting started',
-					collapsed: true,
 					items: [
 						'guides/getting-started/welcome-to-warp',
 				{ slug: 'guides/getting-started/10-coding-features-you-should-know', label: '10 coding features you should know' },
@@ -700,7 +699,6 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 				},
 				{
 					label: 'Agent workflows',
-					collapsed: true,
 					items: [
 						{ slug: 'guides/agent-workflows/how-to-review-ai-generated-code', label: 'Review AI-generated code' },
 						{ slug: 'guides/agent-workflows/how-to-attach-agent-session-context-to-github-prs', label: 'Attach agent context to PRs' },
@@ -718,7 +716,6 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 				},
 				{
 					label: 'Build a software factory',
-					collapsed: true,
 					items: [
 						{ slug: 'guides/agent-workflows/build-a-triage-agent', label: 'Build a triage agent' },
 						{ slug: 'guides/agent-workflows/write-product-and-tech-specs-with-agents', label: 'Write specs with agents' },
@@ -729,7 +726,6 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 				},
 				{
 					label: 'Configuration',
-					collapsed: true,
 					items: [
 						{ slug: 'guides/configuration/how-to-create-project-rules-for-an-existing-project-astro-typescript-tailwind', label: 'Create project Rules' },
 						{ slug: 'guides/configuration/how-to-set-coding-best-practices', label: 'Set coding best practices with Rules' },
@@ -746,7 +742,6 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 				},
 				{
 					label: 'External tools & integrations',
-					collapsed: true,
 					items: [
 						{ slug: 'guides/external-tools/how-to-set-up-claude-code', label: 'Set up Claude Code' },
 						{ slug: 'guides/external-tools/how-to-set-up-codex-cli', label: 'Set up Codex CLI' },
@@ -766,7 +761,6 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 				},
 				{
 					label: 'Build an app in Warp',
-					collapsed: true,
 					items: [
 						{ slug: 'guides/build-an-app-in-warp/building-a-real-time-chat-app-github-mcp-railway', label: 'Build a real-time chat app' },
 						{ slug: 'guides/build-an-app-in-warp/building-a-chrome-extension-d3js-javascript-html-css', label: 'Build a Chrome extension' },
@@ -775,7 +769,6 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 				},
 				{
 					label: 'DevOps & infrastructure',
-					collapsed: true,
 					items: [
 						{ slug: 'guides/devops/how-to-analyze-cloud-run-logs-gcloud', label: 'Analyze Cloud Run logs (gcloud)' },
 						{ slug: 'guides/devops/how-to-create-a-production-ready-docker-setup', label: 'Create a production-ready Docker setup' },
@@ -788,7 +781,6 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 				},
 				{
 					label: 'Frontend & UI',
-					collapsed: true,
 					items: [
 						{ slug: 'guides/frontend/how-to-replace-a-ui-element-in-warp-rust-codebase', label: 'Replace a UI element in Warp (Rust codebase)' },
 						{ slug: 'guides/frontend/how-to-actually-code-ui-that-matches-your-mockup-react-tailwind', label: 'Code UI that matches your mockup (React + Tailwind)' },


### PR DESCRIPTION
## Summary
Make the Guides sidebar groups expanded by default. All eight groups in the Guides topic (Getting started, Agent workflows, Build a software factory, Configuration, External tools & integrations, Build an app in Warp, DevOps & infrastructure, Frontend & UI) had `collapsed: true`, so the Guides tab opened with every group closed. This removes those flags in `src/sidebar.ts` so the guide links are visible immediately.

## Validation
- `npm run typecheck` — 0 errors
- `npm run build` — completes successfully

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
