### PR TITLE
feat: add cookie consent banner for Kapa Ask AI tracking

### DIFF
--- a/src/components/CookieConsentBanner.astro
+++ b/src/components/CookieConsentBanner.astro
@@ -1,0 +1,82 @@
+---
+// Site-wide cookie consent for Kapa Ask AI anonymous analytics.
+// Decision is stored in localStorage and consumed by KapaChatLauncher.
+// Kept as a lightweight Astro island (no React) so it paints with the page.
+const privacyHref = '/support-and-community/privacy-and-security/privacy/';
+---
+
+<div
+	id="warp-cookie-banner"
+	class="warp-cookie-banner"
+	role="dialog"
+	aria-live="polite"
+	aria-label="Cookie consent"
+	hidden
+>
+	<div class="warp-cookie-banner__inner">
+		<p class="warp-cookie-banner__copy">
+			We use a first-party cookie so Ask AI can measure unique visitors and improve answers.
+			See our <a href={privacyHref}>privacy docs</a> for details.
+		</p>
+		<div class="warp-cookie-banner__actions">
+			<button type="button" class="warp-cookie-banner__btn warp-cookie-banner__btn--ghost" data-cookie-consent="declined">
+				Decline
+			</button>
+			<button type="button" class="warp-cookie-banner__btn warp-cookie-banner__btn--primary" data-cookie-consent="accepted">
+				Accept
+			</button>
+		</div>
+	</div>
+</div>
+
+<script is:inline>
+	(() => {
+		var STORAGE_KEY = 'warp_docs_cookie_consent';
+		var EVENT_NAME = 'warp-docs-cookie-consent';
+		var banner = document.getElementById('warp-cookie-banner');
+		if (!banner) return;
+
+		function readConsent() {
+			try {
+				var value = localStorage.getItem(STORAGE_KEY);
+				if (value === 'accepted' || value === 'declined') return value;
+			} catch (e) {}
+			return null;
+		}
+
+		function writeConsent(value) {
+			try {
+				localStorage.setItem(STORAGE_KEY, value);
+			} catch (e) {}
+			window.dispatchEvent(
+				new CustomEvent(EVENT_NAME, {
+					detail: { consent: value },
+				})
+			);
+		}
+
+		function hideBanner() {
+			banner.hidden = true;
+		}
+
+		function showBanner() {
+			banner.hidden = false;
+		}
+
+		var existing = readConsent();
+		if (!existing) {
+			showBanner();
+		}
+
+		banner.addEventListener('click', function (event) {
+			var target = event.target;
+			if (!(target instanceof Element)) return;
+			var button = target.closest('[data-cookie-consent]');
+			if (!button) return;
+			var value = button.getAttribute('data-cookie-consent');
+			if (value !== 'accepted' && value !== 'declined') return;
+			writeConsent(value);
+			hideBanner();
+		});
+	})();
+</script>

--- a/src/components/CookieConsentBanner.astro
+++ b/src/components/CookieConsentBanner.astro
@@ -48,14 +48,6 @@ const privacyHref = '/support-and-community/privacy-and-security/privacy/';
 			try {
 				localStorage.setItem(STORAGE_KEY, value);
 			} catch (e) {}
-			// Preview QA helper: always log the click path, even before React remounts.
-			try {
-				console.info('[warp-docs cookie banner]', {
-					consent: value,
-					localStorageConsent: localStorage.getItem(STORAGE_KEY),
-					hostname: location.hostname,
-				});
-			} catch (e) {}
 			window.dispatchEvent(
 				new CustomEvent(EVENT_NAME, {
 					detail: { consent: value },

--- a/src/components/CookieConsentBanner.astro
+++ b/src/components/CookieConsentBanner.astro
@@ -48,6 +48,14 @@ const privacyHref = '/support-and-community/privacy-and-security/privacy/';
 			try {
 				localStorage.setItem(STORAGE_KEY, value);
 			} catch (e) {}
+			// Preview QA helper: always log the click path, even before React remounts.
+			try {
+				console.info('[warp-docs cookie banner]', {
+					consent: value,
+					localStorageConsent: localStorage.getItem(STORAGE_KEY),
+					hostname: location.hostname,
+				});
+			} catch (e) {}
 			window.dispatchEvent(
 				new CustomEvent(EVENT_NAME, {
 					detail: { consent: value },

--- a/src/components/FeedbackFooter.astro
+++ b/src/components/FeedbackFooter.astro
@@ -7,6 +7,7 @@ import Pagination from 'virtual:starlight/components/Pagination';
 import config from 'virtual:starlight/user-config';
 import DocsFeedbackLinks from './DocsFeedbackLinks.astro';
 import MermaidControls from './MermaidControls.astro';
+import CookieConsentBanner from './CookieConsentBanner.astro';
 
 // `starlightRoute.editUrl` is typed as `URL | undefined`; DocsFeedbackLinks
 // expects a plain string so it can pass the same value through untouched
@@ -28,6 +29,8 @@ const pageUrl = Astro.url.href;
     )
   }
 </footer>
+{/* Fixed bottom cookie bar; lives outside the footer layout flow. */}
+<CookieConsentBanner />
 
 <style>
   @layer starlight.core {

--- a/src/components/KapaChatLauncher.tsx
+++ b/src/components/KapaChatLauncher.tsx
@@ -120,67 +120,6 @@ function trackingModeForConsent(consent: CookieConsent | null): KapaUserTracking
 	return consent === 'accepted' ? 'cookie' : 'none';
 }
 
-type KapaConsentDebugSnapshot = {
-	consent: CookieConsent | null;
-	userTrackingMode: KapaUserTrackingMode;
-	hostname: string;
-	isPreviewHost: boolean;
-	kapaWebIdCookiePresent: boolean;
-	documentCookie: string;
-	localStorageConsent: string | null;
-	note: string;
-};
-
-function isKapaConsentDebugEnabled() {
-	if (typeof window === 'undefined') return false;
-	const host = window.location.hostname;
-	const isProdDocs = host === 'docs.warp.dev' || host === 'www.docs.warp.dev';
-	const force =
-		new URLSearchParams(window.location.search).has('kapaDebug') ||
-		window.localStorage.getItem('warp_docs_kapa_debug') === '1';
-	// Enabled by default outside production docs so Vercel previews are easy to QA.
-	return force || !isProdDocs;
-}
-
-function readKapaWebIdFromDocumentCookie() {
-	if (typeof document === 'undefined') return false;
-	return document.cookie.split('; ').some((part) => part.startsWith('kapa_web_id='));
-}
-
-function publishKapaConsentDebug(snapshot: KapaConsentDebugSnapshot) {
-	if (typeof window === 'undefined' || !isKapaConsentDebugEnabled()) return;
-	const debugWindow = window as Window & {
-		__warpDocsKapaDebug?: KapaConsentDebugSnapshot & {
-			refresh?: () => KapaConsentDebugSnapshot;
-		};
-	};
-	const refresh = () => {
-		const consent = readCookieConsent();
-		const next: KapaConsentDebugSnapshot = {
-			consent,
-			userTrackingMode: trackingModeForConsent(consent),
-			hostname: window.location.hostname,
-			isPreviewHost: /\.vercel\.app$/i.test(window.location.hostname) || window.location.hostname === 'localhost',
-			kapaWebIdCookiePresent: readKapaWebIdFromDocumentCookie(),
-			documentCookie: document.cookie,
-			localStorageConsent: (() => {
-				try {
-					return localStorage.getItem(cookieConsentStorageKey);
-				} catch {
-					return null;
-				}
-			})(),
-			note:
-				'kapa_web_id is written by the Kapa SDK on query submit. On *.vercel.app public-suffix hosts the SDK domain cookie often fails to stick; trust userTrackingMode + localStorage on preview.',
-		};
-		debugWindow.__warpDocsKapaDebug = { ...next, refresh };
-		return next;
-	};
-	debugWindow.__warpDocsKapaDebug = { ...snapshot, refresh };
-	// eslint-disable-next-line no-console -- intentional preview QA signal
-	console.info('[warp-docs kapa consent]', snapshot);
-}
-
 function getChatErrorMessage(error: unknown) {
 	const message = typeof error === 'string' ? error : String(error ?? '');
 	const normalized = message.toLowerCase();
@@ -1331,28 +1270,6 @@ export default function KapaChatLauncher({ autoOpen = false }: { autoOpen?: bool
 	// Cookie mode only after explicit accept from CookieConsentBanner.
 	// https://docs.kapa.ai/dev/sdk/components/KapaProvider#user-tracking-mode
 	const userTrackingMode = trackingModeForConsent(cookieConsent);
-
-	useEffect(() => {
-		if (typeof window === 'undefined') return;
-		const hostname = window.location.hostname;
-		publishKapaConsentDebug({
-			consent: cookieConsent,
-			userTrackingMode,
-			hostname,
-			isPreviewHost: /\.(vercel\.app)$/i.test(hostname) || hostname === 'localhost',
-			kapaWebIdCookiePresent: readKapaWebIdFromDocumentCookie(),
-			documentCookie: document.cookie,
-			localStorageConsent: (() => {
-				try {
-					return localStorage.getItem(cookieConsentStorageKey);
-				} catch {
-					return null;
-				}
-			})(),
-			note:
-				'kapa_web_id is written by the Kapa SDK on query submit. On *.vercel.app public-suffix hosts the SDK domain cookie often fails to stick; trust userTrackingMode + localStorage on preview.',
-		});
-	}, [cookieConsent, userTrackingMode, chatSessionKey]);
 
 	if (!integrationId) {
 		return null;

--- a/src/components/KapaChatLauncher.tsx
+++ b/src/components/KapaChatLauncher.tsx
@@ -34,6 +34,8 @@ const welcomeMessage = 'What do you want to know about Warp?';
 const uncertaintyThreshold = 0.15;
 const conversationLengthThreshold = 3;
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const cookieConsentStorageKey = 'warp_docs_cookie_consent';
+const cookieConsentEventName = 'warp-docs-cookie-consent';
 const warpDocsMcpUrl = 'https://warp.mcp.kapa.ai';
 const warpDocsMcpConfig = JSON.stringify(
 	{
@@ -98,6 +100,24 @@ function isAnswerUncertain(metadata: unknown) {
 
 function isValidEmailAddress(value: string) {
 	return emailPattern.test(value.trim());
+}
+
+type CookieConsent = 'accepted' | 'declined';
+type KapaUserTrackingMode = 'cookie' | 'none';
+
+function readCookieConsent(): CookieConsent | null {
+	if (typeof window === 'undefined') return null;
+	try {
+		const value = localStorage.getItem(cookieConsentStorageKey);
+		if (value === 'accepted' || value === 'declined') return value;
+	} catch {
+		// Ignore storage access errors (private mode, blocked storage).
+	}
+	return null;
+}
+
+function trackingModeForConsent(consent: CookieConsent | null): KapaUserTrackingMode {
+	return consent === 'accepted' ? 'cookie' : 'none';
 }
 function getChatErrorMessage(error: unknown) {
 	const message = typeof error === 'string' ? error : String(error ?? '');
@@ -1217,6 +1237,7 @@ function ChatSurface({ title, welcomeMessage, autoOpen = false, onNewConversatio
 export default function KapaChatLauncher({ autoOpen = false }: { autoOpen?: boolean } = {}) {
 	const [chatSessionKey, setChatSessionKey] = useState(0);
 	const [sessionAutoOpen, setSessionAutoOpen] = useState(autoOpen);
+	const [cookieConsent, setCookieConsent] = useState<CookieConsent | null>(() => readCookieConsent());
 	const callbacks = useMemo(
 		() => ({
 			askAI: {
@@ -1229,6 +1250,22 @@ export default function KapaChatLauncher({ autoOpen = false }: { autoOpen?: bool
 		}),
 		[]
 	);
+
+	useEffect(() => {
+		const onConsent = (event: Event) => {
+			const detail = (event as CustomEvent<{ consent?: string }>).detail;
+			const next = detail?.consent;
+			if (next !== 'accepted' && next !== 'declined') return;
+			setCookieConsent(next);
+			// Remount the provider so the new tracking mode takes effect cleanly.
+			setChatSessionKey((key) => key + 1);
+		};
+		window.addEventListener(cookieConsentEventName, onConsent);
+		return () => {
+			window.removeEventListener(cookieConsentEventName, onConsent);
+		};
+	}, []);
+
 	if (!integrationId) {
 		return null;
 	}
@@ -1239,15 +1276,16 @@ export default function KapaChatLauncher({ autoOpen = false }: { autoOpen?: bool
 		setChatSessionKey((key) => key + 1);
 	};
 
+	// Cookie mode only after explicit accept from CookieConsentBanner.
+	// https://docs.kapa.ai/dev/sdk/components/KapaProvider#user-tracking-mode
+	const userTrackingMode = trackingModeForConsent(cookieConsent);
+
 	return (
 		<KapaProvider
-			key={chatSessionKey}
+			key={`${chatSessionKey}-${userTrackingMode}`}
 			integrationId={integrationId}
 			callbacks={callbacks}
-			// Anonymous first-party cookie (`kapa_web_id`). Default in the Kapa
-			// React SDK; set explicitly so we do not accidentally ship `none` again.
-			// https://docs.kapa.ai/dev/sdk/components/KapaProvider#user-tracking-mode
-			userTrackingMode="cookie"
+			userTrackingMode={userTrackingMode}
 		>
 			<ChatSurface
 				title={title}

--- a/src/components/KapaChatLauncher.tsx
+++ b/src/components/KapaChatLauncher.tsx
@@ -119,6 +119,68 @@ function readCookieConsent(): CookieConsent | null {
 function trackingModeForConsent(consent: CookieConsent | null): KapaUserTrackingMode {
 	return consent === 'accepted' ? 'cookie' : 'none';
 }
+
+type KapaConsentDebugSnapshot = {
+	consent: CookieConsent | null;
+	userTrackingMode: KapaUserTrackingMode;
+	hostname: string;
+	isPreviewHost: boolean;
+	kapaWebIdCookiePresent: boolean;
+	documentCookie: string;
+	localStorageConsent: string | null;
+	note: string;
+};
+
+function isKapaConsentDebugEnabled() {
+	if (typeof window === 'undefined') return false;
+	const host = window.location.hostname;
+	const isProdDocs = host === 'docs.warp.dev' || host === 'www.docs.warp.dev';
+	const force =
+		new URLSearchParams(window.location.search).has('kapaDebug') ||
+		window.localStorage.getItem('warp_docs_kapa_debug') === '1';
+	// Enabled by default outside production docs so Vercel previews are easy to QA.
+	return force || !isProdDocs;
+}
+
+function readKapaWebIdFromDocumentCookie() {
+	if (typeof document === 'undefined') return false;
+	return document.cookie.split('; ').some((part) => part.startsWith('kapa_web_id='));
+}
+
+function publishKapaConsentDebug(snapshot: KapaConsentDebugSnapshot) {
+	if (typeof window === 'undefined' || !isKapaConsentDebugEnabled()) return;
+	const debugWindow = window as Window & {
+		__warpDocsKapaDebug?: KapaConsentDebugSnapshot & {
+			refresh?: () => KapaConsentDebugSnapshot;
+		};
+	};
+	const refresh = () => {
+		const consent = readCookieConsent();
+		const next: KapaConsentDebugSnapshot = {
+			consent,
+			userTrackingMode: trackingModeForConsent(consent),
+			hostname: window.location.hostname,
+			isPreviewHost: /\.vercel\.app$/i.test(window.location.hostname) || window.location.hostname === 'localhost',
+			kapaWebIdCookiePresent: readKapaWebIdFromDocumentCookie(),
+			documentCookie: document.cookie,
+			localStorageConsent: (() => {
+				try {
+					return localStorage.getItem(cookieConsentStorageKey);
+				} catch {
+					return null;
+				}
+			})(),
+			note:
+				'kapa_web_id is written by the Kapa SDK on query submit. On *.vercel.app public-suffix hosts the SDK domain cookie often fails to stick; trust userTrackingMode + localStorage on preview.',
+		};
+		debugWindow.__warpDocsKapaDebug = { ...next, refresh };
+		return next;
+	};
+	debugWindow.__warpDocsKapaDebug = { ...snapshot, refresh };
+	// eslint-disable-next-line no-console -- intentional preview QA signal
+	console.info('[warp-docs kapa consent]', snapshot);
+}
+
 function getChatErrorMessage(error: unknown) {
 	const message = typeof error === 'string' ? error : String(error ?? '');
 	const normalized = message.toLowerCase();
@@ -1266,6 +1328,32 @@ export default function KapaChatLauncher({ autoOpen = false }: { autoOpen?: bool
 		};
 	}, []);
 
+	// Cookie mode only after explicit accept from CookieConsentBanner.
+	// https://docs.kapa.ai/dev/sdk/components/KapaProvider#user-tracking-mode
+	const userTrackingMode = trackingModeForConsent(cookieConsent);
+
+	useEffect(() => {
+		if (typeof window === 'undefined') return;
+		const hostname = window.location.hostname;
+		publishKapaConsentDebug({
+			consent: cookieConsent,
+			userTrackingMode,
+			hostname,
+			isPreviewHost: /\.(vercel\.app)$/i.test(hostname) || hostname === 'localhost',
+			kapaWebIdCookiePresent: readKapaWebIdFromDocumentCookie(),
+			documentCookie: document.cookie,
+			localStorageConsent: (() => {
+				try {
+					return localStorage.getItem(cookieConsentStorageKey);
+				} catch {
+					return null;
+				}
+			})(),
+			note:
+				'kapa_web_id is written by the Kapa SDK on query submit. On *.vercel.app public-suffix hosts the SDK domain cookie often fails to stick; trust userTrackingMode + localStorage on preview.',
+		});
+	}, [cookieConsent, userTrackingMode, chatSessionKey]);
+
 	if (!integrationId) {
 		return null;
 	}
@@ -1275,10 +1363,6 @@ export default function KapaChatLauncher({ autoOpen = false }: { autoOpen?: bool
 		setSessionAutoOpen(true);
 		setChatSessionKey((key) => key + 1);
 	};
-
-	// Cookie mode only after explicit accept from CookieConsentBanner.
-	// https://docs.kapa.ai/dev/sdk/components/KapaProvider#user-tracking-mode
-	const userTrackingMode = trackingModeForConsent(cookieConsent);
 
 	return (
 		<KapaProvider

--- a/src/styles/warp-components.css
+++ b/src/styles/warp-components.css
@@ -1597,3 +1597,123 @@ site-search #starlight__search .pagefind-ui__result-nested .pagefind-ui__result-
 .sl-markdown-content code.glyph-success {
   color: var(--sl-color-green-high);
 }
+
+/* --------------------------------------------------------------------------
+   21. Cookie consent banner — bottom bar for Kapa Ask AI analytics
+   --------------------------------------------------------------------------
+   Fixed bottom strip using the shared `--warp-control-*` chrome palette so
+   it matches search/Ask/copy controls. Shown only until the visitor accepts
+   or declines; decision lives in localStorage (`warp_docs_cookie_consent`).
+   -------------------------------------------------------------------------- */
+
+.warp-cookie-banner {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem calc(0.75rem + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid var(--sl-color-hairline-light);
+  background: color-mix(in srgb, var(--sl-color-bg) 92%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 -0.5rem 1.5rem rgba(0, 0, 0, 0.18);
+}
+
+.warp-cookie-banner[hidden] {
+  display: none !important;
+}
+
+.warp-cookie-banner__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  max-width: 72rem;
+  margin-inline: auto;
+}
+
+.warp-cookie-banner__copy {
+  margin: 0;
+  color: var(--sl-color-gray-2);
+  font-family: var(--__sl-font, 'Inter', sans-serif);
+  font-size: var(--sl-text-sm);
+  font-weight: 400;
+  line-height: 1.45;
+}
+
+.warp-cookie-banner__copy a {
+  color: var(--sl-color-text-accent);
+  text-decoration: none;
+}
+
+.warp-cookie-banner__copy a:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.warp-cookie-banner__actions {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.warp-cookie-banner__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.25rem;
+  padding: 0 0.875rem;
+  border-radius: var(--sl-radius-sm);
+  border: 1px solid var(--warp-control-border);
+  background: var(--warp-control-bg);
+  color: var(--warp-control-text);
+  cursor: pointer;
+  font-family: var(--__sl-font, 'Inter', sans-serif);
+  font-size: var(--sl-text-sm);
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.warp-cookie-banner__btn:hover {
+  border-color: var(--warp-control-border-hover);
+  background: var(--warp-control-bg-hover);
+  color: var(--warp-control-text-hover);
+}
+
+.warp-cookie-banner__btn:focus-visible {
+  outline: 2px solid var(--sl-color-accent-high);
+  outline-offset: 2px;
+}
+
+.warp-cookie-banner__btn--primary {
+  border-color: color-mix(in srgb, var(--sl-color-accent) 55%, var(--warp-control-border));
+  background: color-mix(in srgb, var(--sl-color-accent) 22%, var(--warp-control-bg));
+  color: var(--sl-color-white);
+}
+
+.warp-cookie-banner__btn--primary:hover {
+  border-color: color-mix(in srgb, var(--sl-color-accent) 70%, var(--warp-control-border-hover));
+  background: color-mix(in srgb, var(--sl-color-accent) 32%, var(--warp-control-bg-hover));
+  color: var(--sl-color-white);
+}
+
+@media (max-width: 40rem) {
+  .warp-cookie-banner__inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .warp-cookie-banner__actions {
+    width: 100%;
+  }
+
+  .warp-cookie-banner__btn {
+    flex: 1 1 auto;
+  }
+}

--- a/src/styles/warp-components.css
+++ b/src/styles/warp-components.css
@@ -1608,15 +1608,23 @@ site-search #starlight__search .pagefind-ui__result-nested .pagefind-ui__result-
 
 .warp-cookie-banner {
   position: fixed;
-  inset-inline: 0;
+  /* Full-bleed on mobile; desktop offsets past the left sidebar so the bar
+     never paints over nav (Starlight `--sl-sidebar-width` = 18.75rem). */
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   bottom: 0;
-  z-index: 100;
+  z-index: 40;
   padding: 0.75rem 1rem calc(0.75rem + env(safe-area-inset-bottom, 0px));
   border-top: 1px solid var(--sl-color-hairline-light);
-  background: color-mix(in srgb, var(--sl-color-bg) 92%, transparent);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  box-shadow: 0 -0.5rem 1.5rem rgba(0, 0, 0, 0.18);
+  /* Solid canvas fill — no glass/transparency over page chrome. */
+  background: var(--sl-color-bg);
+  box-shadow: 0 -0.5rem 1.25rem rgba(0, 0, 0, 0.22);
+}
+
+@media (min-width: 50rem) {
+  .warp-cookie-banner {
+    inset-inline-start: var(--sl-sidebar-width, 18.75rem);
+  }
 }
 
 .warp-cookie-banner[hidden] {
@@ -1628,8 +1636,8 @@ site-search #starlight__search .pagefind-ui__result-nested .pagefind-ui__result-
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  max-width: 72rem;
-  margin-inline: auto;
+  width: 100%;
+  max-width: 46rem;
 }
 
 .warp-cookie-banner__copy {


### PR DESCRIPTION
## Summary
Add a bottom cookie consent banner for docs Ask AI analytics, and gate Kapa `userTrackingMode="cookie"` until the visitor accepts.

## Changes

### src/components/CookieConsentBanner.astro
- Fixed bottom consent bar with Accept / Decline
- Persists choice in `localStorage` (`warp_docs_cookie_consent`)
- Dispatches `warp-docs-cookie-consent` so the chat island can react live

### src/components/KapaChatLauncher.tsx
- Defaults Kapa tracking to `none`
- Switches to `cookie` only after consent is `accepted`
- Remounts `KapaProvider` when consent changes

### src/components/FeedbackFooter.astro
- Mounts the banner site-wide on docs content pages

### src/styles/warp-components.css
- Styles the banner with the shared `--warp-control-*` chrome palette
- Solid page background (no glass/transparency)
- On desktop, offsets the bar past the left sidebar (`--sl-sidebar-width`) so it does not overlay nav

## Behavior
- **Accept** → `userTrackingMode="cookie"` (anonymous first-party `kapa_web_id` when the host allows it)
- **Decline** / no choice yet → `userTrackingMode="none"` (Ask AI still works)
- Choice persists across reloads via `localStorage`

## Preview QA notes
- On `*.vercel.app`, `kapa_web_id` often does not stick because the Kapa SDK sets the cookie against the registrable domain from `tldts`, and `vercel.app` is a public suffix. That does not mean Accept failed.
- Trust `localStorage.warp_docs_cookie_consent` plus the wired tracking mode, not `document.cookie`, on preview hosts.
- Real cookie presence should be verified on `docs.warp.dev` after merge.

## Unverified claims
None for UI wiring. Legal sufficiency of this banner for GDPR/CCPA should be confirmed with privacy/legal if needed.

Co-Authored-By: Warp <agent@warp.dev>
