### PR TITLE
docs(factories): full content pass over the launch stack — link fixes and cross-page seams

### DIFF
--- a/src/content/docs/factories/connect-your-factory.mdx
+++ b/src/content/docs/factories/connect-your-factory.mdx
@@ -15,17 +15,17 @@ Pick the sources that match where work starts for your team. You can connect mor
 
 | Source | Best for | Where follow-ups continue |
 | --- | --- | --- |
-| [Slack](./integrations/slack) | Chat and support requests | The Slack thread or DM |
-| [GitHub](./integrations/github) | Issues, pull requests, reviews, and CI | The issue, pull request, or review thread |
-| [Linear](./integrations/linear) | Planned issues | The Linear issue and its agent session |
-| [Jira](./integrations/jira) | Work items assigned to Warp | The Jira agent session |
-| [Factory MCP](./factory-mcp) | Sending work from a local coding agent | The factory work item |
+| [Slack](/factories/integrations/slack/) | Chat and support requests | The Slack thread or DM |
+| [GitHub](/factories/integrations/github/) | Issues, pull requests, reviews, and CI | The issue, pull request, or review thread |
+| [Linear](/factories/integrations/linear/) | Planned issues | The Linear issue and its agent session |
+| [Jira](/factories/integrations/jira/) | Work items assigned to Warp | The Jira agent session |
+| [Factory MCP](/factories/factory-mcp/) | Sending work from a local coding agent | The factory work item |
 | Direct runs and schedules | One-off or recurring work | The factory work item |
 
 ## Connect a source
 
-1. Pick the factory you want to connect. If you don't have one yet, follow the [Warp Factories quickstart](./quickstart).
-2. Connect the source: install the provider integration, set up the [Factory MCP](./factory-mcp), or create a schedule. Each integration guide below walks through authorization; grant only the access the factory needs.
+1. Pick the factory you want to connect. If you don't have one yet, follow the [Warp Factories quickstart](/factories/quickstart/).
+2. Connect the source: install the provider integration, set up the [Factory MCP](/factories/factory-mcp/), or create a schedule. Each integration guide below walks through authorization; grant only the access the factory needs.
 3. Tell the factory how to respond. Provider connections come with default automations that decide which events start work and which agent handles them; review their filters and run settings. Schedules and direct runs skip this step.
 4. Send a test request, such as mentioning the factory in Slack or assigning it an issue, and confirm it picks up the work and replies at the source.
 
@@ -43,28 +43,28 @@ flowchart LR
 
 An event from a connected tool starts the automation whose filters match it, such as a specific repository, channel, or label. Schedules start their automation on a timer, and direct requests go straight to the factory.
 
-Every request then lands with the foreman agent, the factory's orchestrator. The foreman turns the request into a work item, works out which stage the work needs next, and dispatches a specialized agent for each stage: triage to scope the request, spec when the design needs agreement, implementation to write the code, and review to check it. Between stages it relays questions and progress back to the source, and it pauses wherever a decision belongs to a human, such as approving a spec or merging a pull request. See [how Warp Factories work](./how-factories-work) for the full lifecycle.
+Every request then lands with the foreman agent, the factory's orchestrator. The foreman turns the request into a work item, works out which stage the work needs next, and dispatches a specialized agent for each stage: triage to scope the request, spec when the design needs agreement, implementation to write the code, and review to check it. Between stages it relays questions and progress back to the source, and it pauses wherever a decision belongs to a human, such as approving a spec or merging a pull request. See [how Warp Factories work](/factories/how-factories-work/) for the full lifecycle.
 
 ## Review the default automations
 
 When you create a factory through the setup wizard, Warp adds default automations for each tool you connect, so common requests work immediately:
 
-* **GitHub** - Starts work when the factory is mentioned or assigned, and follows up when pull requests close or merge, completing a linked tracker issue when it can. See the [GitHub integration guide](./integrations/github).
-* **Jira** - Starts work when someone assigns or mentions Warp on a work item in one of the Jira projects you selected. See the [Jira integration guide](./integrations/jira).
-* **Slack** - Starts work from mentions and messages, as described in the [Slack integration guide](./integrations/slack).
+* **GitHub** - Starts work when the factory is mentioned or assigned, and follows up when pull requests close or merge, completing a linked tracker issue when it can. See the [GitHub integration guide](/factories/integrations/github/).
+* **Jira** - Starts work when someone assigns or mentions Warp on a work item in one of the Jira projects you selected. See the [Jira integration guide](/factories/integrations/jira/).
+* **Slack** - Starts work from mentions and messages, as described in the [Slack integration guide](/factories/integrations/slack/).
 
 These defaults are starting points. Review each automation's filters, agent, and run settings, and adjust them to match your workflow.
 
 ## Integration guides
 
-* [Slack](./integrations/slack) - Route chat requests, direct messages, and thread follow-ups through a dedicated factory app.
-* [GitHub](./integrations/github) - Route repository events with issue, pull request, review, or CI context.
-* [Linear](./integrations/linear) - Route planned issues through issue activity and agent sessions.
-* [Jira](./integrations/jira) - Route Jira work items assigned to Warp into factory work.
+* [Slack](/factories/integrations/slack/) - Route chat requests, direct messages, and thread follow-ups through a dedicated factory app.
+* [GitHub](/factories/integrations/github/) - Route repository events with issue, pull request, review, or CI context.
+* [Linear](/factories/integrations/linear/) - Route planned issues through issue activity and agent sessions.
+* [Jira](/factories/integrations/jira/) - Route Jira work items assigned to Warp into factory work.
 
 ## Factory MCP
 
-The Factory MCP connects local coding agents and other MCP clients to your factory. Use it to send work to the factory from your terminal, check status, coordinate with the foreman agent, and hand finished work back to the same work item. See the [Factory MCP guide](./factory-mcp).
+The Factory MCP connects local coding agents and other MCP clients to your factory. Use it to send work to the factory from your terminal, check status, coordinate with the foreman agent, and hand finished work back to the same work item. See the [Factory MCP guide](/factories/factory-mcp/).
 
 ## Direct runs and schedules
 
@@ -73,13 +73,13 @@ Not every task starts in an external tool:
 * Start a direct factory run for one-off work: describe the task and the foreman agent takes it from there.
 * Create a scheduled automation for recurring work such as maintenance or reports.
 
-See the [triggers overview](../platform/triggers/) for how schedules and other triggers work across the platform.
+See the [triggers overview](/platform/triggers/) for how schedules and other triggers work across the platform.
 
 ## Good to know
 
 * **Follow-ups continue the same work item** - Replying in the same Slack thread, GitHub issue or pull request, Linear issue, or Jira agent session adds to the existing work item instead of starting a new one. Repeated event deliveries from a provider don't create duplicate work either.
-* **One issue tracker per factory** - A factory can use [Linear](./integrations/linear) or [Jira](./integrations/jira), or no tracker at all, but not both at once. The setup wizard currently offers Linear; to use Jira, connect it after setup or in your [factory definition](./factory-as-code).
+* **One issue tracker per factory** - A factory can use [Linear](/factories/integrations/linear/) or [Jira](/factories/integrations/jira/), or no tracker at all, but not both at once. The setup wizard currently offers Linear; to use Jira, connect it after setup or in your [factory definition](/factories/factory-as-code/).
 * **Filters route work; they don't restrict access** - Automation filters (repository, channel, team, project, label, author, or status) choose which requests start work. To limit what an integration can reach, change what you authorize for that provider instead.
 * **The factory hands off at the pull request** - It pushes branches and opens pull requests with the repository credentials you configure, and waits for a human to review and merge. Branch protection and required reviews apply as usual.
 
-Next, customize which agents receive work and how it's routed with [factory definitions as code](./factory-as-code).
+Next, customize which agents receive work and how it's routed with [factory definitions as code](/factories/factory-as-code/).

--- a/src/content/docs/factories/connect-your-factory.mdx
+++ b/src/content/docs/factories/connect-your-factory.mdx
@@ -26,7 +26,7 @@ Pick the sources that match where work starts for your team. You can connect mor
 
 1. Pick the factory you want to connect. If you don't have one yet, follow the [Warp Factories quickstart](/factories/quickstart/).
 2. Connect the source: install the provider integration, set up the [Factory MCP](/factories/factory-mcp/), or create a schedule. Each integration guide below walks through authorization; grant only the access the factory needs.
-3. Tell the factory how to respond. Provider connections come with default automations that decide which events start work and which agent handles them; review their filters and run settings. Schedules and direct runs skip this step.
+3. Tell the factory how to respond. Provider connections come with default automations that decide which events start work and which agent handles them; review their [filters](/factories/automation-filters/) and run settings. Schedules and direct runs skip this step.
 4. Send a test request, such as mentioning the factory in Slack or assigning it an issue, and confirm it picks up the work and replies at the source.
 
 ## How work reaches your factory
@@ -79,7 +79,7 @@ See the [triggers overview](/platform/triggers/) for how schedules and other tri
 
 * **Follow-ups continue the same work item** - Replying in the same Slack thread, GitHub issue or pull request, Linear issue, or Jira agent session adds to the existing work item instead of starting a new one. Repeated event deliveries from a provider don't create duplicate work either.
 * **One issue tracker per factory** - A factory can use [Linear](/factories/integrations/linear/) or [Jira](/factories/integrations/jira/), or no tracker at all, but not both at once. The setup wizard currently offers Linear; to use Jira, connect it after setup or in your [factory definition](/factories/factory-as-code/).
-* **Filters route work; they don't restrict access** - Automation filters (repository, channel, team, project, label, author, or status) choose which requests start work. To limit what an integration can reach, change what you authorize for that provider instead.
+* **Filters route work; they don't restrict access** - Automation filters (repository, channel, team, project, label, author, or status) choose which requests start work. To limit what an integration can reach, change what you authorize for that provider instead. See [automation filters](/factories/automation-filters/) for the matching rules.
 * **The factory hands off at the pull request** - It pushes branches and opens pull requests with the repository credentials you configure, and waits for a human to review and merge. Branch protection and required reviews apply as usual.
 
 Next, customize which agents receive work and how it's routed with [factory definitions as code](/factories/factory-as-code/).

--- a/src/content/docs/factories/factory-mcp.mdx
+++ b/src/content/docs/factories/factory-mcp.mdx
@@ -10,7 +10,7 @@ topic: factories
 
 Factory MCP is a hosted Model Context Protocol (MCP) server that connects coding agents to your Warp Factories. With it, the agent you already work with, in Warp or in any MCP-capable tool, can send work to a factory, pick up a factory task to continue locally, and hand the finished work back.
 
-The factory keeps a single record of each task throughout. Whether a change happens in the cloud or on your machine, it lands on the same task with the same history and conversation.
+The factory keeps a single record of each task throughout. Whether a change happens in the cloud or on your machine, it lands on the same task with the same history and conversation. A task is the factory's work item: the same unit of work that appears in the control room's [Activity view](/factories/control-room/#track-work-items-on-activity).
 
 ## What you can use it for
 

--- a/src/content/docs/factories/how-factories-work.mdx
+++ b/src/content/docs/factories/how-factories-work.mdx
@@ -16,7 +16,7 @@ A **work item** is one unit of engineering work, such as an issue, support reque
 
 ## The inner loop: intake to handoff
 
-The **foreman** coordinates every work item. It routes work between the specialized agents, passes each one the context it needs, and continues existing agent conversations instead of starting new ones. The specialized agents keep narrow responsibilities, and each of their runs stays distinct in run history. See [factory agents](./factory-agents) for the role definitions.
+The **foreman** coordinates every work item. It routes work between the specialized agents, passes each one the context it needs, and continues existing agent conversations instead of starting new ones. The specialized agents keep narrow responsibilities, and each of their runs stays distinct in run history. See [factory agents](/factories/factory-agents/) for the role definitions.
 
 Not every work item needs every stage. The foreman picks the shortest path that still meets your quality policy. It skips stages when the work is already well defined, starts partway through when enough context exists, and sends work back to an earlier agent when revisions are needed.
 
@@ -40,7 +40,7 @@ flowchart LR
   Handoff --> Complete[Complete]
 ```
 
-* **Intake** - A work item enters from a [connected integration](./connect-your-factory), an automation, a direct run, or the [Factory MCP](./factory-mcp). It keeps its source context as it moves through later stages.
+* **Intake** - A work item enters from a [connected integration](/factories/connect-your-factory/), an automation, a direct run, or the [Factory MCP](/factories/factory-mcp/). It keeps its source context as it moves through later stages.
 * **Triage** - The triage agent researches the request, reproduces it when needed, and defines its scope and complexity. The foreman skips this stage when the request is already well bounded.
 * **Specification** - The specification agent defines product behavior, technical constraints, and validation criteria. The foreman skips this stage for localized changes.
 * **Implementation** - The implementation agent makes the code change on a branch and opens a pull request with test and visual evidence.
@@ -54,7 +54,7 @@ A work item and an agent run track different things. The work item is the single
 
 The work item's **stage** shows progress at a glance. It reflects the most recently active role, so it can move backward during a revision or skip ahead. Run history is the complete execution record.
 
-In the [control room](./control-room), use the **Activity** view to find, filter, and stop work items.
+In the [control room](/factories/control-room/), use the **Activity** view to find, filter, and stop work items.
 
 ## What humans decide
 
@@ -68,10 +68,10 @@ These checkpoints come from the factory's agent instructions and your repository
 
 ## The outer loop: improving the factory
 
-Each completed work item leaves evidence behind, including run and pull request activity, costs, [Scorer](./measure-and-improve) evaluations, and benchmarks. Teams use this evidence to spot repeated failures and compare model or harness configurations.
+Each completed work item leaves evidence behind, including run and pull request activity, costs, [Scorer](/factories/measure-and-improve/) evaluations, and benchmarks. Teams use this evidence to spot repeated failures and compare model or harness configurations.
 
-The factory can also act on that evidence directly. Its [self-improvement](./measure-and-improve#configure-and-review-self-improvement) capability groups the failures Scorers flag and files follow-up runs that propose changes to the application code or the factory's own definition. Nothing is adopted without your review.
+The factory can also act on that evidence directly. Its [self-improvement](/factories/measure-and-improve/#configure-and-review-self-improvement) capability groups the failures Scorers flag and files follow-up runs that propose changes to the application code or the factory's own definition. Nothing is adopted without your review.
 
-Anyone on the team, or an agent, can also propose changes to the factory's instructions, skills, models, environments, or other [definitions](./factory-as-code). Definitions stored in GitHub can go through pull request review and configuration checks before a change reaches the production branch; Warp-managed definitions sync changes directly. Match your review policy to the definition source and the risk of the change.
+Anyone on the team, or an agent, can also propose changes to the factory's instructions, skills, models, environments, or other [definitions](/factories/factory-as-code/). Definitions stored in GitHub can go through pull request review and configuration checks before a change reaches the production branch; Warp-managed definitions sync changes directly. Match your review policy to the definition source and the risk of the change.
 
-Benchmarks organize the evidence; they don't replace your judgment about whether a change is correct. See [measure and improve](./measure-and-improve) for the evaluation workflow, or [build a self-improving agent](/guides/agent-workflows/build-a-self-improving-agent) to apply the same outer-loop pattern to a standalone agent.
+Benchmarks organize the evidence; they don't replace your judgment about whether a change is correct. See [measure and improve](/factories/measure-and-improve/) for the evaluation workflow, or [build a self-improving agent](/guides/agent-workflows/build-a-self-improving-agent/) to apply the same outer-loop pattern to a standalone agent.

--- a/src/content/docs/factories/how-factories-work.mdx
+++ b/src/content/docs/factories/how-factories-work.mdx
@@ -54,7 +54,7 @@ A work item and an agent run track different things. The work item is the single
 
 The work item's **stage** shows progress at a glance. It reflects the most recently active role, so it can move backward during a revision or skip ahead. Run history is the complete execution record.
 
-In the [control room](/factories/control-room/), use the **Activity** view to find, filter, and stop work items.
+In the [control room](/factories/control-room/), use the **Activity** view to find, filter, and stop work items. Activity groups these stages under its own names: Triage, Planning (specification), Building (implementation), and Reviewing.
 
 ## What humans decide
 

--- a/src/content/docs/factories/index.mdx
+++ b/src/content/docs/factories/index.mdx
@@ -30,12 +30,12 @@ Warp Factories is designed for engineering teams with repeatable work that exten
 
 ## What you get with Warp Factories
 
-* **Coordinated specialist agents** - A team of [factory agents](./factory-agents) runs each work item. A coordinating foreman routes it through the triage, spec, implement, and review roles, skipping stages that don't apply. You can add custom agents and automations to handle work the default roles don't cover.
-* **Factory definitions as code** - [Version-controlled definition files](./factory-as-code) describe your repositories, agents, automations, runners, skills, and MCP servers, so factory changes get the same review, history, and rollback as code changes.
-* **Integrations and the Factory MCP** - Work flows in from [Slack](./integrations/slack), [Linear](./integrations/linear), [Jira](./integrations/jira), and [GitHub](./integrations/github), plus direct runs and schedules. The [Factory MCP](./factory-mcp) connects coding agents and other MCP clients.
-* **Model and harness choice** - Each agent role can use a different model and [supported harness](../platform/harnesses), including the Warp Agent, Claude Code, and Codex.
-* **Measurement and self-improvement** - The [control room](./control-room) shows work-item status, runs, automations, costs, and benchmarks. [Scorers](./measure-and-improve) grade completed work, and [Self-improvement](./measure-and-improve#configure-and-review-self-improvement) turns repeated failures into follow-up work the factory proposes for review.
-* **Infrastructure control** - Run on Warp-hosted infrastructure, or self-host execution on an eligible Enterprise plan. Teams can also connect supported inference providers, scope secrets, and (if eligible) store transcripts, artifacts, and run attachments in their own S3 or GCS buckets. See [infrastructure and security](./infrastructure-and-security) for the available controls.
+* **Coordinated specialist agents** - A team of [factory agents](/factories/factory-agents/) runs each work item. A coordinating foreman routes it through the triage, spec, implement, and review roles, skipping stages that don't apply. You can add custom agents and automations to handle work the default roles don't cover.
+* **Factory definitions as code** - [Version-controlled definition files](/factories/factory-as-code/) describe your repositories, agents, automations, runners, skills, and MCP servers, so factory changes get the same review, history, and rollback as code changes.
+* **Integrations and the Factory MCP** - Work flows in from [Slack](/factories/integrations/slack/), [Linear](/factories/integrations/linear/), [Jira](/factories/integrations/jira/), and [GitHub](/factories/integrations/github/), plus direct runs and schedules. The [Factory MCP](/factories/factory-mcp/) connects coding agents and other MCP clients.
+* **Model and harness choice** - Each agent role can use a different model and [supported harness](/platform/harnesses/), including the Warp Agent, Claude Code, and Codex.
+* **Measurement and self-improvement** - The [control room](/factories/control-room/) shows work-item status, runs, automations, costs, and benchmarks. [Scorers](/factories/measure-and-improve/) grade completed work, and [Self-improvement](/factories/measure-and-improve/#configure-and-review-self-improvement) turns repeated failures into follow-up work the factory proposes for review.
+* **Infrastructure control** - Run on Warp-hosted infrastructure, or self-host execution on an eligible Enterprise plan. Teams can also connect supported inference providers, scope secrets, and (if eligible) store transcripts, artifacts, and run attachments in their own S3 or GCS buckets. See [infrastructure and security](/factories/infrastructure-and-security/) for the available controls.
 
 ## How Warp Factories relates to other Warp products
 
@@ -48,7 +48,7 @@ Warp Factories is designed for engineering teams with repeatable work that exten
 
 ## Next steps
 
-* [**Set up a factory**](./quickstart) - Create a factory and send its first work item.
-* [**Understand the execution model**](./how-factories-work) - See how the foreman coordinates stages, runs, and human decisions.
-* [**Meet the factory agents**](./factory-agents) - See what each role does and how to configure its model, harness, and instructions.
-* **Adapt the system** - [Define the factory as code](./factory-as-code) and [connect its work sources](./connect-your-factory).
+* [**Set up a factory**](/factories/quickstart/) - Create a factory and send its first work item.
+* [**Understand the execution model**](/factories/how-factories-work/) - See how the foreman coordinates stages, runs, and human decisions.
+* [**Meet the factory agents**](/factories/factory-agents/) - See what each role does and how to configure its model, harness, and instructions.
+* **Adapt the system** - [Define the factory as code](/factories/factory-as-code/) and [connect its work sources](/factories/connect-your-factory/).

--- a/src/content/docs/factories/integrations/jira.mdx
+++ b/src/content/docs/factories/integrations/jira.mdx
@@ -70,7 +70,7 @@ Filters like `project_keys` decide whether *your* automation starts a run; they 
 
 The agent runs in the cloud and starts with the assignment text and the work item it came from. When the factory declares Jira as an integration, the agent can also read the work item's details, comments, and available workflow transitions.
 
-Jira shows the task's status as it progresses: submitted, working, waiting for input, completed, failed, or canceled. For more than status updates, open the run under the matching automation in your factory: [cloud agent session sharing](/platform/viewing-cloud-agent-runs/) shows the full run, including every command, log, and output, in real time or after the run finishes.
+Jira shows the task's status as it progresses: submitted, working, waiting for input, completed, failed, or cancelled. For more than status updates, open the run under the matching automation in your factory: [cloud agent session sharing](/platform/viewing-cloud-agent-runs/) shows the full run, including every command, log, and output, in real time or after the run finishes.
 
 Replies in the same agent session continue the same run, even after the agent finishes a turn, so you can answer questions or add direction mid-task.
 

--- a/src/content/docs/factories/integrations/linear.mdx
+++ b/src/content/docs/factories/integrations/linear.mdx
@@ -26,7 +26,7 @@ Two parts work together:
 * **A linked Warp account (agent sessions only)** - Anyone who starts a Linear agent session must link their Linear user to their Warp account. If Warp can't identify the session creator, Linear shows an authentication prompt instead of starting work.
 * **Code host access** - Configure repository credentials separately. The factory needs them to change code or create a pull request.
 
-For workspace-level installation, reconnection, and removal steps, see the [Linear integration setup guide](../../platform/integrations/linear).
+For workspace-level installation, reconnection, and removal steps, see the [Linear integration setup guide](/platform/integrations/linear/).
 
 ## Connect Linear during factory setup
 
@@ -50,9 +50,9 @@ Both paths end in the same state: Linear is connected to your factory, and a def
 
 ## Route agent sessions
 
-When someone mentions, assigns, or delegates the Warp app on an issue, Linear starts an agent session. The default automation created when you connected Linear routes new sessions from your selected teams to the factory, so assigning an issue or tagging the factory in a comment is enough to start work. If a session doesn't match any automation, the [Linear integration](../../platform/integrations/linear) handles it with its default behavior.
+When someone mentions, assigns, or delegates the Warp app on an issue, Linear starts an agent session. The default automation created when you connected Linear routes new sessions from your selected teams to the factory, so assigning an issue or tagging the factory in a comment is enough to start work. If a session doesn't match any automation, the [Linear integration](/platform/integrations/linear/) handles it with its default behavior.
 
-Agent sessions don't appear as a trigger in the [automation editor](#configure-linear-triggers). To change how sessions route, for example by creator or keyword, edit the `agent_session_created` event in the factory's [version-controlled definition](../factory-as-code). Replies in an existing session continue that run; they aren't separate triggers.
+Agent sessions don't appear as a trigger in the [automation editor](#configure-linear-triggers). To change how sessions route, for example by creator or keyword, edit the `agent_session_created` event in the factory's [version-controlled definition](/factories/factory-as-code/). Replies in an existing session continue that run; they aren't separate triggers.
 
 ## Configure Linear triggers
 
@@ -103,7 +103,7 @@ The Linear connection doesn't grant repository access or merge permissions. Code
 ## Troubleshooting
 
 * **An agent session shows an authentication prompt** - Complete the prompt to link your Linear user to your Warp account, then retry the request.
-* **Teams or filters don't load** - Reconnect Linear by following the [Linear integration setup guide](../../platform/integrations/linear), then confirm the connection can access the workspace and team you expect.
+* **Teams or filters don't load** - Reconnect Linear by following the [Linear integration setup guide](/platform/integrations/linear/), then confirm the connection can access the workspace and team you expect.
 * **An event doesn't start work** - Confirm the automation is enabled, the event type matches, and every filter matches the issue's current values or the state change.
 * **One action starts multiple runs** - Look for overlapping agent-session and comment triggers, then narrow or remove one.
 * **No pull request appears** - Check the factory's code-host credentials and repository access. Linear authorization alone doesn't allow code changes.

--- a/src/content/docs/factories/quickstart.mdx
+++ b/src/content/docs/factories/quickstart.mdx
@@ -35,7 +35,7 @@ _~5 minutes_
 6. The next screen offers to connect Slack. Click **Next** to skip it for now. See [Connect your factory](/factories/connect-your-factory/) to add integrations later.
 7. Toggle the subagents the foreman can dispatch: **Triage**, **Spec**, **Code**, and **Review**. Keep **Code** on so this quickstart's work item can end in a pull request.
 
-   See [Factory agents](/factories/factory-agents/) for what each role does.
+   See [Factory agents](/factories/factory-agents/) for what each role does. The wizard's **Code** toggle corresponds to the Implement role on that page.
 
 8. Skip the issue tracker screen the same way as Slack: click **Next**. Warp creates the factory.
 

--- a/src/content/docs/platform/agents.mdx
+++ b/src/content/docs/platform/agents.mdx
@@ -66,9 +66,9 @@ When a team is over its plan limit (for example, after downgrading), the extra a
 
 Cloud agents — and individual runs — can also be granted specific capabilities:
 
-* [**Skills as agents**](/platform/skills-as-agents/) - Attach a skill directly to a cloud agent identity, or pass one at run time, so the agent starts from a reusable, version-controlled prompt instead of an ad hoc one.
+* [**Skills as agents**](/platform/skills-as-agents/) - Attach a skill directly to a cloud agent, or pass one at run time, so the agent starts from a reusable, version-controlled prompt instead of an ad hoc one.
 * [**MCP servers**](/platform/mcp/) - Connect a run to external tools and services (GitHub, dbt, Sentry, or a custom internal service) via Model Context Protocol.
-* [**Secrets**](/platform/secrets/) - Store and inject credentials into cloud agent runs without exposing secret values, scoped to a team, a person, or a specific cloud agent identity.
+* [**Secrets**](/platform/secrets/) - Store and inject credentials into cloud agent runs without exposing secret values, scoped to a team, a person, or a specific cloud agent.
 
 ## Related pages
 


### PR DESCRIPTION
## Summary

Full editorial pass over the combined Factories launch content on `hyc/factory-launch` (#508) — the first single-context read of all 16 pages (~14,900 words) after the stack landed as ~20 independent PRs. Two commits: one mechanical link sweep, one set of cross-page seam fixes.

## What was validated (all clean)

- `npm run build` — passes, no content errors
- Internal links — 3,634 checked, 0 broken
- External links — 1,522 checked, 0 broken
- `style_lint --changed` — factories pages have zero violations beyond glossary-candidate advisories
- Frontmatter descriptions — all 16 pages present, 84–145 chars, no filler openers
- Anchor targets used across pages (`#configure-and-review-self-improvement`, `#track-work-items-on-activity`, `#setup`, `#connecting-your-jira-account-to-warp`, etc.) — all resolve
- Sidebar wiring — all 16 pages present, no orphans; `/platform/software-factory/` redirect exists in `vercel.json`
- No bare "Oz" references anywhere in `factories/`

## Fixes in this PR

**Commit 1 — broken-at-runtime links.** #550 converted factory pages to root-absolute links, but #516 (overview, how-factories-work), #520 (connect-your-factory), and #527 (Linear) landed after the sweep with `./` and `../` links. Those resolve against the page's trailing-slash URL (`./x` → `/factories/<page>/x`) and 404 in production while passing the file-based CI checker. Converted ~40 links across 4 pages to the root-absolute trailing-slash convention.

**Commit 2 — seams from combining disparate branches:**
- **Role-name mismatch**: the quickstart's setup-wizard toggles say **Code**, while `factory-agents` calls the same role **Implement**, with no bridge between them. Added a mapping sentence to the quickstart.
- **Stage-name mismatch**: `how-factories-work` describes stages as Triage/Specification/Implementation/Review, but the Activity view groups them as Triage/Planning/Building/Reviewing. Added the mapping where the page hands readers to Activity.
- **Vocabulary bridge**: `factory-mcp` says "task" ~50 times without ever connecting it to "work item", the term every other page uses. Added a one-line definition tying tasks to the Activity view.
- **Missing cross-link**: `automation-filters` (#551) consolidated filter semantics from seven pages, but `connect-your-factory` — the intake hub — never linked to it because #520 merged first. Linked it from the connect steps and the Good-to-know filters bullet.
- **Spelling drift**: Jira page used "canceled" where every other page uses "cancelled".
- **Terminology**: two "cloud agent identity" usages in `platform/agents.mdx` → "cloud agent" per the glossary.

## Deferred to outstanding branches

- **#519 / #526** — `factory-as-code.mdx` and `integrations/github.mdx` are placeholder stubs; untouched here.
- **#549 (GitLab)** — `automation-filters.mdx` has an inline TODO to link the GitLab table row once the page exists; the sidebar also needs the GitLab entry.
- **#540 (infra editorial pass)** — no mechanical issues found on `infrastructure-and-security.mdx`; left its prose alone since #540 rewrites it.
- **#556 (sidebar naming)** — noted for that pass: page title "The Factory control room" vs sidebar "Control room"; `how-factories-work` frontmatter label ("How Factories work") differs from the `sidebar.ts` override ("How Warp Factories work").

## Observations for DRIs (not changed — need a product-truth check)

- `control-room` says a scorer "classifies completed **runs**"; `measure-and-improve` consistently says "completed **conversations**" (and capitalizes **Scorer**, where control-room lowercases it). Worth aligning once someone confirms which object the judge actually evaluates.
- Slack page says the App Home groups tasks under "**Completed**"; control-room/how-factories-work use "**Complete**" for the terminal stage. If the Slack surface really differs, fine — otherwise align.
- `factory-mcp` hardcodes `https://app.warp.dev/api/v1/mcp/factory` while the factory web app var points at `platform.warp.dev` — assumed intentional (API host vs web app), flagging for confirmation.

Overall: content quality across the section is high — zero broken links, complete frontmatter, consistent callout/style usage. The fixes here are the integration seams you'd expect from parallel authorship, nothing structural.

<!-- warp:pr-description-artifacts start -->
_Plans_:
- _[Holistic content audit of #508 (Factories launch docs)](https://staging.warp.dev/drive/notebook/JmLDixldrQbRHEomvp8ZCD)_
<!-- warp:pr-description-artifacts end -->
