### PR TITLE
docs(factories): fix the quickstart's factory-creation entry point

### DIFF
--- a/src/content/docs/factories/quickstart.mdx
+++ b/src/content/docs/factories/quickstart.mdx
@@ -20,10 +20,12 @@ A factory is a team of cloud agents — a foreman you talk to, plus the subagent
 _~5 minutes_
 
 1. Go to the {VARS.FACTORY_WEB_APP} at <a href={VARS.FACTORY_WEB_APP_URL}>platform.warp.dev</a> and sign in.
-2. In the sidebar, next to **Factories**, click **+** to start the setup wizard.
+2. On the welcome screen, click **Let's get started** to open the setup wizard.
+
+   If your team already has a factory, you land in the app instead of the welcome screen. In the sidebar, click **+** next to **Factories** to open the same wizard.
 
    :::note
-   **No team yet?** If the team that owns the factory has no plan or credits, the wizard will ask you to select one. A factory needs credits to run its agents.
+   **No team or credits yet?** Warp asks you to join or create a team and choose a plan before the welcome screen. A factory needs credits to run its agents.
    :::
 
 3. Click **I want to use repos from GitHub** and complete the GitHub authorization.
@@ -31,7 +33,7 @@ _~5 minutes_
 
    Warp provisions a default [environment](/platform/environments/) for the selected repos.
 
-5. Enter a **Factory name**, e.g., `Payments services`. Warp derives a matching **Factory alias**, the handle teammates use to @-mention the factory from connected tools like Slack and Linear. Keep it short and recognizable.
+5. Enter a **Factory name**, e.g., `Payments services`. Warp derives a matching **Foreman name**, the handle teammates use to @-mention the factory's foreman from connected tools like Slack and Linear. Keep it short and recognizable.
 6. The next screen offers to connect Slack. Click **Next** to skip it for now. See [Connect your factory](/factories/connect-your-factory/) to add integrations later.
 7. Toggle the subagents the foreman can dispatch: **Triage**, **Spec**, **Code**, and **Review**. Keep **Code** on so this quickstart's work item can end in a pull request.
 


### PR DESCRIPTION
## Summary

Follow-up to a review question on #526: the GitHub integration page says `click **+** next to **Factories**`, and Rachael asked whether the quickstart's wording (`click **New factory**`) was the correct one instead.

I verified both against `warp-server/client/packages/factory`.

## What the codebase says

**The `+` is correct. There is no "New factory" button anywhere in the Factory web app.**

`AppSidebar.tsx` renders a `Plus` icon `Link` with `aria-label="Create factory"` next to the **Factories** section header, pointing at `CREATE_FACTORY_FIRST_STEP_PATH` (`/create/codeforge-setup`). This is covered by `navigation.test.tsx` ("shows the Create factory link in the sidebar") and `mount.test.tsx`. Grepping the whole package for "New factory" returns nothing.

So #526 needs no change on that point, and the quickstart on `hyc/factory-launch` already says `+` too. The discrepancy Rachael saw was against a stale draft.

## What is actually wrong (fixed here)

Verifying the `+` surfaced two real problems in `factories/quickstart.mdx`:

**1. The `+` is unreachable for the quickstart's own audience.**

`FactoryOnboardingGate` redirects any user whose team has no factory to `/onboarding`, and `OnboardingPage` renders the `Welcome` screen with a **Let's get started** button (`Welcome.tsx`). A first-time reader never sees the app shell, so they never see the sidebar `+`. The `+` only applies once the team already has a factory. The step now leads with the welcome screen and keeps the sidebar `+` as the secondary path.

The note is also corrected: team and plan are prerequisite steps that run *before* the welcome screen (`firstUnmetPrerequisite` in `Onboarding/index.tsx`), not something "the wizard will ask" mid-flow.

**2. "Factory alias" is a stale UI label.**

warp-server `9e3649c4` ("factory: reword stale 'alias' copy to 'Foreman name'") renamed the field. `IdentitySetupStep.tsx` now renders `label="Foreman name"` with the hint "This is the name you will use to @-mention your factory foreman in other integrated platforms." Updated the quickstart to match.

`alias` remains correct as the YAML field name in `factory-as-code.mdx`, so that page is unchanged.

## Also verified as still accurate (no change needed)

`I want to use repos from GitHub` (`CodeforgeSetupStep.tsx`), `Select your repos` / `Add repos` (`types.ts`), the **Triage** / **Spec** / **Code** / **Review** toggles and the Code → `IMPLEMENT` mapping (`AgentsStep.tsx`), and `Factory running!` / `Go to dashboard` (`Summary.tsx`).

## Validation

- `npm run build` passes (only the pre-existing `/404` route-priority warning)
- `style_lint.py --changed` reports no new issues for `factories/quickstart.mdx`

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->

Co-Authored-By: Warp <agent@warp.dev>
