### PR TITLE
docs(factories): alignment pass — Foreman name bridge, dashboard naming, and guide cross-references

### DIFF
--- a/src/content/docs/factories/control-room.mdx
+++ b/src/content/docs/factories/control-room.mdx
@@ -82,7 +82,7 @@ A Scorer is an LLM judge that classifies completed runs against a rubric you def
 
 ## Change factory settings
 
-**Settings** holds the configuration the factory owns: the factory's name and connected repos, whether pull requests are authored by the agent or the run creator (the definition's [`credentialStrategy`](/factories/factory-as-code/#credentialstrategy)), the **Analysis model** [Self-improvement](/factories/measure-and-improve/#configure-and-review-self-improvement) uses to analyze failed runs, runners, the integrations accessible to this factory, and deletion. Deleting a factory cannot be undone.
+**Settings** holds the configuration the factory owns: the factory's identity (its name, avatar, and [**Foreman name**](/factories/factory-as-code/#alias), the @-mention handle), the connected repos, whether pull requests are authored by the agent or the run creator (the definition's [`credentialStrategy`](/factories/factory-as-code/#credentialstrategy)), the **Analysis model** [Self-improvement](/factories/measure-and-improve/#configure-and-review-self-improvement) uses to analyze failed runs, runners, the integrations accessible to this factory, and deletion. Deleting a factory cannot be undone.
 
 For a file-managed factory, `runners/*.yaml` in the repository is the source of truth. Anything managed in an external repository is read-only in Settings.
 

--- a/src/content/docs/factories/factory-as-code.mdx
+++ b/src/content/docs/factories/factory-as-code.mdx
@@ -78,7 +78,7 @@ Optional. What the factory is for.
 
 ### `alias`
 
-Optional. The handle used to @-mention the factory on connected platforms like Slack and Linear. Up to 60 characters: letters, numbers, spaces, `.`, `_`, and `-`. Must be unique across your workspace (compared case-insensitively).
+Optional. The handle used to @-mention the factory's foreman on connected platforms like Slack and Linear; the control room labels this field **Foreman name**. Up to 60 characters: letters, numbers, spaces, `.`, `_`, and `-`. Must be unique across your workspace (compared case-insensitively).
 
 ### `credentialStrategy`
 

--- a/src/content/docs/guides/agent-workflows/build-a-self-improving-agent.mdx
+++ b/src/content/docs/guides/agent-workflows/build-a-self-improving-agent.mdx
@@ -120,7 +120,7 @@ Over time, the companion skill accumulates a clear description of how your team 
 
 ## Next steps
 
-* [Warp Factories overview](/factories/) — How the outer improvement loop fits into the full factory model.
+* [Self-improvement in Warp Factories](/factories/measure-and-improve/#configure-and-review-self-improvement) — The managed version of this outer loop, run inside a factory.
 * [Set up your software factory](/guides/agent-workflows/set-up-a-software-factory) — The inner loop the outer loop improves.
 * [Run a software factory in the cloud](/guides/agent-workflows/run-a-software-factory-in-the-cloud) — Move the loop to the {VARS.WARP_AUTOMATION_PLATFORM} for team-wide visibility.
 * [Scheduled agents](/platform/triggers/scheduled-agents) — Full reference for running cloud agents on a cadence.

--- a/src/content/docs/guides/agent-workflows/build-a-triage-agent.mdx
+++ b/src/content/docs/guides/agent-workflows/build-a-triage-agent.mdx
@@ -121,7 +121,7 @@ Add repo-specific context without forking the core skill by creating a `triage-i
 
 ## Next steps
 
-* [Warp Factories overview](/factories/) — How the triage agent fits into the full development loop.
+* [Warp Factories overview](/factories/) — The managed product where a triage role like this scopes every incoming work item.
 * [Write product and tech specs with agents](/guides/agent-workflows/write-product-and-tech-specs-with-agents) — Add the spec role once your backlog is well-triaged.
 * [Build a self-improving agent](/guides/agent-workflows/build-a-self-improving-agent) — Automate skill improvement based on your corrections.
 * [GitHub Actions integration](/platform/integrations/github-actions) — Full documentation for `warpdotdev/oz-agent-action`.

--- a/src/content/docs/guides/agent-workflows/run-a-software-factory-in-the-cloud.mdx
+++ b/src/content/docs/guides/agent-workflows/run-a-software-factory-in-the-cloud.mdx
@@ -13,7 +13,7 @@ tags:
 ---
 import { VARS } from '@data/vars';
 
-The GitHub Actions approach in [Set up your software factory](/guides/agent-workflows/set-up-a-software-factory) gets the four-agent loop working. This guide covers the {VARS.WARP_AUTOMATION_PLATFORM}-native production setup for teams running the factory at scale: cloud environments, secrets and permissions, triggers, and observability.
+The GitHub Actions approach in [Set up your software factory](/guides/agent-workflows/set-up-a-software-factory) gets the four-agent loop working. This guide covers the {VARS.WARP_AUTOMATION_PLATFORM}-native production setup for teams running the factory at scale: cloud environments, secrets and permissions, triggers, and observability. To run the same loop as a managed product instead, see [Warp Factories](/factories/).
 
 ## Prerequisites
 
@@ -71,7 +71,7 @@ With GitHub Actions, your factory already has event-based triggers. The {VARS.WA
 
 ## 4. Monitor factory runs
 
-Every cloud agent run in your factory appears in the Factory dashboard with:
+Every cloud agent run in your factory appears in the {VARS.DASHBOARD} with:
 
 * A session transcript showing every action the agent took
 * Artifacts: PRs, branches, plans, and reports the agent produced
@@ -96,7 +96,7 @@ See [Multi-agent orchestration](/platform/orchestration) for fan-out, sharding, 
 
 ## Next steps
 
-* [Warp Factories overview](/factories/) — The conceptual overview of the full loop.
+* [Warp Factories overview](/factories/) — The managed product that runs this same loop end to end.
 * [Build a self-improving agent](/guides/agent-workflows/build-a-self-improving-agent) — Add the outer improvement loop on a schedule.
 * [Environments](/platform/environments) — Full reference for cloud agent environments.
 * [Deployment patterns](/platform/deployment-patterns) — Choose the right architecture for your team.

--- a/src/content/docs/guides/agent-workflows/set-up-a-software-factory.mdx
+++ b/src/content/docs/guides/agent-workflows/set-up-a-software-factory.mdx
@@ -11,7 +11,7 @@ tags:
 ---
 import { VARS } from '@data/vars';
 
-This guide adds the implementation and reviewer agents to the [triage](/guides/agent-workflows/build-a-triage-agent) and [spec](/guides/agent-workflows/write-product-and-tech-specs-with-agents) agents you set up previously, then connects all four into a software factory using GitHub labels as the state machine. Issues flow automatically from triage to a reviewable pull request.
+This guide adds the implementation and reviewer agents to the [triage](/guides/agent-workflows/build-a-triage-agent) and [spec](/guides/agent-workflows/write-product-and-tech-specs-with-agents) agents you set up previously, then connects all four into a software factory using GitHub labels as the state machine. Issues flow automatically from triage to a reviewable pull request. To run this same loop as a managed product instead of wiring it yourself, see [Warp Factories](/factories/).
 
 ## Prerequisites
 
@@ -162,7 +162,7 @@ The reviewer agent surfaces issues and inconsistencies; the human makes the fina
 
 ## Next steps
 
-* [Warp Factories overview](/factories/) — The conceptual overview of the full loop.
+* [Warp Factories overview](/factories/) — The managed product that runs this same intake-to-review loop, without the workflow wiring.
 * [Run a software factory in the cloud](/guides/agent-workflows/run-a-software-factory-in-the-cloud) — Move the loop into a managed {VARS.WARP_AUTOMATION_PLATFORM} deployment.
 * [Build a self-improving agent](/guides/agent-workflows/build-a-self-improving-agent) — Add the outer improvement loop.
 * [Review AI-generated code](/guides/agent-workflows/how-to-review-ai-generated-code) — The human review workflow for agent-generated PRs.

--- a/src/content/docs/guides/agent-workflows/write-product-and-tech-specs-with-agents.mdx
+++ b/src/content/docs/guides/agent-workflows/write-product-and-tech-specs-with-agents.mdx
@@ -72,7 +72,7 @@ A tech spec defines how the feature will be implemented, including architecture 
 
 ## Next steps
 
-* [Warp Factories overview](/factories/) — How specs fit into the full development loop.
+* [Warp Factories overview](/factories/) — The managed product where a spec stage gates implementation the same way.
 * [Set up your software factory](/guides/agent-workflows/set-up-a-software-factory) — Connect the spec role to implementation and review.
 * [`warpdotdev/common-skills`](https://github.com/warpdotdev/common-skills) — The full set of shared skills including `write-product-spec`, `write-tech-spec`, and `validate-changes-match-specs`.
 * [Planning](/agents/capabilities/planning) — Warp's built-in planning feature for smaller tasks.


### PR DESCRIPTION
## Summary

Follow-up alignment pass over the launch stack (#508), as requested after #558 merged: a cross-check that pages agree with each other, with the product, and with the pages they reference — including the ~10 pages *outside* `factories/` that link into the section, which no previous pass had covered. 7 files, +10/−10.

## Verified against the product (no doc change needed)

- **`alias` constraints are correct.** `factory-as-code`'s "60 characters; letters, numbers, spaces, `.`, `_`, `-`; unique case-insensitively" matches the server's shared `factoryalias.Normalize` contract exactly (`logic/factoryalias`), which both the API and the file parser use.
- **"Complete" vs "Completed" is real, not drift.** Activity's terminal stage is labeled `Complete` (`FactoryActivity/stages.ts`) while the Slack Home tab uses `Completed` (`slack/slack_app_home.go`). Each page matches its own surface, so both stand.
- **All 16 pages are wired in the sidebar** (`src/sidebar.ts`), the `/platform/software-factory/` redirect is in place, and every one of the 11 external links into `/factories/` resolves.

## Aligned

- **`alias` ↔ Foreman name bridge.** #559 renamed the wizard label to **Foreman name**, but the `alias` reference in `factory-as-code` never mentioned it. The key's description now names the control-room label and says it @-mentions the *foreman*, matching the UI copy. `control-room`'s Settings section now names the identity fields and links **Foreman name** back to the `alias` reference.
- **Wrong dashboard in the DIY guide.** `run-a-software-factory-in-the-cloud` said DIY-loop runs appear in "the Factory dashboard" — those runs land in the cloud agent dashboard, not the Factories product's control room. Now uses `{VARS.DASHBOARD}`.
- **Guides framed the product page as their concept doc.** All five DIY-factory guides described `/factories/` as "the conceptual overview of the full loop" (or "how X fits into the loop"). A reader lands on a managed product, not concepts for their GitHub Actions wiring. Next-step descriptions now say what the destination is, `build-a-self-improving-agent` deep-links the [Self-improvement section](/factories/measure-and-improve/#configure-and-review-self-improvement) it parallels (completing the two-way link — `how-factories-work` already points back), and the two factory-assembly guides' intros now offer Warp Factories as the managed alternative up front.

## Validation

- `npm run build` — passes
- Link checker — 3,664 internal / 1,522 external, 0 broken
- `style_lint` — no new findings on touched files (only pre-existing glossary-candidate advisories)

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
