### PR TITLE
docs(factories): apply GitHub page review follow-ups from #526

### DIFF
--- a/src/content/docs/factories/integrations/github.mdx
+++ b/src/content/docs/factories/integrations/github.mdx
@@ -72,7 +72,7 @@ Use filters to route work precisely. For example, send failed runs of a specific
 
 ## Mention the factory
 
-A factory doesn't get its own GitHub handle. Every factory listens through the same Warp agent account, **@oz-agent**, and the factory's `factory:<alias>` label decides which factory a mention reaches:
+A factory doesn't get its own GitHub handle. Every factory listens through the same Warp agent account, **@oz-agent**, and the factory's `factory:<alias>` label decides which factory a mention reaches, where `<alias>` is the factory's [**Foreman name**](/factories/factory-as-code/#alias):
 
 1. Apply the factory's `factory:<alias>` label to the issue or pull request. Warp creates the label in each connected repository.
 2. Assign **@oz-agent** to the issue or pull request, or mention **@oz-agent** in the body or in any new comment.

--- a/src/content/docs/factories/integrations/github.mdx
+++ b/src/content/docs/factories/integrations/github.mdx
@@ -20,13 +20,20 @@ When you connect a factory to GitHub, repository activity starts work in your fa
 
 1. In the {VARS.FACTORY_WEB_APP} at <a href={VARS.FACTORY_WEB_APP_URL}>platform.warp.dev</a>, click **+** next to **Factories** to open the setup wizard, then choose **I want to use repos from GitHub** under **Connect your code host**.
 2. Under **Select your repos**, choose the repositories to provide code and context for the factory.
-3. In the factory's [control room](/factories/control-room/), click **Automations**. Create an automation or edit a default one, choose the receiving agent, and add any **Additional instructions**.
-4. Under **Triggers**, click **Add trigger**.
-5. Choose **GitHub**, then choose an event.
-6. Select a repository, then use **More filters** to narrow which activity matches.
-7. Click **Save**. To confirm the automation works, trigger a matching event in GitHub, such as opening a test issue, and check that a work item starts in the control room.
 
-Managed GitHub factories start with two editable default automations. The first handles agent mentions and assignments (see [Mention the factory](#mention-the-factory)). The second runs when a pull request closes or merges: on a merge it finds the work items linked from the pull request and moves each one to its tracker's completed state, and on a close without a merge it does nothing.
+That's all the setup GitHub needs. Managed GitHub factories are created with two editable default automations, so the factory responds to GitHub activity without you configuring anything else. The first handles agent mentions and assignments (see [Mention the factory](#mention-the-factory)). The second runs when a pull request closes or merges: on a merge it finds the work items linked from the pull request and moves each one to its tracker's completed state, and on a close without a merge it does nothing.
+
+To confirm the connection works, mention the factory on a test issue and check that a work item starts in the factory's [control room](/factories/control-room/).
+
+## Add a custom automation
+
+The defaults cover mentions, assignments, and pull request completion. To start work from any other GitHub activity, such as a failed CI run or a review request, add your own automation:
+
+1. In the factory's [control room](/factories/control-room/), click **Automations**. Create an automation or edit a default one, choose the receiving agent, and add any **Additional instructions**.
+2. Under **Triggers**, click **Add trigger**.
+3. Choose **GitHub**, then choose an event.
+4. Select a repository, then use **More filters** to narrow which activity matches.
+5. Click **Save**. To confirm the automation works, trigger a matching event in GitHub, such as opening a test issue, and check that a work item starts in the control room.
 
 ## Supported triggers
 
@@ -72,10 +79,10 @@ Use filters to route work precisely. For example, send failed runs of a specific
 
 ## Mention the factory
 
-A factory doesn't get its own GitHub handle. Every factory listens through the same Warp agent account, **@oz-agent**, and the factory's `factory:<alias>` label decides which factory a mention reaches, where `<alias>` is the factory's [**Foreman name**](/factories/factory-as-code/#alias):
+A factory doesn't get its own GitHub handle. Every factory listens through the same Warp agent account, **@warp-factory**, and the factory's `factory:<alias>` label decides which factory a mention reaches, where `<alias>` is the factory's [**Foreman name**](/factories/factory-as-code/#alias):
 
 1. Apply the factory's `factory:<alias>` label to the issue or pull request. Warp creates the label in each connected repository.
-2. Assign **@oz-agent** to the issue or pull request, or mention **@oz-agent** in the body or in any new comment.
+2. Assign **@warp-factory** to the issue or pull request, or mention **@warp-factory** in the body or in any new comment.
 
 The default mentions-and-assignments automation starts a work item in the matching factory, and the factory replies in the same thread. The label is what routes the request. A mention without the factory's label doesn't match the default automation.
 


### PR DESCRIPTION
Follow-ups to the GitHub integration page that couldn't land in #526, which merged first.

## 1. Maggie's review on #526

Both comments arrived after #526 merged, so they're applied here.

**[The handle should be `@warp-factory`](https://github.com/warpdotdev/docs/pull/526#discussion_r3800266350).** Changed in both spots. This matches warp-server's `factoryGitHubHandleDefault`, where `FactoryGitHubHandle()` is documented as "permanently distinct from `GitHubAgentHandle()`: callers pick whichever applies, never fall back between them", and `githubSeedAutomations` materializes it into the seeded mention and assignment filters.

⚠️ **Sequencing.** [warp-server#15306](https://github.com/warpdotdev/warp-server/pull/15306) carries that rename and is **still an open draft with merge conflicts**, gated behind a `factory_github_handle` flag. Until it lands, this page names a handle that won't answer in production. That's fine while #508 is unmerged and the factories docs aren't public, but **#15306 needs to land before #508 reaches `main`**. Worth someone owning that ordering.

**[Default automations are populated on factory creation](https://github.com/warpdotdev/docs/pull/526#discussion_r3800266493), so steps 3–7 weren't required.** Correct, and the old shape actively misled: a seven-step procedure where five steps build an automation by hand implied the factory sits idle until you configure a trigger, when it's already listening. Connecting is now the two steps it actually takes, followed by what the defaults do and how to verify. The custom-automation walkthrough moved to its own **Add a custom automation** section, which is Maggie's suggested alternative and keeps it available for the cases the defaults don't cover — a failed CI run, a review request.

## 2. The original Foreman name bridge

#560's alignment pass linked the control room's **Foreman name** field to the definition's `alias` key on `control-room.mdx` and `quickstart.mdx`, but skipped this page because it was still unmerged in #526. The page used `factory:<alias>` three times without saying where `<alias>` comes from, so a reader who only knows the control room label had nothing connecting the two. Bridged on first use, matching the sibling pages' link convention.

## Verification

- `npm run build` exits 0, with only the pre-existing `/404` route-priority warning
- Confirmed in the built HTML that `connect-github-to-a-factory`, `add-a-custom-automation`, and `mention-the-factory` all emit anchor IDs, and that `factory-as-code/index.html` emits `id="alias"` so the bridge link resolves
- 6 `@warp-factory` occurrences render, 0 `oz-agent` remain on the page
- `style_lint --changed` reports 0 errors; remaining warnings are bolded UI labels, which the style guide requires
- No inbound links target the old section anchors, so the split breaks nothing

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
