### PR TITLE
docs(factories): document that factories and the Oz web app coexist

### DIFF
--- a/src/content/docs/factories/index.mdx
+++ b/src/content/docs/factories/index.mdx
@@ -46,6 +46,8 @@ Warp Factories is designed for engineering teams with repeatable work that exten
 | **{VARS.WARP_CLI}** | Runs the Warp Agent in any terminal and exchanges work with a factory through the Factory MCP. |
 | **{VARS.WARP_AUTOMATION_PLATFORM}** | Provides the cloud runs, environments, runners, integrations, secrets, orchestration, and APIs that a factory assembles into one workflow. |
 
+Warp Factories runs alongside the {VARS.WEB_APP} rather than replacing it. Each has its own home: the <a href={VARS.FACTORY_WEB_APP_URL}>{VARS.FACTORY_WEB_APP}</a> for factories, and the <a href={VARS.WEB_APP_URL}>{VARS.WEB_APP}</a> for everything you run there today. Creating a factory changes nothing about your existing environments, schedules, and Slack and Linear integrations, which keep working.
+
 ## Next steps
 
 * [**Set up a factory**](/factories/quickstart/) - Create a factory and send its first work item.

--- a/src/content/docs/factories/integrations/linear.mdx
+++ b/src/content/docs/factories/integrations/linear.mdx
@@ -50,7 +50,7 @@ Both paths end in the same state: Linear is connected to your factory, and a def
 
 ## Route agent sessions
 
-When someone mentions, assigns, or delegates the Warp app on an issue, Linear starts an agent session. The default automation created when you connected Linear routes new sessions from your selected teams to the factory, so assigning an issue or tagging the factory in a comment is enough to start work. If a session doesn't match any automation, the [Linear integration](/platform/integrations/linear/) handles it with its default behavior.
+When someone mentions, assigns, or delegates the Warp app on an issue, Linear starts an agent session. The default automation created when you connected Linear routes new sessions from your selected teams to the factory, so assigning an issue or tagging the factory in a comment is enough to start work. The factory takes precedence for the teams its automations cover: a matching session routes to the factory rather than to the [Linear integration](/platform/integrations/linear/), which still handles any session that matches no automation.
 
 Agent sessions don't appear as a trigger in the [automation editor](#configure-linear-triggers). To change how sessions route, for example by creator or keyword, edit the `agent_session_created` event in the factory's [version-controlled definition](/factories/factory-as-code/). Replies in an existing session continue that run; they aren't separate triggers.
 

--- a/src/content/docs/platform/integrations/linear.mdx
+++ b/src/content/docs/platform/integrations/linear.mdx
@@ -66,6 +66,14 @@ Because PRs are created as _you_, this makes code review, auditing, and team col
 
 ---
 
+### Factories and this integration
+
+If your team also runs a [software factory](/factories/), both keep working. This integration continues to handle the Linear teams that no factory covers, so an existing setup needs no changes.
+
+Where the two overlap, the factory takes precedence: when a factory automation matches an agent session, that session routes to the factory instead of starting a run here. A session that matches no factory automation falls back to the behavior described above. For how that routing is configured, see [Connect Linear to your factory](/factories/integrations/linear/).
+
+---
+
 ### Requirements
 
 * **Team membership** - The Linear integration requires you to be part of a [Warp team](/knowledge-and-collaboration/teams/). Teams can be created on any plan, including Free.

--- a/src/content/docs/platform/integrations/slack.mdx
+++ b/src/content/docs/platform/integrations/slack.mdx
@@ -96,6 +96,12 @@ Because PRs are created as you, the workflow slots seamlessly into your team’s
 
 ---
 
+### Factories and this integration
+
+If your team also runs a [software factory](/factories/), both keep working. A factory connected to Slack installs its own app carrying that factory's name, so the two never compete for the same mention: **@Warp** starts a cloud agent run through this integration, and mentioning a factory's app sends the request to that factory. See [Connect Slack to your factory](/factories/integrations/slack/).
+
+---
+
 ### Configuration
 
 #### 1. Create an environment


### PR DESCRIPTION
Closes the gap between what Aloke told sales the soft launch would look like and what the docs actually say.

His note spells out three customer-visible facts. The docs covered one of them.

## What was missing

The launch stack documents factories as though Oz v1 doesn't exist. `git grep` across all of `src/content/docs/factories/` for `oz.warp.dev`, "Oz v1", or "legacy" returned nothing, and neither `platform/integrations/slack.mdx` nor `platform/integrations/linear.mdx` mentioned factories at all. The customer Aloke is preparing sales for — one who has both — had no page written for them.

Only the `oz` → `warp` handle rename was already handled, by #542.

## Changes

- **`platform/integrations/linear.mdx`** and **`platform/integrations/slack.mdx`** — new "Factories and this integration" section on each. The two cases differ, so the copy does too: Slack has no conflict because each factory installs its own app carrying the factory's name, while Linear genuinely overlaps, so that page states the precedence rule.
- **`factories/integrations/linear.mdx`** — the precedence sentence led with the fallback ("if a session doesn't match any automation, the Linear integration handles it with its default behavior"), which reads as though the legacy integration were primary. Now leads with precedence and keeps the fallback as the tail.
- **`factories/index.mdx`** — places the two web apps side by side and says plainly that creating a factory changes nothing you already run.

## On accuracy

The precedence claim is grounded in code rather than in the Slack message. `replaysBuiltInWhenUnclaimed` in `logic/ai/ambient_agents/webhook/workflow.go` documents an unclaimed delivery as one with "zero matched Factory actions", which then falls back to the provider's built-in behavior — so a *matched* delivery does not. That's the same rule from the other direction.

The Slack wording deliberately avoids claiming precedence, because per `factories/integrations/slack.mdx` each factory gets its own dedicated app, so nothing competes for a single mention.

**No migration or consolidation timeline appears anywhere in this PR**, per Aloke's note not to communicate that yet.

## Verification

- `npm run build` exits 0, with only the pre-existing `/404` route-priority warning
- `style_lint --changed` reports **0 errors** across the four files; remaining warnings are pre-existing (`screenshot-width`, bolded UI labels, one Title Case header)
- Confirmed in the built HTML that the `VARS` expressions resolve to real text and URLs rather than literal tokens, and that `/factories/` exists as a link target

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
