### PR TITLE
docs(factories): launch polish pass

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -200,8 +200,12 @@ export default defineConfig({
 				// llms-small.txt; our patch (patches/starlight-llms-txt+0.8.1.patch)
 				// extends it to llms-full.txt and custom sets as well.
 				exclude: ['support-and-community/community/open-source-licenses'],
+					// This string is the first thing an AI engine reads about Warp, so it
+					// carries the product lineup. Kept in sync with the rename and with
+					// launches: it said "the Oz platform" until the 8/18 rename, which
+					// left the most-consumed AI-facing artifact on the old name.
 					description:
-						'Documentation for Warp, the agentic development environment. Covers Warp Terminal, Warp Agents, and the Oz platform for cloud agents and orchestration at scale.',
+						'Documentation for Warp, the agentic development environment. Covers the Warp terminal, Warp agents, the Automation Platform for cloud agents and orchestration at scale, and Warp Factories for running software factories.',
 					customSets: [
 						{ label: 'Terminal', description: 'Warp Terminal features and configuration.', paths: ['terminal/**'] },
 						{ label: 'Agents', description: 'Warp\'s agents: capabilities, local agents, and CLI agents.', paths: ['agents/**'] },

--- a/src/components/CopyPageButton.astro
+++ b/src/components/CopyPageButton.astro
@@ -9,7 +9,13 @@
  */
 import { VARS } from '@data/vars';
 
-const IMPORT_LINE = /^import\s+[^\n]*?from\s+['"][^'"]+['"];?\s*$/gm;
+// Not global, and applied line by line from the top of the file rather than
+// across the whole body: an MDX component import only ever appears in the
+// leading block, while a code sample can legitimately contain the same shape.
+// A global replace ate `import OpenAI from "openai";` out of the Node example
+// in guides/external-tools/how-to-set-up-ollama.mdx, so the copied snippet no
+// longer ran.
+const IMPORT_LINE = /^import\s+[^\n]*?from\s+['"][^'"]+['"];?\s*$/;
 // The optional leading `$` matters: MDX authors write `{VARS.KEY}` in prose but
 // `${VARS.KEY}` inside JSX template literals, e.g. href={`${VARS.WEB_APP_URL}/runs`}.
 // Matching only the braces leaves the dollar behind and yields `$https://...`.
@@ -44,13 +50,24 @@ const { body, title, agentPrompt } = Astro.props;
  * fix is for this button to fetch the page's own `.md` URL on click rather than
  * carry a second copy of the content.
  */
+/** Drops the leading `import` block, stopping at the first line of content. */
+function stripLeadingImports(source: string): string {
+  const lines = source.split('\n');
+  let start = 0;
+  while (
+    start < lines.length &&
+    (lines[start].trim() === '' || IMPORT_LINE.test(lines[start]))
+  ) {
+    start++;
+  }
+  return lines.slice(start).join('\n');
+}
+
 function resolveMdxSource(source: string): string {
   const vars = VARS as unknown as Record<string, string>;
-  return source
-    .replace(IMPORT_LINE, '')
+  return stripLeadingImports(source)
     .replace(PROSE_TOKEN, (match, key) => vars[key] ?? match)
-    .replace(FRONTMATTER_TOKEN, (match, key) => vars[key] ?? match)
-    .replace(/^\n+/, '');
+    .replace(FRONTMATTER_TOKEN, (match, key) => vars[key] ?? match);
 }
 
 const markdownContent = `# ${title}\n\n${resolveMdxSource(body)}`;

--- a/src/content/docs/factories/factory-as-code.mdx
+++ b/src/content/docs/factories/factory-as-code.mdx
@@ -161,7 +161,7 @@ harness:
 
 ### `agentDefaults.harness`
 
-The harness and model runs execute with. Use the `harness` form to run a third-party harness or to set advanced options. `type` accepts `oz`, `claude` (alias `claude-code`), `codex`, or `gemini`; see [supported harnesses](/platform/harnesses/).
+The harness and model runs execute with. Use the `harness` form to run a third-party harness or to set advanced options. `type` accepts `oz`, `claude` (alias `claude-code`), `codex`, or `gemini` — the values the definition schema validates. For what each harness does and which ones your team can run, see [supported harnesses](/platform/harnesses/).
 
 ```yaml
 harness:

--- a/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
+++ b/src/content/docs/support-and-community/plans-and-billing/platform-credits.mdx
@@ -38,7 +38,7 @@ Whether platform credits apply depends on where the agent runs and who's paying 
 
 ### Uses platform credits
 
-* **Cloud agents on any plan** use platform credits for every cloud agent run, regardless of which agent runs the task (Warp Agent, Claude Code, or Codex), inference source (Warp-managed, BYOK, or BYOLLM), or compute source (Warp-hosted or self-hosted workers). Warp's platform infrastructure coordinates every cloud agent run.
+* **Cloud agents on any plan** use platform credits for every cloud agent run, regardless of which agent runs the task (Warp Agent, Claude Code, or Codex), inference source (Warp-managed, BYOK, or BYOLLM), or compute source (Warp-hosted or self-hosted workers). Warp's platform infrastructure coordinates every cloud agent run. [Warp Factories](/factories/) runs are cloud agent runs, so a factory's agents draw platform credits the same way.
 * **Local agents on Business or Enterprise with customer-supplied inference** use platform credits when the local agent run uses [BYOK](/agents/inference/bring-your-own-api-key/), a [custom inference endpoint](/agents/inference/custom-inference-endpoint/), or BYOLLM. Warp isn't paying for the model call, but Warp's platform infrastructure is still running the local agent. BYOK and customer-supplied inference are subject to plan-size eligibility — see the callout above.
 
 ### Doesn't use platform credits

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -199,7 +199,7 @@ const specBaseUrl = (specObject.servers as Array<{ url?: string }> | undefined)?
     <WarpTopbar crumb="API Reference" />
     <!-- llms.txt directive: machine-readable signal for agents and AI tools. -->
     <span class="api-visually-hidden" aria-hidden="true">For the complete documentation in markdown, see <a href="/llms.txt" tabindex="-1">llms.txt</a>.</span>
-    <h1 class="api-visually-hidden">Warp & Oz HTTP API reference</h1>
+    <h1 class="api-visually-hidden">Warp Automation Platform HTTP API reference</h1>
     <!--
       Server-rendered API index for crawlers and agents that don't execute JS.
       Scalar (below) provides the interactive experience for browser users.

--- a/vercel.json
+++ b/vercel.json
@@ -78,7 +78,7 @@
   ],
   "redirects": [
     {
-      "source": "/platform/software-factory/",
+      "source": "/platform/software-factory(/?)",
       "destination": "/factories/",
       "statusCode": 308
     },


### PR DESCRIPTION
Follow-up to #563, targeting `hyc/factory-launch`. Six small fixes from the original audit of #508 that weren't part of the review-feedback batch. Ready to merge — no open questions.

| Fix | Why it matters for launch |
| --- | --- |
| `astro.config.mjs` — llms.txt site description | Still said "the Oz platform" and never mentioned Factories. This is the first thing an AI engine reads about Warp and the most-consumed AI-facing artifact we publish, so the rename skipping it was the costliest miss of the set. Now names the terminal, agents, the Automation Platform, and Warp Factories. |
| `vercel.json` — software-factory redirect | Only matched `/platform/software-factory/` with a trailing slash. Every internal link that used to point there had no slash, and 1,231 of 1,292 existing entries use the bare or `(/?)` form. Now `(/?)`, so both resolve. |
| `CopyPageButton.astro` | Stripped `import ... from ...` from anywhere in the page rather than just the leading MDX import block, so "Copy page" silently deleted `import OpenAI from "openai";` from the Node sample in the Ollama guide. Now walks the leading block only; verified against a page with a code-sample import, a page with MDX imports, and one with both. |
| `api.astro` | Screen-reader `h1` still read "Warp & Oz HTTP API reference". |
| `platform-credits.mdx` | Never mentioned factories, though the Factories quickstart sends readers there to learn what a factory costs. Factory runs are cloud agent runs, so the existing rule already covered them — now it says so explicitly. |
| `factory-as-code.mdx` | Listed `gemini` as an accepted harness while linking to a page documenting three. The list is correct — the schema enum derives from `AllAgentHarnesses` in warp-server — so the sentence now separates what the schema validates from what a team can actually run. |

## One thing I could not fix

The hero image on `/platform/overview/` (`most-flexible-platform-for-building-with-agents.png`) carries what looks like a presenter annotation from an internal deck — a starred callout reading **"Use to program against agents"** — plus deck-style title framing. It's a launch-visible page and needs a re-export rather than a docs change, so I left it alone. The second diagram on that page (`platform-architecture.png`) is clean.

## Validation

`npm run build` clean · 0 broken internal links (3,695 checked) · `factory-proper-noun`, `platform-determiner`, and `hardcoded-var` all 0 on changed files · both style_lint suites pass · confirmed "Warp Factories" now appears in the built `llms.txt`.

<!-- warp:pr-description-artifacts start -->
_Plans_:
- _[Factories docs: access CTA, dashboard rename, task-oriented quickstart](https://staging.warp.dev/drive/notebook/fwldi7lQCKUEXIwu80GxS6)_
<!-- warp:pr-description-artifacts end -->
