### PR TITLE
docs(factories): add "The platform behind a factory" section

### DIFF
--- a/src/content/docs/factories/how-factories-work.mdx
+++ b/src/content/docs/factories/how-factories-work.mdx
@@ -50,7 +50,7 @@ flowchart LR
 
 ## Work items and agent runs
 
-A work item and an agent run track different things. The work item is the single unit of engineering work your team follows from intake to completion. An agent run is one agent's execution within that work item. The first factory-agent run creates the work item, and each later run records one stage's actions and outputs within that work item.
+A work item and an agent run track different things. The work item is the single unit of engineering work your team follows from intake to completion. An agent run is one agent's execution within that work item, and it's an ordinary [cloud agent run](/platform/): you can watch and steer it through [session sharing](/platform/viewing-cloud-agent-runs/) like any other. The first factory-agent run creates the work item, and each later run records one stage's actions and outputs within that work item.
 
 The work item's **stage** shows progress at a glance. It reflects the most recently active role, so it can move backward during a revision or skip ahead. Run history is the complete execution record.
 

--- a/src/content/docs/factories/index.mdx
+++ b/src/content/docs/factories/index.mdx
@@ -46,6 +46,19 @@ Warp Factories is designed for engineering teams with repeatable work that exten
 | **{VARS.WARP_CLI}** | Runs the Warp Agent in any terminal and exchanges work with a factory through the Factory MCP. |
 | **{VARS.WARP_AUTOMATION_PLATFORM}** | Provides the cloud runs, environments, runners, integrations, secrets, orchestration, and APIs that a factory assembles into one workflow. |
 
+## The platform behind a factory
+
+Warp Factories is built on the [{VARS.WARP_AUTOMATION_PLATFORM}](/platform/overview/), Warp's programmable system for running and coordinating agents at scale. A factory doesn't replace the platform; it assembles the platform's primitives into one standing workflow, so what you already know about cloud agents carries over:
+
+* **Runs** - Every factory agent executes as a [cloud agent run](/platform/), with the same run records and [session sharing](/platform/viewing-cloud-agent-runs/) as any other cloud agent.
+* **Execution** - [Environments](/platform/environments/) define the workspace, [runners](/platform/runners/) provide the compute, and eligible Enterprise teams can route execution to [managed self-hosted workers](/platform/self-hosting/).
+* **Agent configuration** - Each role runs on a supported [harness](/platform/harnesses/) and model, with [secrets](/platform/secrets/) and [MCP servers](/platform/mcp/) scoping what it can reach.
+* **Billing** - A factory's runs consume [platform credits](/support-and-community/plans-and-billing/platform-credits/) the same way as any other cloud agent run.
+
+The factory layer adds the workflow on top: the foreman and its specialized roles, work items that carry each request across runs, definitions as code, default automations for connected tools, and the Scorer, benchmark, and Self-improvement loop.
+
+A standalone [cloud agent](/platform/) remains the right tool for a single task or a one-trigger automation. Reach for a factory when the work is a standing, multi-stage process your team wants to route, measure, and improve in one place.
+
 ## Next steps
 
 * [**Set up a factory**](/factories/quickstart/) - Create a factory and send its first work item.


### PR DESCRIPTION
Stacks on #508. Adds the section ZL suggested: the relationship between Warp Factories and the Automation Platform.

## What's included

- **`factories/index.mdx`** — New "The platform behind a factory" section (heading follows the "The platform behind the agent" precedent on the agents landing page, keeping the rename-sensitive product name out of heading slugs). It covers:
  - What carries over from cloud agents: runs + session sharing, environments/runners/self-hosted workers, harnesses/secrets/MCP servers, and platform credits.
  - What the factory layer adds: foreman + roles, work items, definitions as code, default automations, and the Scorer/benchmark/Self-improvement loop.
  - When to use a standalone cloud agent vs. a factory.
- **`factories/how-factories-work.mdx`** — One sentence noting a factory agent run is an ordinary cloud agent run, viewable and steerable through session sharing.

## Second-pass audit (no further changes needed)

- Link check across all 17 factories pages: 0 broken pages, 0 broken anchors.
- `style_lint --changed`: clean (only informational glossary warnings for bolded UI labels).
- `npm run build` passes.

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
