### PR TITLE
docs(factories): apply Aloke's Loom review

### DIFF
--- a/src/content/docs/factories/connect-your-factory.mdx
+++ b/src/content/docs/factories/connect-your-factory.mdx
@@ -20,7 +20,7 @@ Pick the sources that match where work starts for your team. You can connect mor
 | [GitLab](/factories/integrations/gitlab/) | Merge request activity and bot mentions | The merge request thread |
 | [Linear](/factories/integrations/linear/) | Planned issues | The Linear issue and its agent session |
 | [Jira](/factories/integrations/jira/) | Work items assigned to Warp | The Jira agent session |
-| [Factory MCP](/factories/factory-mcp/) | Sending work from a local coding agent | The factory work item |
+| [Factory MCP](/factories/factory-mcp/) | Exchanging work with a local coding agent, in both directions | The factory work item |
 | Direct runs and schedules | One-off or recurring work | The factory work item |
 
 ## Connect a source
@@ -68,7 +68,7 @@ These defaults are starting points. Review each automation's filters, agent, and
 
 ## Factory MCP
 
-The Factory MCP connects local coding agents and other MCP clients to your factory. Use it to send work to the factory from your terminal, check status, coordinate with the foreman agent, and hand finished work back to the same work item. See the [Factory MCP guide](/factories/factory-mcp/).
+The Factory MCP connects local coding agents and other MCP clients to your factory, and it works in both directions: send work to the factory, or take work over from it — pull a task down to your machine, iterate on it locally, and hand it back to the same work item. See the [Factory MCP guide](/factories/factory-mcp/).
 
 ## Direct runs and schedules
 
@@ -84,6 +84,6 @@ See the [triggers overview](/platform/triggers/) for how schedules and other tri
 * **Follow-ups continue the same work item** - Replying in the same Slack thread, GitHub issue or pull request, Linear issue, or Jira agent session adds to the existing work item instead of starting a new one. Repeated event deliveries from a provider don't create duplicate work either.
 * **One issue tracker per factory** - A factory can use [Linear](/factories/integrations/linear/) or [Jira](/factories/integrations/jira/), or no tracker at all, but not both at once. The setup wizard currently offers Linear; to use Jira, connect it after setup or in your [factory definition](/factories/factory-as-code/).
 * **Filters route work; they don't restrict access** - Choosing which requests start work is separate from what a running agent can reach. See [automation filters](/factories/automation-filters/#filters-route-work-they-dont-restrict-access).
-* **The factory hands off at the pull request** - It pushes branches and opens pull requests, then waits for a person. See [what humans decide](/factories/how-factories-work/#what-humans-decide).
+* **The factory hands off at the pull request** - It pushes branches and opens pull requests, then waits for a person. See [where your team stays in charge](/factories/how-factories-work/#where-your-team-stays-in-charge).
 
 Next, customize which agents receive work and how it's routed with [factory definitions as code](/factories/factory-as-code/).

--- a/src/content/docs/factories/factory-agents.mdx
+++ b/src/content/docs/factories/factory-agents.mdx
@@ -7,13 +7,13 @@ sidebar:
   label: "Factory agents"
 ---
 
-Every factory has a small team of agents, and each agent has a specific job. The foreman coordinates the work and holds one continuous conversation with the person who requested it; the other agents investigate, plan, build, and check the work. Together, they take a work item from the moment it reaches your factory to a finished pull request that's ready for a human to review.
+Every factory has a **foreman**, the one agent you talk to from whichever tool a request starts in. Around it sit four default agents, one for each part of the software development lifecycle: triage scopes the request, spec writes the plan, implement writes the code, and review checks it. Together they take a work item from the moment it reaches your factory to a pull request ready for a person to review.
 
-## Default agent roles
+## The default agents
 
-When you set up a factory, Warp offers five default roles. Every factory gets a foreman; you choose one to four of the other roles to go with it, for a starting team of two to five agents. Each role owns one part of the workflow, so it's always clear which agent is responsible for what. These defaults are a starting point — you can [add custom agents and automations](#add-custom-agents-and-automations) for work they don't cover.
+Every factory gets a foreman, and you choose one to four of the others to go with it. These defaults are a starting point — you can [add custom agents and automations](#add-custom-agents-and-automations) for work they don't cover.
 
-| Role | What it does | What it produces |
+| Agent | What it does | What it produces |
 | --- | --- | --- |
 | Foreman | Coordinates the work and talks to the requester | Decisions, questions, status updates, and the final handoff |
 | Triage | Investigates the request and establishes scope | Evidence, issue context, complexity, and open questions |
@@ -21,13 +21,13 @@ When you set up a factory, Warp offers five default roles. Every factory gets a 
 | Implement | Makes and validates the code change | Code, tests, validation results, and visual evidence |
 | Review | Checks the finished change with fresh eyes | Findings and a recommendation |
 
-These roles describe responsibilities, not a fixed pipeline. A small, well-understood change can skip the spec stage entirely, and review can send work back to implementation for another pass. By default, work that goes through the spec stage needs a human to approve the spec before implementation starts.
+These are responsibilities, not a fixed pipeline. A small, well-understood change can skip the spec stage entirely, and review can send work back to implementation for another pass. By default, work that goes through the spec stage needs a human to approve the spec before implementation starts.
 
 For the complete lifecycle, see [how Warp Factories work](/factories/how-factories-work/).
 
 ## Foreman
 
-The **foreman agent** runs the factory floor. It decides which role a work item needs next, hands the work to that agent, and keeps the requester informed. It's the only default agent that talks to the requester directly: when another agent needs a human answer, the foreman asks the question and routes the answer back. For revisions and follow-ups, the foreman goes back to the same agent and continues its existing conversation instead of starting a new one, so no context is lost.
+The **foreman agent** runs the factory floor. It decides which agent a work item needs next, hands the work over, and keeps the requester informed. It's the only default agent that talks to the requester directly: when another agent needs a human answer, the foreman asks the question and routes the answer back. For revisions and follow-ups, the foreman goes back to the same agent and continues its existing conversation instead of starting a new one, so no context is lost.
 
 When the work is done, the foreman presents the final pull request and its supporting evidence, then marks the work item complete. Complete means the work was handed to a human, not that the change was merged or deployed. Merging stays with your team.
 
@@ -35,52 +35,46 @@ When the work is done, the foreman presents the final pull request and its suppo
 
 ### Triage
 
-Triage figures out what the request actually involves. It researches the codebase, related issues, and other available context, and only tries to reproduce a problem when research alone can't establish the cause. It reports back with the relevant context, the scope and complexity of the change, and anything that's still unclear. The foreman uses that report to decide what happens next: ask the requester for clarification, request a spec, or go straight to implementation.
+Triage researches the codebase and related issues first, and reproduces a problem only when research can't establish the cause. Its report — context, scope, complexity, open questions — is what the foreman uses to decide whether to ask the requester for clarification, request a spec, or go straight to implementation.
 
 ### Spec
 
-Spec turns an ambiguous request into a concrete plan. It interviews the requester (through the foreman) to pin down requirements, then writes product and technical specifications with criteria for validating the change. It opens a draft pull request on a branch that implementation later continues. By default, the foreman waits for a human to approve the spec before starting implementation; you can change that policy in the foreman's instructions.
+Spec works through the foreman to pin down requirements, then writes product and technical specifications with criteria for validating the change, in a draft pull request that implement later continues. By default the foreman waits for a person to approve the spec before implementation starts; change that in the foreman's instructions.
 
 ### Implement
 
-Implement makes the change. When a spec exists, it continues the spec's branch and draft pull request rather than starting over. It writes the code, adds tests, runs the repository's validation, reviews its own diff, and, when [computer use](/agents/capabilities/computer-use/) is available, captures visual evidence of user-facing changes. If review finds problems, implement revises the change. It never merges.
+Implement continues the spec's branch and draft pull request rather than starting over. It adds tests, runs the repository's validation, and, when [computer use](/agents/capabilities/computer-use/) is available, captures visual evidence of user-facing changes. If review finds problems, implement revises. It never merges.
 
 ### Review
 
-Review checks the finished change with fresh eyes, deliberately hunting for problems: unmet requirements, broken conventions, missing or failing tests, security issues, and evidence that doesn't hold up. It separates clear defects from judgment calls, then gives the foreman one of three recommendations: accept the change, send it back for revision, or ask a human to decide. The recommendation is advice for the foreman; it doesn't approve or merge the pull request.
+Review comes to the change with fresh eyes, hunting for unmet requirements, broken conventions, missing or failing tests, security issues, and evidence that doesn't hold up. It reruns or extends validation where the evidence is thin, then recommends one of three things to the foreman: accept, revise, or ask a person to decide. The recommendation is advice — review doesn't approve or merge the pull request.
 
-## Where verification happens
-
-There's no separate verification agent, and the default team doesn't need one. Implement proves its own change works: it runs the tests and repository checks, and, when [computer use](/agents/capabilities/computer-use/) is available, uses it to capture visual evidence of user-facing changes, such as screenshots and recordings of the running app. Review then checks that proof, reruns or extends validation when necessary, and confirms the results meet the criteria. You can add custom agents for extra quality coverage, but implement and review keep these responsibilities either way.
-
-## Built-in skills and memory
+## Built-in skills
 
 Every default agent comes with GitHub skills, and the foreman also comes with a Slack skill. The issue tracker you choose during setup adds to that baseline: choosing Linear or Jira gives the agents that tracker's skill and instructions for working with it. If you don't choose a tracker, the agents get only the baseline.
-
-Each default agent also has its own [Auto-memory store](/agents/agent-memory/). Over time, Warp consolidates the agent's conversations into memory, and that accumulated memory shapes how the agent behaves. Keep this in mind when comparing two agents: identical settings don't guarantee identical behavior, because each agent remembers different things.
 
 ## Configure agent behavior
 
 Use the agent editor in the [factory dashboard](/factories/factory-dashboard/) to change an agent's description, model, runner, host, MCP servers, secrets, and instructions.
 
-You can also manage the whole factory as version-controlled code, with [factory definition files](/factories/factory-as-code/) in a Git repository, where changes get the same review, history, and rollback as any other code. A few agent settings can only be set in the files: harness, environment, and credential strategy. Where the repository lives determines how the two editing paths work together:
+You can also manage the whole factory as version-controlled code, with [factory definition files](/factories/factory-as-code/) in a Git repository, where changes get the same review, history, and rollback as any other code. A few agent settings can only be set in the files, such as harness and credential strategy. Where the repository lives determines how the two editing paths work together:
 
 * **Warp-managed repository** - Edit agents in the agent editor, or edit the definition files directly in the factory dashboard's **Factory definition** tab, whichever fits the change. Both write to the same files, so the editor and the code always agree.
 * **A GitHub repository your team owns** - The files are the only way to change the factory. Edits go through pull requests, and the file-owned settings in the factory dashboard are read-only.
 
-Factory setup doesn't choose models for you. To change the model a role uses, edit that agent.
+Factory setup doesn't choose models for you. To change the model an agent uses, edit that agent.
 
-## Choose models and harnesses by role
+## Choose models and harnesses per agent
 
-Each role can run on its own model and harness. Supported harnesses include the Warp Agent harness, Claude Code, and Codex, and any role can use any of them. A foreman running on Claude Code or Codex can still dispatch the factory's other agents, and the runs it starts are still tracked as its children.
+Each agent can run on its own model and harness. Supported harnesses include the Warp Agent harness, Claude Code, and Codex, and any agent can use any of them. A foreman running on Claude Code or Codex can still dispatch the factory's other agents, and the runs it starts are still tracked as its children.
 
 :::note
-Third-party harnesses require a Build plan or higher; on the Free plan every role runs on the Warp Agent harness. See [harnesses](/platform/harnesses/#plan-requirements).
+Third-party harnesses require a Build plan or higher; on the Free plan every agent runs on the Warp Agent harness. See [harnesses](/platform/harnesses/#plan-requirements).
 :::
 
-Default model IDs change over time, so choose based on what each role has to do well:
+Default model IDs change over time, so choose based on what each agent has to do well:
 
-| Role | What to optimize for |
+| Agent | What to optimize for |
 | --- | --- |
 | Foreman | Orchestration, instruction following, and long-running conversations |
 | Triage | Research, evidence gathering, and working with connected tools |
@@ -88,11 +82,11 @@ Default model IDs change over time, so choose based on what each role has to do 
 | Implement | Coding strength, with a harness that fits your repositories and toolchain |
 | Review | A different model or harness from implement, so the two don't share blind spots |
 
-See [model choice for agents](/agents/inference/model-choice/) and [harnesses for cloud agents](/platform/harnesses/) for available options. Define reusable procedures with [skills](/agents/capabilities/skills/), and scope each role's external access through [MCP servers](/platform/mcp/) and [cloud agent secrets](/platform/secrets/).
+See [model choice for agents](/agents/inference/model-choice/) and [harnesses for cloud agents](/platform/harnesses/) for available options. Define reusable procedures with [skills](/agents/capabilities/skills/), and scope each agent's external access through [MCP servers](/platform/mcp/) and [cloud agent secrets](/platform/secrets/).
 
 ## Add custom agents and automations
 
-Add custom agents for jobs the default roles don't handle, such as documentation, security analysis, migrations, or release checks. A custom agent doesn't have to be a required step for every work item.
+Add custom agents for jobs the default agents don't handle, such as documentation, security analysis, migrations, or release checks. A custom agent doesn't have to be a required step for every work item.
 
 Automations start a chosen agent on a schedule or when an event fires. They're one more way for work to enter your factory; the foreman still coordinates whatever they start. For all the ways to route work into a factory, see [connect your factory](/factories/connect-your-factory/).
 
@@ -102,10 +96,10 @@ Automations start a chosen agent on a schedule or when an event fires. They're o
 | --- | --- | --- |
 | Spec approval | The foreman asks a human to clarify ambiguity and approve every spec | Workflow policy in the foreman's instructions, which your team can change |
 | Merging | Agents never merge; the foreman hands the finished pull request to a human | Your repository's permissions decide who can approve and merge |
-| Runtime access | Each agent uses only the environment, secrets, and MCP servers in its configuration | Platform configuration and the permissions of the connected providers |
+| Runtime access | Each agent reaches only the repositories, secrets, and MCP servers in its configuration | Platform configuration and the permissions of the connected providers |
 
-A few capabilities sit outside an agent's configuration: built-in harness tools, the runtime credentials the platform issues, provider permissions, and network access are governed by their own controls.
+The first two rows are conventions: they live in the foreman's instructions and your repository settings, and your team can change them. Access is different. What an agent can reach comes from its configuration and the permissions of the connected providers, never from its instructions — changing what an agent is told to do doesn't change what it's able to do.
 
-Treat the approval steps as workflow conventions, not access control. Warp Factories has no special approver role, and nothing written in an agent's instructions grants it access beyond what it's configured with. Real enforcement lives in your repository permissions and platform configuration.
+So enforce with the real controls: branch protection and repository permissions decide who merges, and each agent's configuration decides what it can reach.
 
 Next, capture these choices in [factory definitions as code](/factories/factory-as-code/).

--- a/src/content/docs/factories/factory-agents.mdx
+++ b/src/content/docs/factories/factory-agents.mdx
@@ -39,7 +39,7 @@ Triage researches the codebase and related issues first, and reproduces a proble
 
 ### Spec
 
-Spec works through the foreman to pin down requirements, then writes product and technical specifications with criteria for validating the change, in a draft pull request that implement later continues. By default the foreman waits for a person to approve the spec before implementation starts; change that in the foreman's instructions.
+Spec works through the foreman to pin down requirements, then writes product and technical specifications in a draft pull request with criteria for validating the change. The implement agent later continues that pull request. By default, the foreman waits for a person to approve the spec before implementation starts; change that in the foreman's instructions.
 
 ### Implement
 

--- a/src/content/docs/factories/factory-as-code.mdx
+++ b/src/content/docs/factories/factory-as-code.mdx
@@ -180,7 +180,7 @@ The name of a runner defined under [`runners/`](#runnersnameyaml) that provides 
 
 ### `agentDefaults.environmentId`
 
-The ID of an existing [environment](/platform/environments/) that runs execute in.
+The ID of an existing [environment](/platform/environments/) that runs execute in. Most factories never set this: leave it out, and Warp manages the workspace from the factory's repositories.
 
 ### `agentDefaults.secrets`
 

--- a/src/content/docs/factories/factory-dashboard.mdx
+++ b/src/content/docs/factories/factory-dashboard.mdx
@@ -21,7 +21,7 @@ Select a factory in the sidebar to open its pages. **Runs**, **MCPs and apps**, 
 | --- | --- | --- |
 | **Dashboard** | The factory's metrics: autonomy, PR cycle time, cost, and run volume | Compare periods and find work worth investigating |
 | **Activity** | Work items grouped by stage | Search, filter, open, and stop work items |
-| **Agents** | The factory's agent roster | Create and edit agents |
+| **Agents** | The factory's agents | Create and edit agents |
 | **Automations** | Triggers that start runs | Create, edit, and delete automations |
 | **Runs** | The factory's individual agent runs | Start, stop, and score runs |
 | **Scorers** | Scorer definitions and results | Define rubrics and review classifications |
@@ -51,7 +51,7 @@ A run is a single agent execution. A work item on **Activity** tracks one piece 
 Click **New** on a factory's **Runs** page to send a prompt to the factory's foreman agent. Open a run to see its timeline and cost, plus a **Sub-agents** tab for an orchestrator run's child runs. From there you can view the agent's full session, stop or score the run, or turn it into a benchmark task.
 
 :::note
-Run pages don't include a chat input, but you can still steer a run: **View session** opens its [shared agent session](/platform/viewing-cloud-agent-runs/), where you follow the agent in real time and send follow-up instructions while the run's environment is active. After the environment shuts down, the same button opens the conversation transcript.
+Run pages don't include a chat input, but you can still steer a run: **View session** opens its [shared agent session](/platform/viewing-cloud-agent-runs/), where you follow the agent in real time and send follow-up instructions while the run's sandbox is active. After it shuts down, the same button opens the conversation transcript.
 :::
 
 ## Read metrics on the Dashboard page
@@ -66,9 +66,9 @@ The page also charts opened versus merged PRs and a breakdown of runs, and the *
 
 ## Manage agents and automations
 
-**Agents** is the factory's roster. Create agents and edit their instructions, model or harness, runner, host, secrets, and MCP servers. **Automations** defines the triggers that start runs: a schedule (including custom cron expressions) or a GitHub, Linear, Slack, or Jira event.
+**Agents** lists the factory's agents. Create agents and edit their instructions, model or harness, runner, host, secrets, and MCP servers. **Automations** defines the triggers that start runs: a schedule (including custom cron expressions) or a GitHub, Linear, Slack, or Jira event.
 
-Environment is set in the factory definition, not the agent editor. The automation editor doesn't change execution settings either; an automation only overrides them through [execution overrides in the definition files](/factories/factory-as-code/#execution-overrides). When the factory's definition lives in an external repository, Agents, Automations, and Scorers are read-only; make changes there through pull requests.
+The automation editor doesn't change execution settings; an automation only overrides them through [execution overrides in the definition files](/factories/factory-as-code/#execution-overrides). When the factory's definition lives in an external repository, Agents, Automations, and Scorers are read-only; make changes there through pull requests.
 
 ## Edit definitions in the Factory definition tab
 
@@ -104,6 +104,6 @@ For a file-managed factory, `runners/*.yaml` in the repository is the source of 
 
 * [How Warp Factories work](/factories/how-factories-work/) - The lifecycle behind Activity's stages and where humans stay in the loop.
 * [Definitions as code](/factories/factory-as-code/) - Define agents, automations, runners, and source ownership in code.
-* [Factory agents](/factories/factory-agents/) - What each default role does and how to configure it.
+* [Factory agents](/factories/factory-agents/) - What each default agent does and how to configure it.
 * [Measure and improve a factory](/factories/measure-and-improve/) - Configure the Scorers and benchmarks behind the **Dashboard** page.
 * [Troubleshooting Warp Factories](/factories/troubleshooting/) - Fixes for setup problems, work that doesn't start, and stuck runs.

--- a/src/content/docs/factories/factory-mcp.mdx
+++ b/src/content/docs/factories/factory-mcp.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: "Factory MCP"
 ---
 
-Factory MCP is a hosted Model Context Protocol (MCP) server that connects coding agents to your team's factories. With it, the agent you already work with — in Warp or in any MCP-capable tool — can send work to a factory, pick up a factory task to continue locally, and hand the finished work back.
+Factory MCP is a hosted Model Context Protocol (MCP) server that connects coding agents to your team's factories, in both directions: the agent you already work with — in Warp or in any MCP-capable tool — can send work to a factory, or take work over from one by pulling a task down, continuing it locally, and handing the result back.
 
 The factory keeps a single record of each task throughout. Whether a change happens in the cloud or on your machine, it lands on the same task with the same history and conversation. A task is the factory's work item: the same unit of work that appears in the factory dashboard's [Activity view](/factories/factory-dashboard/#track-work-items-on-activity).
 
@@ -71,7 +71,7 @@ Factory MCP has no read-only or per-factory scopes: a connected client acts with
 
 ## How it works
 
-Factory MCP exposes ten tools that your agent calls on your behalf. You don't need to learn them to use it: the server publishes its own usage guidance and tool schemas, so agents pick up the correct workflow on their own. Prompts like these are enough:
+Factory MCP exposes a small set of tools that your agent calls on your behalf. You don't need to learn them to use it: the server publishes its own usage guidance and tool schemas, so agents pick up the correct workflow on their own. Prompts like these are enough:
 
 * "Send this bug to the factory, including my branch."
 * "What's the status of the checkout-flow task?"
@@ -105,7 +105,7 @@ Sending work to a factory means you're no longer watching it. To be notified whe
 
 ## Tool reference
 
-Factory MCP exposes these ten tools. Your MCP client fetches the full input schemas from the server, and tool results include links that open the corresponding task or run in the factory's [factory dashboard](/factories/factory-dashboard/).
+Your MCP client fetches the full input schemas from the server, and tool results include links that open the corresponding task or run in the factory's [factory dashboard](/factories/factory-dashboard/).
 
 | Tool | What it does |
 | --- | --- |

--- a/src/content/docs/factories/how-factories-work.mdx
+++ b/src/content/docs/factories/how-factories-work.mdx
@@ -7,18 +7,15 @@ sidebar:
   label: "How Factories work"
 ---
 
-A factory runs two connected loops:
+A factory is a team of cloud agents that ships software the way your team does: a request comes in, moves through the stages it needs, and comes back as a pull request for a person to review. You talk to one agent — the **foreman** — from whichever tool a request starts in, and it dispatches the factory's other agents, each owning one part of the software development lifecycle.
 
-* The **inner loop** moves each work item from intake to a human handoff.
-* The **outer loop** uses evidence from completed work to improve the factory itself.
+A **work item** is one unit of that engineering work, such as an issue, support request, pull request, or Factory MCP task. It keeps its identity from intake to handoff, however many agents contribute to it along the way.
 
-A **work item** is one unit of engineering work, such as an issue, support request, pull request, or Factory MCP task. It keeps its identity while specialized agents contribute to it through separate runs.
+## How a work item moves through the factory
 
-## The inner loop: intake to handoff
+The foreman coordinates every work item. It routes work between the factory's agents, passes each one the context it needs, and continues existing agent conversations instead of starting new ones. See [factory agents](/factories/factory-agents/) for what each agent does.
 
-The **foreman** coordinates every work item. It routes work between the specialized agents, passes each one the context it needs, and continues existing agent conversations instead of starting new ones. The specialized agents keep narrow responsibilities, and each of their runs stays distinct in run history. See [factory agents](/factories/factory-agents/) for the role definitions.
-
-Not every work item needs every stage. The foreman picks the shortest path that still meets your quality policy. It skips stages when the work is already well defined, starts partway through when enough context exists, and sends work back to an earlier agent when revisions are needed.
+Not every work item needs every stage. The foreman picks the shortest path that still meets your quality policy: it skips stages when the work is already well defined, starts partway through when enough context exists, and sends work back to an earlier agent when revisions are needed.
 
 ### Stages
 
@@ -48,30 +45,22 @@ flowchart LR
 * **Human handoff** - The factory presents the result, its evidence, and any findings. A person decides what happens next.
 * **Complete or Cancelled** - The work item ends when the factory finishes its work, or stops early if someone cancels it.
 
-## Work items and agent runs
+In the [factory dashboard](/factories/factory-dashboard/), the **Activity** view is where you find, filter, and stop work items. It groups these stages under its own names — Triage, Planning (specification), Building (implementation), and Reviewing — and each agent's run within a work item is an ordinary [cloud agent run](/platform/) you can watch and steer.
 
-A work item and an agent run track different things. The work item is the single unit of engineering work your team follows from intake to completion. An agent run is one agent's execution within that work item, and it's an ordinary [cloud agent run](/platform/): you can watch and steer it through [session sharing](/platform/viewing-cloud-agent-runs/) like any other. The first factory-agent run creates the work item, and each later run records one stage's actions and outputs within that work item.
+## Where your team stays in charge
 
-The work item's **stage** shows progress at a glance. It reflects the most recently active role, so it can move backward during a revision or skip ahead. Run history is the complete execution record.
+A factory is built to pause where the call belongs to a person. By default, that's three places:
 
-In the [factory dashboard](/factories/factory-dashboard/), use the **Activity** view to find, filter, and stop work items. Activity groups these stages under its own names: Triage, Planning (specification), Building (implementation), and Reviewing.
+* **Approving the spec** - When work goes through the spec stage, implementation waits until a person signs off on the plan.
+* **Answering questions** - When requirements are unclear or a review finding is ambiguous, the foreman asks instead of guessing.
+* **Merging** - The factory opens the pull request and hands it off. Whether and when it merges is your team's call.
 
-## What humans decide
+The first two are workflow policy, written into the foreman's instructions — edit them to change when the factory checks in. Merging is enforced by your repository, so if you require human-only merges, use branch protection and repository permissions.
 
-By default, a factory asks for a human decision at three points:
+## How the factory improves itself
 
-* **Specification review** - A person approves the specification before implementation starts.
-* **Clarification** - The factory asks a person about unclear requirements, blockers, and ambiguous review findings.
-* **Merge** - A person decides whether and when to merge the final pull request.
+Your factory is self-improving, and you define what "better" means. [Scorers](/factories/measure-and-improve/) grade completed runs against criteria you write, and [Self-improvement](/factories/measure-and-improve/#configure-and-review-self-improvement) groups the failures they flag into follow-up runs that propose fixes — to the application code or to the factory's own definition. Every proposal arrives as a change for your review; nothing is adopted on its own.
 
-These checkpoints come from the factory's agent instructions and your repository policy, not from a platform-level approval feature. Warp Factories doesn't enforce human-only merges. If your team requires them, use branch protection and repository permissions.
+The factory's definition is open to the same loop. Anyone on the team, or an agent, can propose changes to its instructions, skills, models, or other [definition files](/factories/factory-as-code/), and definitions stored in GitHub go through pull request review and [configuration checks](/factories/factory-as-code/#pull-request-checks-for-github-backed-factories) before a change reaches the production branch.
 
-## The outer loop: improving the factory
-
-Each completed work item leaves evidence behind, including run and pull request activity, costs, [Scorer](/factories/measure-and-improve/) evaluations, and benchmarks. Teams use this evidence to spot repeated failures and compare model or harness configurations.
-
-The factory can also act on that evidence directly. Its [Self-improvement](/factories/measure-and-improve/#configure-and-review-self-improvement) capability groups the failures Scorers flag and files follow-up runs that propose changes to the application code or the factory's own definition. Nothing is adopted without your review.
-
-Anyone on the team, or an agent, can also propose changes to the factory's instructions, skills, models, environments, or other [definitions](/factories/factory-as-code/). Definitions stored in GitHub can go through pull request review and [configuration checks](/factories/factory-as-code/#pull-request-checks-for-github-backed-factories) before a change reaches the production branch; Warp-managed definitions sync changes directly. Match your review policy to the definition source and the risk of the change.
-
-Benchmarks organize the evidence; they don't replace your judgment about whether a change is correct. See [measure and improve](/factories/measure-and-improve/) for the evaluation workflow, or [build a self-improving agent](/guides/agent-workflows/build-a-self-improving-agent/) to apply the same outer-loop pattern to a standalone agent.
+See [measure and improve](/factories/measure-and-improve/) for the evaluation workflow, or [build a self-improving agent](/guides/agent-workflows/build-a-self-improving-agent/) to apply the same pattern to a standalone agent.

--- a/src/content/docs/factories/index.mdx
+++ b/src/content/docs/factories/index.mdx
@@ -8,7 +8,7 @@ sidebar:
 ---
 import { VARS } from '@data/vars';
 
-Warp Factories lets engineering teams define and operate **software factories**: cloud workflows where specialized agents move engineering work from intake to a reviewed pull request. Your team sets the policy and makes the final decisions; the factory does the repetitive work and records the evidence you need to improve it.
+Warp Factories lets engineering teams define and operate **software factories**: cloud workflows where specialized agents move engineering work from intake to a reviewed pull request. The factory does the repetitive work; your team stays in the loop at the points that matter, approving specs and merging every pull request.
 
 :::note
 Warp Factories is in **Early Access** and available to a limited set of teams. [Request access](https://www.warp.dev/factories/request-access) to use it with your team.
@@ -18,7 +18,7 @@ Warp Factories is in **Early Access** and available to a limited set of teams. [
 
 A software factory automates the software development lifecycle. It takes a **work item**, such as an issue, ticket, or triggered task, and moves it through specialized agents that triage it, write a specification when one is needed, implement the change, and review the result.
 
-A **factory** is one deployed instance of that pattern. It connects your repositories and engineering tools to agent roles, execution infrastructure, and a measurable workflow. Each factory applies a single policy across all of its work sources, so deploy separate factories for repository groups that need different policies.
+A **factory** is one deployed instance of that pattern. It connects your repositories and engineering tools to a team of agents, execution infrastructure, and a measurable workflow. Each factory applies a single policy across all of its work sources, so deploy separate factories for repository groups that need different policies.
 
 ## Who benefits from Warp Factories
 
@@ -30,10 +30,10 @@ Warp Factories is designed for engineering teams with repeatable work that exten
 
 ## What you get with Warp Factories
 
-* **Coordinated specialist agents** - A team of [factory agents](/factories/factory-agents/) handles each work item. A coordinating foreman routes it through the triage, spec, implement, and review roles, skipping stages that don't apply. You can add custom agents and automations to handle work the default roles don't cover.
+* **Coordinated specialist agents** - A team of [factory agents](/factories/factory-agents/) handles each work item. A coordinating foreman routes it through the triage, spec, implement, and review agents, skipping stages that don't apply. You can add custom agents and automations to handle work the defaults don't cover.
 * **Definitions as code** - [Version-controlled definition files](/factories/factory-as-code/) describe your repositories, agents, automations, runners, skills, and MCP servers, so factory changes get the same review, history, and rollback as code changes.
 * **Integrations and the Factory MCP** - Work flows in from [Slack](/factories/integrations/slack/), [GitHub](/factories/integrations/github/), [GitLab](/factories/integrations/gitlab/), [Linear](/factories/integrations/linear/), and [Jira](/factories/integrations/jira/), plus direct runs and schedules. The [Factory MCP](/factories/factory-mcp/) connects coding agents and other MCP clients.
-* **Model and harness choice** - Each agent role can use a different model and [supported harness](/platform/harnesses/), including the Warp Agent, Claude Code, and Codex.
+* **Model and harness choice** - Each agent can use a different model and [supported harness](/platform/harnesses/), including the Warp Agent, Claude Code, and Codex.
 * **Measurement and self-improvement** - The [factory dashboard](/factories/factory-dashboard/) shows work-item status, runs, automations, costs, and benchmarks. [Scorers](/factories/measure-and-improve/) grade completed work, and [Self-improvement](/factories/measure-and-improve/#configure-and-review-self-improvement) turns repeated failures into follow-up work the factory proposes for review.
 * **Infrastructure control** - Run on Warp-hosted infrastructure, or self-host execution on an eligible Enterprise plan. Teams can also connect supported inference providers, scope secrets, and (if eligible) store transcripts, artifacts, and run attachments in their own S3 or GCS buckets. See [infrastructure and security](/factories/infrastructure-and-security/) for the available controls.
 
@@ -42,20 +42,20 @@ Warp Factories is designed for engineering teams with repeatable work that exten
 | Product | How it relates |
 | --- | --- |
 | **Warp** | The interactive terminal where you develop locally with agents and code review. A factory runs independently in the cloud. |
-| **Warp Agent** | Warp's built-in agent harness. Factory roles can run on it or on another supported harness. |
+| **Warp Agent** | Warp's built-in agent harness. A factory's agents can run on it or on another supported harness. |
 | **{VARS.WARP_CLI}** | Runs the Warp Agent in any terminal and exchanges work with a factory through the Factory MCP. |
-| **{VARS.WARP_AUTOMATION_PLATFORM}** | Provides the cloud runs, environments, runners, integrations, secrets, orchestration, and APIs that a factory assembles into one workflow. |
+| **{VARS.WARP_AUTOMATION_PLATFORM}** | Provides the cloud runs, runners, integrations, secrets, orchestration, and APIs that a factory assembles into one workflow. |
 
 ## The platform behind a factory
 
 Warp Factories is built on the [{VARS.WARP_AUTOMATION_PLATFORM}](/platform/overview/), Warp's programmable system for running and coordinating agents at scale. A factory doesn't replace the platform; it assembles the platform's primitives into one standing workflow, so what you already know about cloud agents carries over:
 
 * **Runs** - Every factory agent executes as a [cloud agent run](/platform/), with the same run records and [session sharing](/platform/viewing-cloud-agent-runs/) as any other cloud agent.
-* **Execution** - [Environments](/platform/environments/) define the workspace, [runners](/platform/runners/) provide the compute, and eligible Enterprise teams can route execution to [managed self-hosted workers](/platform/self-hosting/).
-* **Agent configuration** - Each role runs on a supported [harness](/platform/harnesses/) and model, with [secrets](/platform/secrets/) and [MCP servers](/platform/mcp/) scoping what it can reach.
+* **Execution** - [Runners](/platform/runners/) provide the compute each agent works on, and eligible Enterprise teams can route execution to [managed self-hosted workers](/platform/self-hosting/).
+* **Agent configuration** - Each agent runs on a supported [harness](/platform/harnesses/) and model, with [secrets](/platform/secrets/) and [MCP servers](/platform/mcp/) scoping what it can reach.
 * **Billing** - A factory's runs consume [platform credits](/support-and-community/plans-and-billing/platform-credits/) the same way as any other cloud agent run.
 
-The factory layer adds the workflow on top: the foreman and its specialized roles, work items that carry each request across runs, definitions as code, default automations for connected tools, and the Scorer, benchmark, and Self-improvement loop.
+The factory layer adds the workflow on top: the foreman and its agents, work items that carry each request across runs, definitions as code, default automations for connected tools, and the Scorer and Self-improvement loop.
 
 A standalone [cloud agent](/platform/) remains the right tool for a single task or a one-trigger automation. Reach for a factory when the work is a standing, multi-stage process your team wants to route, measure, and improve in one place.
 
@@ -63,5 +63,5 @@ A standalone [cloud agent](/platform/) remains the right tool for a single task 
 
 * [**Set up a factory**](/factories/quickstart/) - Create a factory and send its first work item.
 * [**Understand the execution model**](/factories/how-factories-work/) - See how the foreman coordinates stages, runs, and human decisions.
-* [**Meet the factory agents**](/factories/factory-agents/) - See what each role does and how to configure its model, harness, and instructions.
+* [**Meet the factory agents**](/factories/factory-agents/) - See what each agent does and how to configure its model, harness, and instructions.
 * **Adapt the system** - [Define the factory as code](/factories/factory-as-code/) and [connect its work sources](/factories/connect-your-factory/).

--- a/src/content/docs/factories/infrastructure-and-security.mdx
+++ b/src/content/docs/factories/infrastructure-and-security.mdx
@@ -29,16 +29,11 @@ flowchart LR
 
 Self-hosting moves only the execution plane: with a managed self-hosted worker, repository checkouts, command execution, and the sandbox filesystem stay on machines you control, but content that enters prompts, results, transcripts, attachments, artifacts, or telemetry still flows through Warp and the providers you configure. See [deployment patterns](/platform/deployment-patterns/) and [self-hosting security and networking](/platform/self-hosting/security-and-networking/) for the broader data model.
 
-## Environments and runners
+## Runners
 
-Two configurations define where and how a factory's agents work:
+A runner defines the compute a factory's agents work on: the operating system and architecture, the sandbox image, and the instance shape (vCPUs and memory). It's the infrastructure choice you make for a factory. The workspace itself — repositories, setup commands, and secrets — comes from the factory's [definition](/factories/factory-as-code/), and Warp keeps it in step for you. See the [runner reference](/platform/runners/) for the available compute options.
 
-| Configuration | Defines | Key settings |
-| --- | --- | --- |
-| **Environment** | What an agent works on: the workspace and runtime context | Repositories, setup commands, secrets, toolchain image, and provider configuration |
-| **Runner** | Where the work executes: the compute | Operating system, architecture, sandbox image, vCPUs, and memory |
-
-You don't manage a factory's environment directly — each factory keeps one in step with the repositories in its [definition](/factories/factory-as-code/). Runners are the choice you make. See [environments](/platform/environments/) for the underlying workspace model and the [runner reference](/platform/runners/) for compute options and how a run picks one.
+Runners are declared as `runners/*.yaml` files in the definition, and you can define more than one — a Linux runner with more cores and memory for builds, a macOS runner for platform-specific work. Every agent inherits the factory's default (`agentDefaults.runner`), and any agent or automation can name its own `runner` instead, so the foreman can send implementation to a macOS runner while every other agent stays on Linux.
 
 The **Runners** section of a factory's **Settings** page in the [factory dashboard](/factories/factory-dashboard/) shows each runner's operating system and architecture, setup commands, size, and whether it's the default. Where you edit runners depends on where the factory's source lives:
 
@@ -101,7 +96,7 @@ Scope each credential to the resources and actions its agent needs. Warp redacts
 
 ## Governance and metering
 
-Factories use your existing [team roles](/enterprise/team-management/roles-and-permissions/): Team Owners and Admins control factory definitions, environments, runners, secrets, and provider configuration. Warp Factories doesn't add a factory-specific approval role, so who reviews specifications and who approves merges stays a workflow and repository policy decision. Treat factory-definition changes as operational code: review them like any other change, and keep merge access with the people responsible for shipping.
+Factories use your existing [team roles](/enterprise/team-management/roles-and-permissions/): Team Owners and Admins control factory definitions, runners, secrets, and provider configuration. Warp Factories doesn't add a factory-specific approval role, so who reviews specifications and who approves merges stays a workflow and repository policy decision. Treat factory-definition changes as operational code: review them like any other change, and keep merge access with the people responsible for shipping.
 
 Warp meters hosted compute, Warp-provided inference, and platform services. Managed self-hosted execution moves compute costs to your own infrastructure, and customer-supplied inference bills model usage through your provider account. Platform services consume credits regardless of these choices. See [platform credits](/support-and-community/plans-and-billing/platform-credits/) for details.
 
@@ -109,7 +104,7 @@ Warp meters hosted compute, Warp-provided inference, and platform services. Mana
 
 1. **Classify the workload** - Identify the repositories, data, internal services, and regulated systems the factory can reach.
 2. **Choose execution** - Decide where checkout, commands, and the sandbox filesystem must run.
-3. **Configure the workspace and runners** - Set the factory's repositories, setup commands, and secrets, and choose the runner operating system, architecture, image, and compute.
+3. **Configure the factory and its runners** - Set the repositories, setup commands, and secrets in the factory's definition, and choose each runner's operating system, architecture, image, and compute.
 4. **Choose inference and storage** - Select provider routing and where supported run data persists.
 5. **Scope credentials** - Set each agent's secret allowlist, harness authentication, and repository identity.
 6. **Set review gates** - Decide where humans review specifications and pull requests, and enforce those gates in workflow and repository policy.

--- a/src/content/docs/factories/integrations/linear.mdx
+++ b/src/content/docs/factories/integrations/linear.mdx
@@ -13,7 +13,7 @@ When the factory needs an answer, reply in Linear, or open the live run to steer
 
 ## Prerequisites
 
-* **A factory** - Create a factory with the agents, repositories, and environment needed to handle Linear work.
+* **A factory** - Create a factory with the agents and repositories needed to handle Linear work.
 * **A Linear workspace** - Use a Linear account that can authorize the Warp app for the workspace.
 * **A linked Warp account (agent sessions only)** - Anyone who starts a Linear agent session must link their Linear user to their Warp account. If Warp can't identify the session creator, Linear shows an authentication prompt instead of starting work.
 * **Code host access** - Configure repository access separately through the factory's [GitHub connection](/platform/integrations/github/). The factory needs it to change code or create a pull request.

--- a/src/content/docs/factories/quickstart.mdx
+++ b/src/content/docs/factories/quickstart.mdx
@@ -8,15 +8,17 @@ sidebar:
 ---
 import { VARS } from '@data/vars';
 
-A factory is a team of cloud agents: a foreman you talk to, plus the subagents it dispatches. Together they turn incoming requests into pull requests for your team to review. In this quickstart, you will create a factory and take one small work item from prompt to pull request in about 10 minutes.
+A factory is a team of cloud agents that turns your team's requests into pull requests. You talk to one agent, the **foreman**, from whichever tool the request starts in — Slack, an issue tracker, a code host — and it dispatches the factory's other agents, each owning one part of the software development lifecycle. People stay in the loop at the points that matter: approving the spec and merging the pull request.
+
+In this quickstart, you will create a factory and take one small work item from prompt to pull request in about 10 minutes.
 
 ## What you'll decide
 
-Warp walks you through factory setup in a wizard; your job is to decide four things:
+Warp walks you through factory setup; your job is to decide four things:
 
 * **Which code the factory works on** - The code host and the set of repositories.
-* **What it's called** - The factory's name, and the handle your team @-mentions to reach its foreman.
-* **Which agents it runs** - The subagents the foreman can dispatch.
+* **What it's called** - The factory's name, and the alias your team @-mentions to reach it.
+* **Which agents it runs** - The agents the foreman can dispatch.
 * **Where work comes from** - Optionally, a chat tool and an issue tracker.
 
 Every one of these is editable afterward, so pick something reasonable and keep moving.
@@ -33,30 +35,32 @@ _~5 minutes_
 
 Sign in to the {VARS.FACTORY_WEB_APP} at <a href={VARS.FACTORY_WEB_APP_URL}>platform.warp.dev</a> and start a new factory. Setup asks you for the following.
 
+You don't have to click through setup at all: an agent connected to the [Factory MCP](/factories/factory-mcp/) can create the factory for you with the `create_factory` tool — tell it which repositories to use and what to call the factory, and it makes the same decisions described below.
+
 ### Connect a code host and choose repositories
 
 Authorize GitHub or GitLab, then select the repositories the factory works in.
 
 Start with one or two. Every agent in the factory shares this repo set, so a focused set keeps their context tight, and you can add more later. Warp provisions a default [environment](/platform/environments/) for what you select.
 
-### Name the factory and its foreman
+### Name your factory
 
-**Factory name** identifies the factory in the app. **Foreman name** is the handle your team @-mentions to reach the foreman from connected tools like Slack and Linear, so keep it short and recognizable. Warp derives one from the factory name if you don't set it yourself.
+Name the factory, and give it an [alias](/factories/factory-as-code/#alias): the handle your team @-mentions to reach it from connected tools like Slack and Linear, so keep it short and recognizable. In setup, the alias is the **Foreman name** field, and Warp derives it from the factory name if you don't set one.
 
-### Confirm the agent roster
+### Design your factory
 
-The foreman is always on the roster: it's the agent you talk to. You choose which subagents it can dispatch:
+Every factory has a **foreman**: the one agent you talk to, no matter where the request starts. Around it, the factory is composed of four default agents, one for each part of the software development lifecycle, and this step is where you choose which of them your factory runs:
 
-| Subagent | What it does |
+| Agent | What it does |
 | --- | --- |
 | **Triage** | Accepts work from issue trackers and establishes scope |
 | **Spec** | Iterates with your team to produce a spec |
 | **Code** | Implements the change and opens the pull request |
 | **Review** | Inspects the result and reports findings |
 
-All four start enabled and a factory needs at least one, so this step is about turning off what you don't want yet. Leave **Code** on so this quickstart can end in a pull request.
+All four start enabled and a factory needs at least one, so this step is about turning off what you don't want yet. Leave **Code** on so this quickstart can end in a pull request. You can add your own agents and automations later.
 
-See [factory agents](/factories/factory-agents/) for what each role does in depth; the roster's **Code** toggle is the Implement role on that page.
+See [factory agents](/factories/factory-agents/) for what each agent does in depth; the **Code** toggle is the Implement role on that page.
 
 ### Optionally connect Slack and an issue tracker
 
@@ -68,8 +72,9 @@ Warp then creates the factory and opens its [dashboard](/factories/factory-dashb
 
 _~5 minutes_
 
-1. On your factory's **Runs** page, start a new run.
-2. Describe one small, verifiable change and submit it:
+Send the request from the tool your team already works in — that's what a factory is for. Mention the factory in a Slack channel, or assign it an issue in your tracker, and it replies right there. If you skipped the integrations, start a run from the **Runs** page of the factory's [dashboard](/factories/factory-dashboard/) instead.
+
+1. Describe one small, verifiable change and send it:
 
    ```text title="Example first request"
    Add a "Local development" section to README.md that summarizes the setup
@@ -79,14 +84,12 @@ _~5 minutes_
 
    Adapt the pattern to your repository: name the file, the change you expect, and the command that verifies it. A narrow, explicit request makes the first run easy to judge.
 
-   The foreman picks up the request and dispatches your subagents as child runs.
-
-3. Follow it from two places in the factory's [dashboard](/factories/factory-dashboard/):
+2. The foreman picks up the request, dispatches the factory's agents as child runs, and posts progress and questions back where the request started. Follow the details in the factory's [dashboard](/factories/factory-dashboard/):
 
    * **Runs** - The foreman's run and the child runs it dispatches.
    * **Activity** - The work item as it moves through its stages. Open it for the event history and pull request artifacts.
 
-4. When the Code agent finishes, the work item links a pull request. Review and merge it the way you would any other: a factory hands off at the pull request and never merges for you.
+3. When the Code agent finishes, the work item links a pull request. Review and merge it the way you would any other: a factory hands off at the pull request and never merges for you.
 
 ## Next steps
 

--- a/src/content/docs/factories/quickstart.mdx
+++ b/src/content/docs/factories/quickstart.mdx
@@ -8,7 +8,7 @@ sidebar:
 ---
 import { VARS } from '@data/vars';
 
-A factory is a team of cloud agents that turns your team's requests into pull requests. You talk to one agent, the **foreman**, from whichever tool the request starts in — Slack, an issue tracker, a code host — and it dispatches the factory's other agents, each owning one part of the software development lifecycle. People stay in the loop at the points that matter: approving the spec and merging the pull request.
+A factory is a team of cloud agents that turns your team's requests into pull requests. You talk to one agent, the **foreman**, from whichever tool the request starts in, such as Slack, an issue tracker, or a code host. The foreman dispatches the factory's other agents, each owning one part of the software development lifecycle. People stay in the loop at the points that matter: approving specs when needed and merging pull requests.
 
 In this quickstart, you will create a factory and take one small work item from prompt to pull request in about 10 minutes.
 
@@ -72,7 +72,7 @@ Warp then creates the factory and opens its [dashboard](/factories/factory-dashb
 
 _~5 minutes_
 
-Send the request from the tool your team already works in — that's what a factory is for. Mention the factory in a Slack channel, or assign it an issue in your tracker, and it replies right there. If you skipped the integrations, start a run from the **Runs** page of the factory's [dashboard](/factories/factory-dashboard/) instead.
+Send the request from the tool your team already works in. Mention the factory in a Slack channel, or assign it an issue in your tracker, and it replies right there. If you skipped the integrations, start a run from the **Runs** page of the factory's [dashboard](/factories/factory-dashboard/) instead.
 
 1. Describe one small, verifiable change and send it:
 

--- a/src/content/docs/factories/quickstart.mdx
+++ b/src/content/docs/factories/quickstart.mdx
@@ -35,13 +35,13 @@ _~5 minutes_
 
 Sign in to the {VARS.FACTORY_WEB_APP} at <a href={VARS.FACTORY_WEB_APP_URL}>platform.warp.dev</a> and start a new factory. Setup asks you for the following.
 
-You don't have to click through setup at all: an agent connected to the [Factory MCP](/factories/factory-mcp/) can create the factory for you with the `create_factory` tool — tell it which repositories to use and what to call the factory, and it makes the same decisions described below.
+You can also skip the wizard: ask an agent connected to the [Factory MCP](/factories/factory-mcp/) to create the factory with its `create_factory` tool, giving it the team, the repositories, and a name. That covers the first two steps below; choose the agents and connect your tools afterward in the factory's dashboard.
 
 ### Connect a code host and choose repositories
 
 Authorize GitHub or GitLab, then select the repositories the factory works in.
 
-Start with one or two. Every agent in the factory shares this repo set, so a focused set keeps their context tight, and you can add more later. Warp provisions a default [environment](/platform/environments/) for what you select.
+Start with one or two. Every agent in the factory shares this repo set, so a focused set keeps their context tight, and you can add more later.
 
 ### Name your factory
 
@@ -60,7 +60,7 @@ Every factory has a **foreman**: the one agent you talk to, no matter where the 
 
 All four start enabled and a factory needs at least one, so this step is about turning off what you don't want yet. Leave **Code** on so this quickstart can end in a pull request. You can add your own agents and automations later.
 
-See [factory agents](/factories/factory-agents/) for what each agent does in depth; the **Code** toggle is the Implement role on that page.
+See [factory agents](/factories/factory-agents/) for what each agent does in depth; the **Code** toggle is that page's Implement agent.
 
 ### Optionally connect Slack and an issue tracker
 

--- a/src/content/docs/factories/troubleshooting.mdx
+++ b/src/content/docs/factories/troubleshooting.mdx
@@ -78,7 +78,7 @@ Then check the causes specific to where the work came from:
 
 1. Open the work item on **Activity** and read its event history to see which agent ran last.
 2. Use **View agent** to open that agent's session, where a question waiting on a human is visible and answerable.
-3. If the run's environment is still active, you can steer it directly. See [cloud agent session sharing](/platform/viewing-cloud-agent-runs/).
+3. If the run is still active, you can steer it directly. See [cloud agent session sharing](/platform/viewing-cloud-agent-runs/).
 
 ### No pull request appears
 


### PR DESCRIPTION
Fixes from Aloke's Loom review, [Factory Documentation Review and Key Fixes](https://www.loom.com/share/51757516036f4de690eed165d9ce66a9). Two commits: the quickstart, then the rest of the section.

## Quickstart

**Intro adopts his framing.** You talk to one agent, the foreman, from whichever tool the request starts in, and it dispatches agents that each own part of the SDLC. Adds the humans-in-the-loop sentence he flagged as missing up front.

**"Name the factory and its foreman" → "Name your factory."** You name the factory and give it an alias you @-mention. **Foreman name** appears once, as where the alias lives in setup.

**"Confirm the agent roster" → "Design your factory."** Explains the foreman and the four default agents as components of the factory. "Roster" and "subagents" are gone.

**First work item comes from your own tools.** Slack mention or tracker assignment first; the **Runs** page is the fallback and the place you watch. That was the flow he said "actually feels wrong."

**Agent-driven creation surfaced.** `create_factory` via Factory MCP, which existed only as a table row. Scoped accurately to what the tool does — team, repositories, name — with agents and integrations chosen afterward.

## How Warp Factories work

Opens by explaining what a factory is instead of leading cold with inner/outer loop. Scorers no longer appear up front; they arrive under "How the factory improves itself," framed as *your factory is self-improving, and you define what better means*. **Work items and agent runs** is deleted, with its one useful fact folded into Stages. **What humans decide** moved above self-improvement and rewritten as "Where your team stays in charge" — the "very AI-y" copy is gone.

## Factory agents

Cut the Auto-memory store paragraph. Beyond his note that we "don't really have a real memory feature this way here," Agent Memory is a research preview, so linking factory readers to it overstated the product.

Rewrote the closing paragraphs from his screenshot. They now state the distinction plainly: spec approval and merging are conventions your team can change, but access comes from configuration and never from an agent's instructions — telling an agent to do something doesn't change what it can reach.

Simplified per "much simpler than this": dropped **Where verification happens**, which existed to explain the absence of a feature, and tightened the four agent descriptions.

## Infrastructure and security

**Environments are gone from the reader's view** — "should be completely opaque to a customer." The Environment/Runner comparison table is removed and the section is now just **Runners**.

**Per-agent runner selection documented.** His point that an implement agent can invoke a macOS runner is real and shipped (`AgentDefaultRunnerUID` in `model/types/factory.go`), but existed only as a key in the syntax reference.

## Factory MCP

Reframed bidirectionally on both its own page and the connect page: send work to the factory, or take work over from it. The tool count is gone.

Also swept role/roster/subagent vocabulary to "agents" section-wide.

## Not in this PR

Runner cost impact (macOS vs Linux) — no per-OS pricing exists in the docs and I won't invent numbers. The Slack product screenshot he asked for. Benchmarks removal, dashboard tab table, and the Scorer/self-improvement rewrite on `measure-and-improve`, which are queued in the plan.

## Validation

Build clean · 0 broken internal links · 0 anchor problems in `factories/` (several headings renamed or deleted; the 30 repo-wide failures are pre-existing and all outside this section) · style lint: 0 enforced violations on the changed files.

<!-- warp:pr-description-artifacts start -->
_Plans_:
- _[Aloke's Loom review: factory docs fixes](https://staging.warp.dev/drive/notebook/VnJHn2djbBR4HjDq99DBaS)_
<!-- warp:pr-description-artifacts end -->
