### PR TITLE
docs(platform): fix outdated integration pages after warp-server audit

### DIFF
--- a/src/content/docs/enterprise/team-management/admin-panel.mdx
+++ b/src/content/docs/enterprise/team-management/admin-panel.mdx
@@ -269,7 +269,7 @@ Controls how screenshots and video recordings captured with [Computer Use](/agen
 
 **Enabled GitHub Orgs**
 
-The **Enabled GitHub Orgs** setting associates your Warp team with one or more GitHub App installations. That association does two things: it lets cloud agents initiated with an [agent API key](/reference/cli/api-keys/) clone repositories and open pull requests using the Oz by Warp GitHub App, and it tells Warp which team owns runs started from the [GitHub integration](/platform/integrations/github/) when someone mentions `@oz-agent` in those repositories.
+The **Enabled GitHub Orgs** setting associates your Warp team with one or more GitHub App installations. That association does two things: it lets cloud agents initiated with an [agent API key](/reference/cli/api-keys/) clone repositories and open pull requests using the Oz by Warp GitHub App, and it tells Warp which team owns runs started from the [GitHub integration](/platform/integrations/github/) when someone mentions `@warp-agent` in those repositories.
 
 To configure:
 
@@ -285,7 +285,7 @@ To configure:
 The organizations and repository access shown here reflect the Oz by Warp GitHub App installation scope, which is configured in [GitHub settings](https://github.com/settings/installations). To change which repositories the app can access, edit the installation directly in GitHub.
 
 :::note
-This setting controls which GitHub App installation agent API key runs authenticate with, and which GitHub organizations can start [GitHub integration](/platform/integrations/github/) runs for this team. Runs from an `@oz-agent` mention also authenticate with the installation's GitHub App token, so their repository access comes from the app installation rather than the person who wrote the mention. Runs triggered from a personal API key, Slack, Linear, or the Warp app continue to use that user's own GitHub authorization. For more details, see [Team GitHub authorization](/platform/team-access-billing-and-identity/#team-github-authorization).
+This setting controls which GitHub App installation agent API key runs authenticate with, and which GitHub organizations can start [GitHub integration](/platform/integrations/github/) runs for this team. Runs from an `@warp-agent` mention also authenticate with the installation's GitHub App token, so their repository access comes from the app installation rather than the person who wrote the mention. Runs triggered from a personal API key, Slack, Linear, or the Warp app continue to use that user's own GitHub authorization. For more details, see [Team GitHub authorization](/platform/team-access-billing-and-identity/#team-github-authorization).
 :::
 
 ## Multi-admin functionality

--- a/src/content/docs/guides/agent-workflows/how-to-run-unattended-agents.mdx
+++ b/src/content/docs/guides/agent-workflows/how-to-run-unattended-agents.mdx
@@ -26,7 +26,7 @@ Use this table to decide where an unattended agent should start.
 | Scheduled agents | Work should run on a predictable cadence, like weekly triage, nightly dependency checks, or monthly cleanup. | [Scheduled Agents](/platform/triggers/scheduled-agents/) or the [Scheduled Agents quickstart](/platform/triggers/scheduled-agents-quickstart/) | {VARS.WEB_APP} Runs page, Agent Management Panel in the Warp app, schedule history, and cloud agent session links |
 | Slack | A teammate should delegate work from a Slack message or thread. | [Slack integration](/platform/integrations/slack/) | Slack thread updates, {VARS.WEB_APP} Runs page, Agent Management Panel in the Warp app, and the shared run session |
 | Linear | An issue, comment, or assignment should start the agent. | [Linear integration](/platform/integrations/linear/) | Linear issue updates, {VARS.WEB_APP} Runs page, Agent Management Panel in the Warp app, and the shared run session |
-| GitHub | Someone should delegate work by mentioning `@oz-agent` on an issue, pull request, or review comment. | [GitHub integration](/platform/integrations/github/) | GitHub thread comments, {VARS.WEB_APP} Runs page, Agent Management Panel in the Warp app, and the shared run session |
+| GitHub | Someone should delegate work by mentioning `@warp-agent` on an issue, pull request, or review comment. | [GitHub integration](/platform/integrations/github/) | GitHub thread comments, {VARS.WEB_APP} Runs page, Agent Management Panel in the Warp app, and the shared run session |
 | GitHub Actions | A repository event, PR workflow, issue workflow, or CI failure should start the agent. | [GitHub Actions](/platform/integrations/github-actions/) | GitHub Actions logs, PR or issue comments, {VARS.WEB_APP}, and cloud agent runs |
 | {VARS.WARP_AGENT_CLI} | You want to start a named cloud run from a terminal, script, or local automation. | [{VARS.WARP_AGENT_CLI}](/reference/cli/#running-agents-remotely-oz-agent-run-cloud) | CLI output, {VARS.WEB_APP} Runs page, Agent Management Panel in the Warp app, and cloud agent session links |
 | {VARS.API_SDK_NAME} | Your internal system should create, query, or monitor runs programmatically. | [{VARS.API_SDK_NAME}](/reference/api-and-sdk/) | Your system, API results, {VARS.WEB_APP}, and run sessions |
@@ -58,7 +58,7 @@ The agent posts progress updates back to the source thread or issue and provides
 
 ### Delegate work from a GitHub thread
 
-Use the [GitHub integration](/platform/integrations/github/) when the task starts from an issue, a pull request, or a review comment. Mention `@oz-agent` in the thread and the agent picks up that context, replies in place, and reports any pull request it opens. This fits:
+Use the [GitHub integration](/platform/integrations/github/) when the task starts from an issue, a pull request, or a review comment. Mention `@warp-agent` in the thread and the agent picks up that context, replies in place, and reports any pull request it opens. This fits:
 
 * asking for a fix from a review comment without leaving the diff
 * turning a bug report issue into a pull request
@@ -73,7 +73,7 @@ Use [GitHub Actions](/platform/integrations/github-actions/) when the trigger sh
 For example:
 
 * review a PR when it opens
-* respond to an `@oz-agent` comment
+* respond to an `@warp-agent` comment
 * summarize issues on a schedule
 * attempt a fix when CI fails
 * suggest fixes for review comments
@@ -132,6 +132,6 @@ Start with one narrow workflow before deploying many unattended agents:
 
 * [Scheduled Agents quickstart](/platform/triggers/scheduled-agents-quickstart/) - Create your first recurring agent in the {VARS.WEB_APP}.
 * [Integrations quickstart](/platform/integrations/quickstart/) - Trigger agents from Slack or Linear.
-* [GitHub integration](/platform/integrations/github/) - Set up `@oz-agent` mentions on issues and pull requests.
+* [GitHub integration](/platform/integrations/github/) - Set up `@warp-agent` mentions on issues and pull requests.
 * [GitHub Actions quickstart](/platform/integrations/quickstart-github-actions/) - Add an agent to a PR review workflow.
 * [Viewing cloud agent runs](/platform/viewing-cloud-agent-runs/) - Inspect and share unattended run sessions.

--- a/src/content/docs/guides/agent-workflows/set-up-a-software-factory.mdx
+++ b/src/content/docs/guides/agent-workflows/set-up-a-software-factory.mdx
@@ -157,7 +157,7 @@ The reviewer agent surfaces issues and inconsistencies; the human makes the fina
 
 * **Validate before the reviewer runs** — After the implementation agent opens a PR, run `/validate-changes-match-specs` to check the diff against `PRODUCT.md` and `TECH.md`. This catches any misalignments before the reviewer agent posts comments. The skill is available from [`warpdotdev/common-skills`](https://github.com/warpdotdev/common-skills).
 * **Start with triage only** — Get your triage agent running well before adding spec and implementation. A groomed, labeled backlog is immediately useful to every developer on the team.
-* **Use `@oz-agent` for one-off requests** — Teammates can mention `@oz-agent` in an issue comment to kick off an agent run directly, bypassing the label workflow for urgent requests.
+* **Use `@warp-agent` for one-off requests** — Teammates can mention `@warp-agent` in an issue comment to kick off an agent run directly, bypassing the label workflow for urgent requests.
 * **Monitor runs in the {VARS.WEB_APP}** — Every cloud agent run appears in the <a href={VARS.WEB_APP_URL}>{VARS.WEB_APP}</a> with a session link. Use it to inspect what each agent did, steer a stuck run, or hand work back to a local session.
 
 ## Next steps

--- a/src/content/docs/platform/integrations/bitbucket.mdx
+++ b/src/content/docs/platform/integrations/bitbucket.mdx
@@ -8,7 +8,7 @@ description: >-
 ---
 import { VARS } from '@data/vars';
 
-Cloud agents work with any Git repository, including those hosted on Bitbucket. Unlike GitHub, Bitbucket does not have a native Warp integration, but you can grant agents access to your Bitbucket repositories using an access token and Warp-managed secrets. Once configured, your environment works with any {VARS.WARP_AUTOMATION_PLATFORM} trigger—Slack, Linear, schedules, or the CLI.
+Cloud agents work with any Git repository, including those hosted on Bitbucket. Unlike GitHub and GitLab, Bitbucket does not have a native Warp integration, but you can grant agents access to your Bitbucket repositories using an access token and Warp-managed secrets. Once configured, your environment works with any {VARS.WARP_AUTOMATION_PLATFORM} trigger—Slack, Linear, schedules, or the CLI.
 
 This page explains how to generate a Bitbucket access token, store it securely, and configure a cloud agent environment that clones your repository at runtime.
 

--- a/src/content/docs/platform/integrations/cloud-providers.mdx
+++ b/src/content/docs/platform/integrations/cloud-providers.mdx
@@ -202,7 +202,7 @@ for example, you would run:
 
 ```bash
 gcloud projects add-iam-policy-binding <project-id> \
-    --member "principalSet://iam.googleapis.com/projects/<project-number>/locations/global/workloadIdentityPools/<pool-id>/attribute.teams/<team-id>" \
+    --member "principalSet://iam.googleapis.com/projects/<project-number>/locations/global/workloadIdentityPools/<pool-id>/group/<team-uid>" \
     --role "roles/compute.viewer"
 ```
 
@@ -253,11 +253,13 @@ Within the agent environment, use the `oz federate issue-token` command to produ
 with your provider as the audience:
 
 ```bash
-oz federate issue-token --audience your-provider.com --output-format json
+oz federate issue-token --run-id <RUN_ID> --audience your-provider.com --output-format json
 ```
 
-Optionally, add `--duration <duration>` to customize the token validity. This cannot exceed the
-maximum runtime of an agent.
+Replace `<RUN_ID>` with the current agent run's ID.
+
+Optionally, add `--duration <duration>` to customize the token validity. Tokens are valid for
+between 5 minutes and 3 hours.
 
 You can then exchange this token for provider-specific credentials.
 
@@ -319,8 +321,9 @@ curl https://app.warp.dev/api/v1/agent/runs -H "Authorization: Bearer $WARP_API_
 
 ### Team
 
-Every token includes a `teams` claim. The value will be a list with your team UID - currently, this
-list only ever contains a single value.
+Tokens for principals on a team include a `teams` claim listing the UIDs of the teams the
+principal belongs to. Users on multiple teams get multiple values, and users on no team get no
+`teams` claim.
 
 ### Run
 

--- a/src/content/docs/platform/integrations/github-actions.mdx
+++ b/src/content/docs/platform/integrations/github-actions.mdx
@@ -14,7 +14,7 @@ Run agents directly in your GitHub Actions workflows using `oz-agent-action`. Th
 :::
 
 :::note
-GitHub Actions is different from the [GitHub integration](/platform/integrations/github/). GitHub Actions runs agents inside workflows you define in your repository, and you control the trigger, permissions, and prompt in YAML. The GitHub integration starts agents when someone mentions `@oz-agent` on an issue, pull request, or review comment, using the Oz by Warp GitHub App with no workflow file.
+GitHub Actions is different from the [GitHub integration](/platform/integrations/github/). GitHub Actions runs agents inside workflows you define in your repository, and you control the trigger, permissions, and prompt in YAML. The GitHub integration starts agents when someone mentions `@warp-agent` on an issue, pull request, or review comment, using the Oz by Warp GitHub App with no workflow file.
 :::
 
 If you're comparing GitHub Actions with schedules, Slack, Linear, the GitHub integration, the {VARS.WARP_AGENT_CLI}, or API-triggered runs, see [Run agents unattended with schedules and triggers](/guides/agent-workflows/how-to-run-unattended-agents/).
@@ -113,7 +113,7 @@ The `oz-agent-action` supports several automation patterns commonly used in CI.
 * **Use case**: Add "@oz-agent fix this typo" or similar comments to a PR or Issue.
 
 :::note
-The [GitHub integration](/platform/integrations/github/) responds to the same `@oz-agent` mentions without a workflow file. Use this Actions pattern when you want the run to happen inside your CI pipeline with workflow-scoped permissions; use the GitHub integration when you want mention-triggered runs on every repository the Oz by Warp GitHub App can access.
+The [GitHub integration](/platform/integrations/github/) responds to `@warp-agent` mentions without a workflow file. Use this Actions pattern when you want the run to happen inside your CI pipeline with workflow-scoped permissions; use the GitHub integration when you want mention-triggered runs on every repository the Oz by Warp GitHub App can access.
 :::
 
 What it does:

--- a/src/content/docs/platform/integrations/github-actions.mdx
+++ b/src/content/docs/platform/integrations/github-actions.mdx
@@ -56,7 +56,7 @@ To use agents in GitHub Actions, you need:
 
 ### Using Skills
 
-Skills provide reusable instructions for agents. You can use pre-built skills from the [oz-skills repository](https://github.com/warpdotdev/oz-skills) or create custom [skills](/agents/capabilities/skills/) for your specific workflows. Skills can also be deployed as [standalone agents](/agents/capabilities/skills/#skills-as-agents) to run on a schedule or in response to events.
+Skills provide reusable instructions for agents. You can use pre-built skills from the [oz-skills repository](https://github.com/warpdotdev/oz-skills) or create custom [skills](/agents/capabilities/skills/) for your specific workflows. Skills can also be deployed as [standalone agents](/platform/skills-as-agents/) to run on a schedule or in response to events.
 
 #### How to use skills
 

--- a/src/content/docs/platform/integrations/github.mdx
+++ b/src/content/docs/platform/integrations/github.mdx
@@ -65,7 +65,7 @@ When a run for that thread is already in flight, a new mention is delivered to t
 ## Requirements
 
 * **Team membership** - The GitHub integration requires a [Warp team](/knowledge-and-collaboration/teams/). Configuration is team-scoped, and runs are owned by the team associated with the GitHub App installation.
-* **Plan and credits** - Your team must be on a Build, Max, or Business plan with at least 20 credits available, or on an Enterprise plan with a team credit pool per your contract. See [Access, billing, and identity](/platform/team-access-billing-and-identity/).
+* **Plan and credits** - Your team must have cloud agents enabled and credits available. On Enterprise plans, runs draw from a team credit pool per your contract. See [Access, billing, and identity](/platform/team-access-billing-and-identity/).
 * **Oz by Warp GitHub App** - A GitHub organization owner installs the [Oz by Warp](https://github.com/apps/oz-by-warp) GitHub App on the organization or account that owns the repositories, granting it access to all repositories or a selected set. The installation's repository access is what agents act with, so scope it deliberately.
 * **An enabled GitHub organization** - A Warp team admin adds the organization under **Enabled GitHub Orgs** in the Admin Panel so the installation maps to your Warp team.
 * **A connected GitHub account** - Each teammate connects their GitHub account to Warp once, so Warp can identify who triggered the run and which team to bill. The connection identifies the requester; it doesn't determine what the agent can reach on GitHub.
@@ -98,7 +98,7 @@ In the Warp app, a team admin goes to **Settings** > **Admin Panel** > **Platfor
 <figcaption>Enabled GitHub Orgs setting in the Admin Panel.</figcaption>
 </figure>
 
-Until the organization is enabled, mentions in its repositories return a comment asking a Warp team admin to enable the organization.
+Until the organization is enabled, mentions in its repositories return a comment asking a Warp workspace admin to configure GitHub repository access in the Admin Panel.
 
 ### 3. Configure how GitHub-triggered runs execute
 
@@ -144,12 +144,12 @@ Every GitHub-triggered run is a cloud agent run:
 
 GitHub-triggered runs separate **what the agent can do on GitHub** from **who the run belongs to**.
 
-**Access comes from the GitHub App installation.** A run started by an `@oz-agent` mention authenticates with a token minted for the Oz by Warp GitHub App installation that delivered the event, not with the mentioning user's GitHub authorization. Cloning, branches, commits, pull requests, and the status comments all use that installation token, so on GitHub the work is attributed to the Oz by Warp GitHub App rather than to the person who wrote the mention. The installation's repository selection is therefore the boundary on what the agent can reach: adjust it in your [GitHub settings](https://github.com/settings/installations).
+**Access comes from the GitHub App installation.** A run started by an `@oz-agent` mention authenticates with a token minted for the Oz by Warp GitHub App installation that delivered the event, not with the mentioning user's GitHub authorization. Cloning, branches, commits, pull requests, and the status comments all use that installation token, so on GitHub the work is attributed to the Oz by Warp GitHub App rather than to the person who wrote the mention. The boundary on what the agent can reach is the installation's repository selection, optionally narrowed further by the repository access a Warp admin grants the team in the Admin Panel. Adjust the installation in your [GitHub settings](https://github.com/settings/installations).
 
 **Identity comes from the account connection.** Warp matches the GitHub account that posted the mention to the Warp account that connected it, not by email address. That binding decides who the run is attributed to in Warp, which team owns it, and whose credits pay for it. The person must be a member of the Warp team that enabled the organization.
 
 :::caution
-Because the run uses the installation's access rather than the mentioner's, anyone who can comment in a repository covered by the installation — and who has a connected GitHub account on that Warp team — can start an agent that acts with the installation's full repository access. Grant the app only the repositories your team wants agents to work in.
+Because the run uses the installation's access rather than the mentioner's, anyone who can comment in a repository covered by the installation — and who has a connected GitHub account on that Warp team — can start an agent that acts with all the repository access granted to that team. Grant the app, and the team, only the repositories your team wants agents to work in.
 :::
 
 For fully automated workflows that run without a triggering user, such as scheduled agents or runs started with an agent API key, see [Team GitHub authorization](/platform/team-access-billing-and-identity/#team-github-authorization).
@@ -180,13 +180,13 @@ The event never reached Warp, or it was filtered out. Check in this order:
 
 Warp received the mention but couldn't match your GitHub account to a Warp account. Use the link in the reply to connect your GitHub account, then mention the agent again.
 
-### "This repository's GitHub App installation is not associated with a Warp team"
+### "This repository is not enabled for a Warp team"
 
-The app is installed, but no Warp team has enabled that GitHub organization. A Warp team admin adds the organization under **Enabled GitHub Orgs** in **Settings** > **Admin Panel** > **Platform** in the Warp app.
+The app is installed, but no Warp team has access to that repository. A Warp workspace admin configures GitHub repository access in **Settings** > **Admin Panel** > **Platform** in the Warp app.
 
-### "Your Warp account is not a member of any team associated with this repository"
+### "Your Warp account is not a member of any team with access to this repository"
 
-Your GitHub account is connected, but your Warp account isn't in the team that enabled the organization. Ask a team admin to add you to the Warp team.
+Your GitHub account is connected, but your Warp account isn't in a team with access to that repository. Ask a team admin to add you to the Warp team.
 
 ### The run starts but fails immediately
 

--- a/src/content/docs/platform/integrations/github.mdx
+++ b/src/content/docs/platform/integrations/github.mdx
@@ -3,12 +3,12 @@ title: GitHub integration
 sidebar:
   label: "GitHub"
 description: >-
-  Mention @oz-agent on a GitHub issue, pull request, or review comment to start
+  Mention @warp-agent on a GitHub issue, pull request, or review comment to start
   a cloud agent that replies in the thread and opens pull requests.
 ---
 import { VARS } from '@data/vars';
 
-The GitHub integration lets your team start cloud agents from GitHub itself. Mention **@oz-agent** in an issue comment, a pull request review comment, or the body of a new pull request, and Warp starts a cloud agent that reads the surrounding context, works the task in your codebase, and posts its progress and results back into the same thread.
+The GitHub integration lets your team start cloud agents from GitHub itself. Mention **@warp-agent** in an issue comment, a pull request review comment, or the body of a new pull request, and Warp starts a cloud agent that reads the surrounding context, works the task in your codebase, and posts its progress and results back into the same thread.
 
 The integration is powered by the **Oz by Warp** GitHub App. Once a team admin installs the app and enables the GitHub organization, every teammate who has connected their GitHub account can trigger agents from GitHub without leaving a review or an issue.
 
@@ -23,7 +23,7 @@ This page covers the native GitHub App integration. It is distinct from two othe
 
 ## What the GitHub integration does
 
-* **@oz-agent mentions** - Mention the agent in a comment or pull request body to start a cloud agent run with the issue or pull request as context.
+* **@warp-agent mentions** - Mention the agent in a comment or pull request body to start a cloud agent run with the issue or pull request as context.
 * **In-thread status** - Warp posts a status comment carrying the run link, then follows up with progress comments and a final summary in the same issue, pull request, or review thread.
 * **Thread-aware follow-ups** - Mention the agent again in the same thread and Warp continues the existing run instead of starting a new one.
 * **Automatic repository access** - The repository the event came from is cloned for the run, alongside any repositories in the environment you configure for the integration.
@@ -31,9 +31,9 @@ This page covers the native GitHub App integration. It is distinct from two othe
 
 ## How it works
 
-When you mention `@oz-agent`, GitHub sends the event to Warp through the Oz by Warp GitHub App installation. Warp then:
+When you mention `@warp-agent`, GitHub sends the event to Warp through the Oz by Warp GitHub App installation. Warp then:
 
-1. Confirms the comment or pull request body contains the `@oz-agent` mention and that the author is a person rather than a bot.
+1. Confirms the comment or pull request body contains the `@warp-agent` mention and that the author is a person rather than a bot.
 2. Maps the GitHub App installation to a Warp team using the organizations enabled in the Admin Panel.
 3. Maps the GitHub account that posted the mention to a Warp account, so the run is attributed to that person.
 4. Posts a status comment in the thread and starts the cloud agent run with the issue, pull request, or review thread as context.
@@ -43,12 +43,12 @@ The agent replies through Warp's status comments, which are posted by the GitHub
 
 ### Supported triggers
 
-The integration starts or continues a run for these GitHub events when the text contains `@oz-agent`:
+The integration starts or continues a run for these GitHub events when the text contains `@warp-agent`:
 
 * **Issue comments** - A new comment on an issue. Warp reads the issue title, description, labels, state, and the recent comment thread.
 * **Pull request comments** - A new top-level comment on a pull request. These continue the pull request's existing run when one exists.
 * **Pull request review comments** - A new inline review comment or a reply in a review thread. Warp reads the pull request, the review thread, and the diff of the commented file, and replies inside the same review thread.
-* **New pull requests** - A pull request opened with `@oz-agent` in its description. Warp reads the title, description, and the head and base branches.
+* **New pull requests** - A pull request opened with `@warp-agent` in its description. Warp reads the title, description, and the head and base branches.
 
 Mentions in other places don't start a run. Editing a comment to add the mention, mentioning the agent in an issue or pull request title, and mentions posted by bots are all ignored.
 
@@ -120,15 +120,15 @@ Each teammate connects their GitHub account so Warp can match the mention to a W
 
 Connect the account from the GitHub integration row in the {VARS.WEB_APP}, or the first time you trigger a run: when Warp can't match your GitHub account, it replies in the thread with a link to connect.
 
-## Using @oz-agent in GitHub
+## Using @warp-agent in GitHub
 
 Mention the agent and describe the task in the same comment:
 
-> @oz-agent this test is flaky on CI. Find the race condition and open a PR with a fix.
+> @warp-agent this test is flaky on CI. Find the race condition and open a PR with a fix.
 
 On a pull request review comment, the agent also receives the diff for the file you commented on, so you can ask for a targeted change:
 
-> @oz-agent rename this helper to `parseRepoRef` and update the call sites.
+> @warp-agent rename this helper to `parseRepoRef` and update the call sites.
 
 Warp responds in the thread with a status comment that links to the run, then posts progress updates as the agent works, and finally posts the agent's summary along with any pull requests it opened and branches it pushed.
 
@@ -144,7 +144,7 @@ Every GitHub-triggered run is a cloud agent run:
 
 GitHub-triggered runs separate **what the agent can do on GitHub** from **who the run belongs to**.
 
-**Access comes from the GitHub App installation.** A run started by an `@oz-agent` mention authenticates with a token minted for the Oz by Warp GitHub App installation that delivered the event, not with the mentioning user's GitHub authorization. Cloning, branches, commits, pull requests, and the status comments all use that installation token, so on GitHub the work is attributed to the Oz by Warp GitHub App rather than to the person who wrote the mention. The boundary on what the agent can reach is the installation's repository selection, optionally narrowed further by the repository access a Warp admin grants the team in the Admin Panel. Adjust the installation in your [GitHub settings](https://github.com/settings/installations).
+**Access comes from the GitHub App installation.** A run started by an `@warp-agent` mention authenticates with a token minted for the Oz by Warp GitHub App installation that delivered the event, not with the mentioning user's GitHub authorization. Cloning, branches, commits, pull requests, and the status comments all use that installation token, so on GitHub the work is attributed to the Oz by Warp GitHub App rather than to the person who wrote the mention. The boundary on what the agent can reach is the installation's repository selection, optionally narrowed further by the repository access a Warp admin grants the team in the Admin Panel. Adjust the installation in your [GitHub settings](https://github.com/settings/installations).
 
 **Identity comes from the account connection.** Warp matches the GitHub account that posted the mention to the Warp account that connected it, not by email address. That binding decides who the run is attributed to in Warp, which team owns it, and whose credits pay for it. The person must be a member of the Warp team that enabled the organization.
 
@@ -167,11 +167,11 @@ For fully automated workflows that run without a triggering user, such as schedu
 
 ## Troubleshooting
 
-### Nothing happens after mentioning @oz-agent
+### Nothing happens after mentioning @warp-agent
 
 The event never reached Warp, or it was filtered out. Check in this order:
 
-1. The comment body contains `@oz-agent`, spelled exactly, rather than only the issue or pull request title.
+1. The comment body contains `@warp-agent`, spelled exactly, rather than only the issue or pull request title.
 2. The Oz by Warp GitHub App is installed on the organization and has access to that repository.
 3. The mention was posted by a person. Bot-authored comments are ignored.
 4. The comment is new. Editing an existing comment to add the mention doesn't start a run.

--- a/src/content/docs/platform/integrations/gitlab.mdx
+++ b/src/content/docs/platform/integrations/gitlab.mdx
@@ -46,7 +46,7 @@ These steps generate a personal access token tied to your GitLab account. If you
 2. Click your avatar in the top-right corner, then click **Edit profile**.
 3. In the left sidebar, click **Access**, then click **Personal access tokens**.
 4. Click **Add new token**.
-5. Enter a descriptive name for the token (e.g. `warp-oz-agent`), and choose an expiration date that matches your team's rotation policy.
+5. Enter a descriptive name for the token (e.g. `warp-agent`), and choose an expiration date that matches your team's rotation policy.
 6. Under **Select scopes**, select **read\_repository**.
 7. Click **Generate token**.
 8. Copy the token value immediately. GitLab will not show it again.
@@ -124,6 +124,6 @@ oz agent run-cloud --environment <ENV_ID> --prompt "Your task here"
 
 With your environment configured, you can connect it to any Warp trigger:
 
-* **Slack** — Tag **@Oz** in a message to start an agent run against your GitLab repo. See [Slack](/platform/integrations/slack/).
-* **Linear** — Tag **@Oz** on an issue to kick off a workflow. See [Linear](/platform/integrations/linear/).
+* **Slack** — Tag **@warp** in a message to start an agent run against your GitLab repo. See [Slack](/platform/integrations/slack/).
+* **Linear** — Tag **@warp** on an issue to kick off a workflow. See [Linear](/platform/integrations/linear/).
 * **Scheduled agents** — Run agents on a recurring schedule. See [Scheduled Agents](/platform/triggers/scheduled-agents/).

--- a/src/content/docs/platform/integrations/gitlab.mdx
+++ b/src/content/docs/platform/integrations/gitlab.mdx
@@ -3,30 +3,40 @@ title: GitLab integration
 sidebar:
   label: "GitLab"
 description: >-
-  Connect cloud agents to GitLab repos using personal access tokens and
-  Warp-managed secrets.
+  Connect cloud agents to GitLab.com repos natively, or use access tokens and
+  Warp-managed secrets for self-managed instances.
 ---
 import { VARS } from '@data/vars';
 
-Cloud agents work with any Git repository, including those hosted on GitLab. Unlike GitHub, GitLab does not have a native Warp integration, but you can grant agents access to your GitLab repositories using a personal access token and Warp-managed secrets. Once configured, your environment works with any {VARS.WARP_AUTOMATION_PLATFORM} trigger—Slack, Linear, schedules, or the CLI.
+Cloud agents work natively with repositories hosted on GitLab.com. Connect your GitLab account when you create an environment in the <a href={VARS.WEB_APP_URL}>{VARS.WEB_APP}</a>, select the projects agents need, and Warp handles the rest at runtime: repositories are cloned automatically, your GitLab credentials are injected into the run, the `glab` CLI is authenticated, and agents can push branches and open merge requests on your behalf. Merge requests the agent opens are reported as run outputs.
 
-This page explains how to generate a GitLab personal access token, store it securely, and configure a cloud agent environment that clones your repository at runtime.
+For self-managed GitLab instances, native connection isn't available yet. Instead, grant agents access using a personal access token and Warp-managed secrets, as described in [Self-managed GitLab instances](#self-managed-gitlab-instances).
 
 :::note
-This approach works for both GitLab.com and self-hosted GitLab instances.
+To route GitLab activity into a factory — merge request events and bot mentions triggering work — see the [GitLab factory integration](/factories/integrations/gitlab/) instead. This page covers standalone cloud agent environments.
 :::
 
 ---
 
-## Prerequisites
+## Connect GitLab.com natively
 
-* A Warp account (<a href={VARS.WEB_APP_URL}>create an account at {VARS.WEB_APP_URL}</a>)
-* A repository hosted on GitLab (cloud or self-hosted)
-* The [{VARS.WARP_AGENT_CLI}](/reference/cli/) installed and authenticated
+1. In the <a href={VARS.WEB_APP_URL}>{VARS.WEB_APP}</a>, create or edit an [environment](/platform/environments/).
+2. Choose GitLab as the repository source and authorize with your GitLab account when prompted. Warp requests the `api` and `read_user` scopes, which grant read and write access to your projects.
+3. Select the projects the agent should clone, then finish configuring the environment (Docker image, setup commands).
+
+At the start of each run, Warp clones the selected repositories and injects your GitLab token, so agents can fetch, push branches, and open merge requests without extra setup. Once configured, the environment works with any {VARS.WARP_AUTOMATION_PLATFORM} trigger—Slack, Linear, schedules, or the CLI.
+
+:::note
+Native GitLab environment creation is available in the {VARS.WEB_APP} only. The `--repo` flag on `oz environment create` accepts GitHub repositories; to script GitLab environments, use the web app or the setup-command approach below.
+:::
 
 ---
 
-## Step 1: Generate a personal access token
+## Self-managed GitLab instances
+
+Native connection supports GitLab.com only. For a self-managed GitLab instance, generate a personal access token, store it securely, and configure an environment that clones your repository at runtime.
+
+### Step 1: Generate a personal access token
 
 :::note
 These steps generate a personal access token tied to your GitLab account. If your team prefers a shared bot user, [GitLab project access tokens](https://docs.gitlab.com/user/project/settings/project_access_tokens/) work the same way.
@@ -42,12 +52,10 @@ These steps generate a personal access token tied to your GitLab account. If you
 8. Copy the token value immediately. GitLab will not show it again.
 
 :::note
-**read\_repository** is the minimum required scope to clone a repository. If a future workflow requires the agent to push commits or open merge requests, you will also need **write\_repository**.
+**read\_repository** is the minimum required scope to clone a repository. If a workflow requires the agent to push commits or open merge requests, you also need **write\_repository**.
 :::
 
----
-
-## Step 2: Store the token as a Warp-managed secret
+### Step 2: Store the token as a Warp-managed secret
 
 Warp injects managed secrets as environment variables at runtime and never exposes them in logs or configuration files. See the [Secrets](/platform/secrets/) documentation for full details on scoping and managing secrets.
 
@@ -71,11 +79,9 @@ If you need to update a secret value, run:
 oz secret update --value GITLAB_TOKEN
 ```
 
----
+### Step 3: Create an environment with a clone setup command
 
-## Step 3: Create an environment with a clone setup command
-
-Create an environment that uses your token to clone the repository at the start of each agent run. Because the `--repo` flag in `oz environment create` is designed for GitHub repositories, you clone your GitLab repo via a setup command instead.
+Create an environment that uses your token to clone the repository at the start of each agent run.
 
 1. Run the following command:
 
@@ -83,7 +89,7 @@ Create an environment that uses your token to clone the repository at the start 
 oz environment create \
   --name "my-gitlab-env" \
   --docker-image <image> \
-  --setup-command 'git clone https://oauth2:$GITLAB_TOKEN@gitlab.com/your-group/your-repo.git' \
+  --setup-command 'git clone https://oauth2:$GITLAB_TOKEN@gitlab.example.com/your-group/your-repo.git' \
   --setup-command 'cd your-repo && <install dependencies>'
 ```
 
@@ -93,8 +99,7 @@ Use single quotes around setup commands that reference secrets. Double quotes ca
 
 2. Replace the following placeholders:
    * `<image>` with your Docker image (for example, `node:22`, `python:3.12`, or a [Warp prebuilt dev image](https://github.com/warpdotdev/oz-dev-environments))
-   * `gitlab.com/your-group/your-repo.git` with your actual repository URL
-   * For a self-hosted GitLab instance, replace `gitlab.com` with your server's hostname.
+   * `gitlab.example.com/your-group/your-repo.git` with your server's hostname and repository path
    * The second `--setup-command` with any dependency install or build steps your project requires. For example, `npm ci` or `pip install -r requirements.txt`.
 
 :::caution
@@ -103,9 +108,7 @@ Setup commands run on a fresh container for every agent run. Write them to be id
 
 3. Note the environment ID returned. You will need it in the next step.
 
----
-
-## Step 4: Test your environment
+### Step 4: Test your environment
 
 Before connecting to integrations, verify the environment works by running a one-off agent.
 
@@ -119,12 +122,8 @@ oz agent run-cloud --environment <ENV_ID> --prompt "Your task here"
 
 ## Next steps
 
-With your environment configured, you can connect it to any Warp trigger exactly as you would with a GitHub-backed environment:
+With your environment configured, you can connect it to any Warp trigger:
 
-* **Slack** — Tag **@warp** in a message to start an agent run against your GitLab repo. See [Slack](/platform/integrations/slack/).
-* **Linear** — Tag **@warp** on an issue to kick off a workflow. See [Linear](/platform/integrations/linear/).
+* **Slack** — Tag **@Oz** in a message to start an agent run against your GitLab repo. See [Slack](/platform/integrations/slack/).
+* **Linear** — Tag **@Oz** on an issue to kick off a workflow. See [Linear](/platform/integrations/linear/).
 * **Scheduled agents** — Run agents on a recurring schedule. See [Scheduled Agents](/platform/triggers/scheduled-agents/).
-
-:::note
-Native support for opening GitLab merge requests from agent-generated changes is planned as a future enhancement.
-:::

--- a/src/content/docs/platform/integrations/index.mdx
+++ b/src/content/docs/platform/integrations/index.mdx
@@ -17,7 +17,7 @@ Warp integrations let your team trigger agents directly from the terminal, or fr
 Integrations are one way to start a cloud agent. For the full set, including schedules, the {VARS.WARP_AGENT_CLI}, and the API, see [Triggers](/platform/triggers/). If you're deciding which one to use, see [Run agents unattended with schedules and triggers](/guides/agent-workflows/how-to-run-unattended-agents/).
 
 :::note
-Warp has two distinct GitHub surfaces. The [GitHub integration](/platform/integrations/github/) starts agents when someone mentions `@oz-agent` on an issue, pull request, or review comment, using the Oz by Warp GitHub App. [GitHub Actions](/platform/integrations/github-actions/) runs agents inside workflows you define in your own CI pipeline.
+Warp has two distinct GitHub surfaces. The [GitHub integration](/platform/integrations/github/) starts agents when someone mentions `@warp-agent` on an issue, pull request, or review comment, using the Oz by Warp GitHub App. [GitHub Actions](/platform/integrations/github-actions/) runs agents inside workflows you define in your own CI pipeline.
 :::
 
 Integrations run on the [{VARS.WARP_AUTOMATION_PLATFORM}](/platform/overview/) (formerly Oz), which handles the trigger, the [environment](/platform/environments/) the agent executes in, and the record of each run.
@@ -33,7 +33,7 @@ Use the setup walkthrough below for a quick look at how environments connect to 
 * [Integrations quickstart](/platform/integrations/quickstart/) - Trigger your first agent from Slack and watch the run from start to finish.
 * [Integration setup](/reference/cli/integration-setup/) - Configure environments, GitHub authorization, CLI flags, and integrations in more detail.
 * [Slack](/platform/integrations/slack/), [Linear](/platform/integrations/linear/), and [Jira](/platform/integrations/jira/) - Trigger agents from team conversations, issues, and comments.
-* [GitHub](/platform/integrations/github/) - Mention `@oz-agent` on issues, pull requests, and review comments to start agents that reply in the thread.
+* [GitHub](/platform/integrations/github/) - Mention `@warp-agent` on issues, pull requests, and review comments to start agents that reply in the thread.
 * [GitHub Actions](/platform/integrations/github-actions/) - Run agents from CI workflows and repository events.
 * [GitLab](/platform/integrations/gitlab/) - Connect GitLab.com repos natively, or self-managed instances with tokens and Warp-managed secrets.
 * [Bitbucket](/platform/integrations/bitbucket/) and [Azure DevOps](/platform/integrations/azure-devops/) - Connect repositories with tokens and Warp-managed secrets.

--- a/src/content/docs/platform/integrations/index.mdx
+++ b/src/content/docs/platform/integrations/index.mdx
@@ -35,6 +35,7 @@ Use the setup walkthrough below for a quick look at how environments connect to 
 * [Slack](/platform/integrations/slack/), [Linear](/platform/integrations/linear/), and [Jira](/platform/integrations/jira/) - Trigger agents from team conversations, issues, and comments.
 * [GitHub](/platform/integrations/github/) - Mention `@oz-agent` on issues, pull requests, and review comments to start agents that reply in the thread.
 * [GitHub Actions](/platform/integrations/github-actions/) - Run agents from CI workflows and repository events.
-* [GitLab](/platform/integrations/gitlab/), [Bitbucket](/platform/integrations/bitbucket/), and [Azure DevOps](/platform/integrations/azure-devops/) - Connect non-GitHub repositories with tokens and Warp-managed secrets.
+* [GitLab](/platform/integrations/gitlab/) - Connect GitLab.com repos natively, or self-managed instances with tokens and Warp-managed secrets.
+* [Bitbucket](/platform/integrations/bitbucket/) and [Azure DevOps](/platform/integrations/azure-devops/) - Connect repositories with tokens and Warp-managed secrets.
 * [AWS, GCP, and other cloud providers](/platform/integrations/cloud-providers/) - Give cloud agents short-lived access to cloud services.
 * [Managing cloud agents](/platform/managing-cloud-agents/) - Monitor and review integration-triggered runs across your team by source, status, or creator.

--- a/src/content/docs/platform/integrations/linear.mdx
+++ b/src/content/docs/platform/integrations/linear.mdx
@@ -69,9 +69,9 @@ Because PRs are created as _you_, this makes code review, auditing, and team col
 ### Requirements
 
 * **Team membership** - The Linear integration requires you to be part of a [Warp team](/knowledge-and-collaboration/teams/). Teams can be created on any plan, including Free.
-* **Plan and credits** - Your team must be on a plan that supports integrations (Build, Max, or Business) and have at least 20 credits available. See [Access, Billing, and Identity](/platform/team-access-billing-and-identity/) for details.
+* **Plan and credits** - Your team must have cloud agents enabled and credits available. See [Access, Billing, and Identity](/platform/team-access-billing-and-identity/) for details.
 * **Infrastructure** - By default, agents run on Warp-hosted infrastructure. Enterprise teams can [self-host agents](/platform/self-hosting/) on their own infrastructure.
-* **Identity** - You must be logged into Warp with the same email as your Linear workspace.
+* **Identity** - The first time you trigger an agent, Warp prompts you to connect your Linear identity to your Warp account.
 * **GitHub authorization** - You must authorize the Warp GitHub app the first time you trigger an agent.
   * The repositories involved must be included in your environment and accessible to the Warp GitHub app.
   * You must have write access to the repo if you want Warp to create PRs on your behalf.

--- a/src/content/docs/platform/integrations/quickstart.mdx
+++ b/src/content/docs/platform/integrations/quickstart.mdx
@@ -18,7 +18,7 @@ import { VARS } from '@data/vars';
 
 ## Prerequisites
 
-* **Eligible plan** - The Slack integration requires a Warp team on Build, Max, or Business plan with at least 20 credits available. See [Access, Billing, and Identity](/platform/team-access-billing-and-identity/).
+* **Eligible team** - The Slack integration requires a Warp team with cloud agents enabled and credits available. See [Access, Billing, and Identity](/platform/team-access-billing-and-identity/).
 * **A cloud environment** - Agents run inside a configured environment that includes repos and other dependencies. If you don't have one yet, follow the [Cloud Agents Quickstart](/platform/quickstart/) or run `/create-environment` in Warp.
 * **GitHub authorization** - Warp needs access to your repos to clone code and open PRs. You'll be prompted to authorize the Warp GitHub app when you first create the integration.
 

--- a/src/content/docs/platform/integrations/slack.mdx
+++ b/src/content/docs/platform/integrations/slack.mdx
@@ -74,7 +74,7 @@ To monitor Slack-triggered runs alongside the rest of your team's agents, open t
 
 ### Joining the live remote session
 
-Selecting **View conversation** or **View run in Oz** opens the active agent session. Inside the session you’ll see:
+Selecting **View conversation** opens the active agent session. Inside the session you’ll see:
 
 * The agent’s full execution log
 * The plan/task list

--- a/src/content/docs/platform/integrations/slack.mdx
+++ b/src/content/docs/platform/integrations/slack.mdx
@@ -30,7 +30,7 @@ The CLI opens a browser window to install the Warp app into your Slack workspace
 #### Requirements
 
 * **Team membership** - The Slack integration requires you to be part of a [Warp team](/knowledge-and-collaboration/teams/). Teams can be created on any plan, including Free.
-* **Plan and credits** - Your team must be on a plan that supports integrations (Build, Max, or Business) and have at least 20 credits available. See [Access, Billing, and Identity](/platform/team-access-billing-and-identity/) for details.
+* **Plan and credits** - Your team must have cloud agents enabled and credits available. See [Access, Billing, and Identity](/platform/team-access-billing-and-identity/) for details.
 * **Infrastructure** - By default, agents run on Warp-hosted infrastructure. Enterprise teams can [self-host agents](/platform/self-hosting/) on their own infrastructure.
 
 ---
@@ -74,7 +74,7 @@ To monitor Slack-triggered runs alongside the rest of your team's agents, open t
 
 ### Joining the live remote session
 
-Selecting **View Agent** opens the active agent session. Inside the session you’ll see:
+Selecting **View conversation** or **View run in Oz** opens the active agent session. Inside the session you’ll see:
 
 * The agent’s full execution log
 * The plan/task list
@@ -145,14 +145,14 @@ If the integration cannot be created or a Slack-triggered run cannot start, use 
 
 * Integrations are scoped to your Warp team.
 * Any teammate in the same Slack workspace and Warp team can use the integration.
-* Warp maps Slack users to Warp accounts by email address.
+* The first time you mention the bot or DM it, Warp sends you a link to connect your Slack identity to your Warp account.
 * Teammates must individually authorize GitHub on their first run.
 
 ---
 
 ### Privacy
 
-The Warp app reads Slack messages only where it is mentioned or directly messaged: the triggering message, its thread history (used as task context), and your Slack profile email (used to map you to your Warp account). Message content is used to run the agent task and is handled per the [Warp Privacy Policy](https://www.warp.dev/privacy), which describes how Warp collects, manages, and stores third-party data.
+The Warp app reads Slack messages only where it is mentioned or directly messaged: the triggering message, its thread history (used as task context), and your Slack profile information. Message content is used to run the agent task and is handled per the [Warp Privacy Policy](https://www.warp.dev/privacy), which describes how Warp collects, manages, and stores third-party data.
 
 ### Uninstallation instructions
 

--- a/src/content/docs/platform/oz-web-app.mdx
+++ b/src/content/docs/platform/oz-web-app.mdx
@@ -226,7 +226,7 @@ The **Integrations** page (`/integrations`) lets you configure first-party integ
 
 ### Available integrations
 
-<table><thead><tr><th width="120">Integration</th><th>Description</th></tr></thead><tbody><tr><td><strong>Slack</strong></td><td>Tag @warp in messages or threads to trigger agents directly from Slack conversations</td></tr><tr><td><strong>Linear</strong></td><td>Tag @warp on issues to trigger agents from your issue tracker</td></tr><tr><td><strong>GitHub</strong></td><td>Mention @oz-agent on issues, pull requests, and review comments to trigger agents from GitHub</td></tr></tbody></table>
+<table><thead><tr><th width="120">Integration</th><th>Description</th></tr></thead><tbody><tr><td><strong>Slack</strong></td><td>Tag @warp in messages or threads to trigger agents directly from Slack conversations</td></tr><tr><td><strong>Linear</strong></td><td>Tag @warp on issues to trigger agents from your issue tracker</td></tr><tr><td><strong>GitHub</strong></td><td>Mention @warp-agent on issues, pull requests, and review comments to trigger agents from GitHub</td></tr></tbody></table>
 
 <figure style={{ maxWidth: "563px" }}>
 ![The Integrations page in the Oz web app.](../../../assets/agent-platform/oz-web-app-integrations.png)

--- a/src/content/docs/platform/team-access-billing-and-identity.mdx
+++ b/src/content/docs/platform/team-access-billing-and-identity.mdx
@@ -62,12 +62,12 @@ A [Warp team](/knowledge-and-collaboration/teams/) is a group of users who share
 
 **What teams enable:**
 
-* **Integrations** - Create Slack, Linear, and Jira integrations that all team members can use, and enable the [GitHub integration](/platform/integrations/github/) so teammates can start agents with an `@oz-agent` mention
+* **Integrations** - Create Slack, Linear, and Jira integrations that all team members can use, and enable the [GitHub integration](/platform/integrations/github/) so teammates can start agents with an `@warp-agent` mention
 * **Shared configuration** - Team-level environments, secrets, and settings
 * **Self-hosting** - Run agents on your own infrastructure (Enterprise only)
 * **Team visibility** - Shared observability into agent runs and history
 
-Integrations are created at the team level, not per-user. Once a Slack or Linear integration is installed, everyone on your Warp team can use **@warp** in the connected workspace. The integration behaves the same way for all teammates, and everyone shares the same underlying environment configuration. The GitHub integration is team-level in the same way: once an admin enables the GitHub organization, any teammate with a connected GitHub account can start a run by mentioning **@oz-agent**.
+Integrations are created at the team level, not per-user. Once a Slack or Linear integration is installed, everyone on your Warp team can use **@warp** in the connected workspace. The integration behaves the same way for all teammates, and everyone shares the same underlying environment configuration. The GitHub integration is team-level in the same way: once an admin enables the GitHub organization, any teammate with a connected GitHub account can start a run by mentioning **@warp-agent**.
 
 When someone triggers a cloud agent for the first time, Warp may prompt them to grant GitHub authorization so the agent can open pull requests or push branches under their identity. This allows each run to use the correct permissions without requiring additional setup from an admin.
 
@@ -98,11 +98,11 @@ Warp needs a reliable way to know which person a cloud agent run is acting for, 
 
 * Slack uses a dedicated account-linking flow to map a Slack user to their Warp account. This is the recommended path for Slack-triggered agents, since it doesn’t rely on email matching.
 * Linear currently maps identities using email address matching. Your Linear email must match your Warp account email for Warp to correctly attribute and scope agent runs.
-* The [GitHub integration](/platform/integrations/github/) maps the GitHub account that mentioned `@oz-agent` to the Warp account that connected it, rather than by email. Until a teammate connects their GitHub account, Warp replies in the thread with a link to connect instead of starting a run. That binding sets run attribution, team ownership, and billing; the run's GitHub access comes from the app installation instead.
+* The [GitHub integration](/platform/integrations/github/) maps the GitHub account that mentioned `@warp-agent` to the Warp account that connected it, rather than by email. Until a teammate connects their GitHub account, Warp replies in the thread with a link to connect instead of starting a run. That binding sets run attribution, team ownership, and billing; the run's GitHub access comes from the app installation instead.
 * Each teammate must authorize GitHub before an agent can write PRs or push branches on their behalf
 * For Slack-triggered, Linear-triggered, and locally triggered runs, agents operate using the GitHub permissions of the triggering user
 
-This ensures runs are scoped to what the user is allowed to see and modify, and that ownership of PRs remains clear across teams and repositories. The two exceptions are agent API key runs with [team GitHub authorization](#team-github-authorization) and runs started from an `@oz-agent` mention, which both authenticate as the Oz by Warp GitHub App installation.
+This ensures runs are scoped to what the user is allowed to see and modify, and that ownership of PRs remains clear across teams and repositories. The two exceptions are agent API key runs with [team GitHub authorization](#team-github-authorization) and runs started from an `@warp-agent` mention, which both authenticate as the Oz by Warp GitHub App installation.
 
 ---
 
@@ -159,7 +159,7 @@ Team GitHub authorization is complementary to the existing personal token flow:
 
 * **User-triggered runs** (personal API key, Slack, Linear, Warp app) - The agent authenticates using the triggering user's personal token. PRs and commits are attributed to that user.
 * **Agent API key runs with GitHub App authorization** - The agent authenticates as the GitHub App installation. On GitHub, PRs and commits are attributed to the Oz by Warp GitHub App rather than any individual user. In the {VARS.DASHBOARD}, the run is attributed to the bound [cloud agent](/platform/agents/), which controls run filtering and audit attribution on the Warp side.
-* **[GitHub integration](/platform/integrations/github/) runs** (an `@oz-agent` mention on an issue or pull request) - The agent authenticates as the installation that delivered the event, so its repository access and its GitHub attribution match the agent API key flow. In the {VARS.DASHBOARD} the run is still attributed to the teammate who wrote the mention, and their team is billed.
+* **[GitHub integration](/platform/integrations/github/) runs** (an `@warp-agent` mention on an issue or pull request) - The agent authenticates as the installation that delivered the event, so its repository access and its GitHub attribution match the agent API key flow. In the {VARS.DASHBOARD} the run is still attributed to the teammate who wrote the mention, and their team is billed.
 
 These flows can coexist on the same team. Personal tokens are still used for user-triggered runs from a personal API key, Slack, Linear, and the Warp app, and the GitHub App installation token is used for agent API key runs and for GitHub integration runs.
 
@@ -202,7 +202,7 @@ Warp’s behavior in GitHub is defined by two layers of control:
 * Are included in the environment configuration
 * Are accessible to both the GitHub app and the triggering user.
 
-Runs triggered by an `@oz-agent` mention through the [GitHub integration](/platform/integrations/github/) follow the first layer only. Warp receives the content of the issue, pull request, or review thread that carried the mention, including the recent comments and the diff of a commented file, and the run authenticates with the GitHub App installation that delivered the event. Cloning, commits, branches, pull requests, and status comments all use that installation's access rather than the mentioning user's, so the installation's repository selection is the only boundary on what those runs can reach. The repository that triggered the mention is cloned alongside any repositories in the configured environment, and only the repositories that installation covers are available to the agent.
+Runs triggered by an `@warp-agent` mention through the [GitHub integration](/platform/integrations/github/) follow the first layer only. Warp receives the content of the issue, pull request, or review thread that carried the mention, including the recent comments and the diff of a commented file, and the run authenticates with the GitHub App installation that delivered the event. Cloning, commits, branches, pull requests, and status comments all use that installation's access rather than the mentioning user's, so the installation's repository selection is the only boundary on what those runs can reach. The repository that triggered the mention is cloned alongside any repositories in the configured environment, and only the repositories that installation covers are available to the agent.
 
 ---
 

--- a/src/content/docs/platform/triggers/index.mdx
+++ b/src/content/docs/platform/triggers/index.mdx
@@ -18,7 +18,7 @@ If you're choosing between schedules, Slack, Linear, GitHub, GitHub Actions, the
 * **[CLI](/reference/cli/)** - Trigger cloud agents directly from your terminal using the {VARS.WARP_AGENT_CLI}.
 * **[API & SDK](/reference/api-and-sdk/)** - Programmatically trigger agents via the Warp API or SDK.
 * **[Integrations](/platform/integrations/)** - Trigger agents from external services like Slack, Linear, or Jira.
-* **[GitHub](/platform/integrations/github/)** - Mention `@oz-agent` on an issue, pull request, or review comment to start an agent that replies in the thread.
+* **[GitHub](/platform/integrations/github/)** - Mention `@warp-agent` on an issue, pull request, or review comment to start an agent that replies in the thread.
 * **[GitHub Actions](/platform/integrations/github-actions/)** - Run agents from your own CI workflows and repository events.
 
 After a trigger fires, track and review the resulting runs across your team from the [Agent Management Panel and {VARS.WEB_APP} Runs page](/platform/managing-cloud-agents/), where you can filter by source, status, day, or creator.

--- a/src/content/docs/reference/cli/integration-setup.mdx
+++ b/src/content/docs/reference/cli/integration-setup.mdx
@@ -230,7 +230,7 @@ The CLI then:
 3. Generates an **integration ID** you can later list or delete.
 
 :::note
-The [GitHub integration](/platform/integrations/github/), which starts agents from `@oz-agent` mentions on issues and pull requests, isn't created with `oz integration create`. It's set up by installing the Oz by Warp GitHub App and enabling the GitHub organization in the Admin Panel.
+The [GitHub integration](/platform/integrations/github/), which starts agents from `@warp-agent` mentions on issues and pull requests, isn't created with `oz integration create`. It's set up by installing the Oz by Warp GitHub App and enabling the GitHub organization in the Admin Panel.
 :::
 
 **Additional `integration create` flags:**


### PR DESCRIPTION
Audited all platform integration pages against warp-server HEAD (Aug 17). Fixes confirmed-wrong claims only.

- `gitlab.mdx` rewritten: native GitLab.com support is live (web app OAuth env picker, auto-clone, `glab` auth, MRs as run outputs). PAT + setup-command flow scoped to self-managed instances. Dropped "MR support planned". Cross-links the factories GitLab page.
- Slack/Linear/factory-slack: "maps users by email" → account-binding connect link (`slack_account_binding`/`linear_account_binding` on in prod); Slack button names match server (`View conversation`/`View run in Oz`).
- GitHub: both quoted error strings match server copy (`github.go:384,408`); permissions section reflects per-team repo scoping (`SetGithubInstallationTeamAccess`).
- Stale "Build/Max/Business plan + 20 credits" gate → "cloud agents enabled and credits available" (no such gate server-side; free tier has ambient agents).
- cloud-providers: `oz federate issue-token` missing required `--run-id`; GCP IAM binding used unmapped `attribute.teams` → `group/<team-uid>`; teams claim + duration bounds corrected.
- index/bitbucket: GitLab out of the token-only bucket; GHA broken skills anchor.

Verified: `npm run build` passes.

Not touched (unverified or bigger rewrites): GHA "runs in cloud" framing, quickstart cloud callout, Linear "Open in Warp" label, "Enabled GitHub Orgs" UI label, @warp handles.

[Conversation](https://staging.warp.dev/conversation/b0dc70da-b8fd-4835-9139-7a30d9e23303)

Co-Authored-By: Warp <agent@warp.dev>

Update: renamed GitHub integration handle `@oz-agent` → `@warp-agent` across 10 pages (warp-server #15306; factory handle `@warp-factory` already correct in factories docs). GHA `oz-agent` user refs left as-is.
