### PR TITLE
docs(factories): link the warp-factory-examples repository

### DIFF
--- a/src/content/docs/factories/factory-agents.mdx
+++ b/src/content/docs/factories/factory-agents.mdx
@@ -86,7 +86,7 @@ Default model IDs change over time, so choose based on what each agent has to do
 | Implement | Coding strength, with a harness that fits your repositories and toolchain |
 | Review | A different model or harness from the implement agent, so the two don't share blind spots |
 
-See [model choice for agents](/agents/inference/model-choice/) and [harnesses for cloud agents](/platform/harnesses/) for available options. Define reusable procedures with [skills](/agents/capabilities/skills/), and scope each agent's external access through [MCP servers](/platform/mcp/) and [cloud agent secrets](/platform/secrets/).
+See [model choice for agents](/agents/inference/model-choice/) and [harnesses for cloud agents](/platform/harnesses/) for available options. Define reusable procedures with [skills](/agents/capabilities/skills/), and scope each agent's external access through [MCP servers](/platform/mcp/) and [cloud agent secrets](/platform/secrets/). For a working definition that runs a different harness per agent, see the [multi-harness example](https://github.com/warpdotdev/warp-factory-examples/tree/main/examples/03-multi-harness) in the warp-factory-examples repository.
 
 ## Add custom agents and automations
 

--- a/src/content/docs/factories/factory-as-code.mdx
+++ b/src/content/docs/factories/factory-as-code.mdx
@@ -321,6 +321,8 @@ A skill is a directory containing a `SKILL.md`, not a YAML key. Skills under `sk
 
 A complete, working definition: one repository, a foreman, an automation triggered by a GitHub label, and a Linux runner. `PAYMENTS_ENVIRONMENT_ID` and `SENTRY_MCP_SERVER_ID` stand in for the IDs of an existing environment and MCP server.
 
+For complete definitions you can copy and register, see the [warp-factory-examples repository](https://github.com/warpdotdev/warp-factory-examples): the default agents as files, a minimal quickstart, a full software development lifecycle factory with scorers and a benchmark suite, and a multi-harness factory.
+
 ```yaml title="factory.yaml"
 schemaVersion: v1alpha1
 name: payments-factory

--- a/src/content/docs/factories/factory-as-code.mdx
+++ b/src/content/docs/factories/factory-as-code.mdx
@@ -321,7 +321,7 @@ A skill is a directory containing a `SKILL.md`, not a YAML key. Skills under `sk
 
 A complete, working definition: one repository, a foreman, an automation triggered by a GitHub label, and a Linux runner. `PAYMENTS_ENVIRONMENT_ID` and `SENTRY_MCP_SERVER_ID` stand in for the IDs of an existing environment and MCP server.
 
-For complete definitions you can copy and register, see the [warp-factory-examples repository](https://github.com/warpdotdev/warp-factory-examples): the default agents as files, a minimal quickstart, a full software development lifecycle factory with scorers and a benchmark suite, and a multi-harness factory.
+For complete definitions you can copy and register, see the [warp-factory-examples repository](https://github.com/warpdotdev/warp-factory-examples): the default agents as files, a minimal quickstart, a full software development lifecycle factory with scorers, and a multi-harness factory.
 
 ```yaml title="factory.yaml"
 schemaVersion: v1alpha1


### PR DESCRIPTION
Adds two links to [warpdotdev/warp-factory-examples](https://github.com/warpdotdev/warp-factory-examples):

- **factory-as-code** \u2192 the example-definition section points at the repo's four complete, registerable definitions (default agents as files, quickstart, full SDLC with scorers + a benchmark suite, multi-harness).
- **factory-agents** \u2192 the models-and-harnesses section points at the multi-harness example.

**Draft on purpose: do not merge until the examples repository is public** (tracked in warp-factory-examples#8) \u2014 until the flip these links 404 for readers.

Co-Authored-By: Warp <agent@warp.dev>