### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/src/content/docs/guides/external-tools/how-to-set-up-gbr.mdx
+++ b/src/content/docs/guides/external-tools/how-to-set-up-gbr.mdx
@@ -1,3 +1,29 @@
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
 ---
 title: Set up Build Remote Agent
 description: >-
@@ -21,15 +47,6 @@ This is **not** [Warp Remote Control](/agents/cli-agents/remote-control/). Remot
 
 ## 1. Install gbr-agent
 
-```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version    # need v0.6.0+
-```
-
-```powershell
-irm https://grokbuildremote.com/install.ps1 | iex
-gbr-agent version
-```
 
 ## 2. Pair the phone
 
@@ -74,3 +91,10 @@ Add that stdio server in **Settings → Agents → MCP servers**, or see [Connec
 * [Third-party CLI agents](/agents/cli-agents/overview/)
 * [Remote Control](/agents/cli-agents/remote-control/) (cloud publish — different product)
 * [Connect agents to MCP servers](/guides/external-tools/using-mcp-servers-with-warp/)
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/src/content/docs/guides/external-tools/how-to-set-up-gbr.mdx
+++ b/src/content/docs/guides/external-tools/how-to-set-up-gbr.mdx
@@ -1,0 +1,76 @@
+---
+title: Set up Build Remote Agent
+description: >-
+  Pair a phone running Build Remote Agent to a Warp session with gbr-agent
+  (gbr/1). Local spectator via 127.0.0.1:8788 or gbr-mcp — not Warp Remote Control.
+sidebar:
+  label: "Set up Build Remote Agent"
+tags:
+  - "third-party-tools"
+---
+
+[Build Remote Agent](https://grokbuildremote.com/) is a phone app plus the free MIT [`gbr-agent`](https://github.com/LinespottingOrg/GrokBuildRemote-Agents). Pair it to this machine so the phone can **spectate** (and optionally inject into) a Warp / CLI-agent session. Protocol `gbr/1`. Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+This is **not** [Warp Remote Control](/agents/cli-agents/remote-control/). Remote Control publishes a session to Warp's cloud so a phone or browser can steer it. Build Remote Agent stays on **loopback**: `gbr-agent pair` / `run`, then attach `http://127.0.0.1:8788` or stdio `gbr-mcp`. Do not mix the two.
+
+## Prerequisites
+
+* macOS or Linux (Windows install script is listed below)
+* `gbr-agent` **v0.6.0+**
+* A phone with Build Remote Agent
+
+## 1. Install gbr-agent
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version    # need v0.6.0+
+```
+
+```powershell
+irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version
+```
+
+## 2. Pair the phone
+
+```bash
+gbr-agent pair
+```
+
+The command opens a browser QR **and** prints an 8-character code. On the phone: open Build Remote Agent → scan the QR **or** type the code. Then:
+
+```bash
+gbr-agent run
+```
+
+Leave `gbr-agent run` running. Unpair in the phone app before switching PCs — force-close is not enough.
+
+## 3. Attach (only these)
+
+| How | Where |
+|-----|--------|
+| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
+| MCP | stdio `gbr-mcp` (same JSON as Bot API) |
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
+Phone is spectator + veto, not orchestrator. Warp (or Claude Code / Codex / Gemini CLI running **inside** Warp) stays in charge on the desktop.
+
+## MCP (optional)
+
+```bash
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+node bin/gbr-mcp.js --diagnose
+```
+
+Add that stdio server in **Settings → Agents → MCP servers**, or see [Connect agents to MCP servers](/guides/external-tools/using-mcp-servers-with-warp/). Never put mailbox keys in Warp MCP config. Phone **Settings → Bot API** is the only place the relay key is copied.
+
+## Related
+
+* [Third-party CLI agents](/agents/cli-agents/overview/)
+* [Remote Control](/agents/cli-agents/remote-control/) (cloud publish — different product)
+* [Connect agents to MCP servers](/guides/external-tools/using-mcp-servers-with-warp/)

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -903,6 +903,7 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
 						{ slug: 'guides/external-tools/how-to-set-up-opencode', label: 'Set up OpenCode' },
 						{ slug: 'guides/external-tools/how-to-set-up-gemini-cli', label: 'Set up Gemini CLI' },
 						{ slug: 'guides/external-tools/how-to-set-up-ollama', label: 'Set up Ollama for local models' },
+        { slug: 'guides/external-tools/how-to-set-up-gbr', label: 'Set up Build Remote Agent' },
 						{ slug: 'guides/external-tools/sentry-mcp-fix-sentry-error-in-empower-website', label: 'Sentry MCP: fix errors' },
 						{ slug: 'guides/external-tools/figma-remote-mcp-create-a-website-from-a-figma-file-from-scratch', label: 'Figma remote MCP: create a website from a Figma file' },
 						{ slug: 'guides/external-tools/linear-mcp-retrieve-issue-data', label: 'Linear MCP: retrieve issue data' },


### PR DESCRIPTION
## What

How-to page for pairing a phone running **Build Remote Agent** to a Warp session. Contrasts with Warp Remote Control (cloud publish/steer): GBR stays loopback (`gbr-agent pair` / `run`, attach `:8788` or `gbr-mcp`).

Files:
- `src/content/docs/guides/external-tools/how-to-set-up-gbr.mdx`
- one nav row in `src/sidebar.ts`

## How

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version          # v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```

Phone is spectator + veto. Protocol `gbr/1`. Independent product by Linespotting AB. Not affiliated with xAI or SpaceX. No mailbox keys.