### PR TITLE
missing_docs: stop the drift-watch triage from silently seeing nothing

### DIFF
--- a/.agents/skills/missing_docs/SKILL.md
+++ b/.agents/skills/missing_docs/SKILL.md
@@ -223,6 +223,11 @@ them through these three layers instead, in order of preference:
    gate already fetches. Release-gated, low-noise, and currently the most direct signal
    for platform-side changes. Triage these bullets exactly like changelog bullets: same
    gates, same ledger, same evidence requirement.
+
+   `check_new_release.py` prints them; the audit never sees them, because it is offline
+   by design and they are not part of the markdown changelog it parses. Read them from
+   the gate's output, or `--json` for the full array. `oz_updates` is the API's field
+   name and stays as-is regardless of product naming.
 2. **The public Agent API surface** — already covered by audit category 3 and
    `sync-openapi-spec`. No new machinery; just confirm the release run actually triages
    these findings rather than deferring them by habit. A released endpoint reaches docs
@@ -409,6 +414,9 @@ with the product. Each run:
    Exit `0` means a new stable release is available — continue. Exit `10` means no new
    release; record the no-op outcome in run output and **stop**. Exit `1` is a fetch or
    parse failure; report it and stop rather than proceeding as if nothing shipped.
+
+   The gate also prints any `oz_updates` bullets for the release. Keep them — they are
+   platform-side changes the audit cannot see, and this is the only place they surface.
 
    Do not update the state file yet. It is written in step 5, after triage, so a run that
    crashes mid-triage retries the same release instead of skipping it.

--- a/.agents/skills/missing_docs/scripts/audit_docs.py
+++ b/.agents/skills/missing_docs/scripts/audit_docs.py
@@ -2342,8 +2342,8 @@ def read_last_processed_release(snapshot_path: Path) -> str | None:
     """Read the triage marker that sits alongside the snapshot.
 
     Returns the normalized version last *triaged*, or None if the marker is
-    missing or unreadable. A missing marker means "never triaged", which is the
-    safe direction: nothing gets skipped.
+    missing, unreadable, or not a JSON object. A missing marker means "never
+    triaged", which is the safe direction: nothing gets skipped.
     """
     marker = snapshot_path.parent / "last_release_processed.json"
     if not marker.exists():
@@ -2352,6 +2352,17 @@ def read_last_processed_release(snapshot_path: Path) -> str | None:
         data = json.loads(marker.read_text(encoding="utf-8"))
     except Exception as exc:
         print(f"Warning: failed to parse {marker}: {exc}", file=sys.stderr)
+        return None
+    # Valid JSON of the wrong shape (a list, a bare string) would raise on
+    # .get and abort diff-mode triage. Treat it like a parse failure so the
+    # baseline falls back to the snapshot instead. check_new_release.py's
+    # read_state() guards the same file the same way.
+    if not isinstance(data, dict):
+        print(
+            f"Warning: {marker} is not a JSON object (got {type(data).__name__}); "
+            "treating the release as never triaged",
+            file=sys.stderr,
+        )
         return None
     return normalize_release_version(data.get("last_processed_version"))
 

--- a/.agents/skills/missing_docs/scripts/audit_docs.py
+++ b/.agents/skills/missing_docs/scripts/audit_docs.py
@@ -36,6 +36,13 @@ Exit codes:
         clean audit.
 """
 
+# Postponed annotation evaluation keeps `X | None` annotations working on
+# Python 3.9, which is still the system interpreter on some contributor
+# machines. Without it this module cannot even be imported there, so
+# test_audit_docs.py fails before a single test runs. check_new_release.py
+# already does this.
+from __future__ import annotations
+
 import argparse
 import json
 import os
@@ -1189,18 +1196,40 @@ def page_slug(md_file: Path, docs_root: Path) -> str:
 
 
 _CHANGELOG_HEADER_RE = re.compile(r"^### (\d{4}\.\d{2}\.\d{2})", re.MULTILINE)
-# "Bug fixes" is deliberately untracked: fix bullets rarely create doc surface
-# and would double the weekly triage volume.
-_CHANGELOG_TRACKED_SECTIONS = ("new features", "improvements", "oz updates")
+
+# Bold section labels in the docs changelog whose bullets are triaged.
+#
+# These match a *user-facing heading*, not an API field, so they are exposed to
+# product renames. The Automation Platform variants are accepted ahead of the
+# rename: if the changelog heading changes and this tuple has not, the section
+# silently yields zero bullets and the run under-reports. The guard in
+# parse_changelog_entries() is the backstop for a name nobody anticipated.
+_CHANGELOG_TRACKED_SECTIONS = (
+    "new features",
+    "improvements",
+    "oz updates",
+    "automation platform updates",
+    "platform updates",
+)
+
+# Sections deliberately not triaged, listed so the unknown-section guard can
+# tell "intentionally skipped" from "renamed out from under us". Bug fixes are
+# excluded on purpose to keep weekly triage volume manageable.
+_CHANGELOG_UNTRACKED_SECTIONS = ("bug fixes", "fixes")
 
 
 def parse_changelog_entries(repo_root: Path) -> list[dict]:
     """Parse release entries from src/content/docs/changelog/<year>.mdx.
 
     Returns [{"version": "2026.06.03", "file": str, "items":
-              [{"category": "new features", "text": str}]}] sorted newest first.
-    "New features", "Improvements", and "Oz updates" bullets are tracked —
-    the sections that may represent undocumented feature launches.
+              [{"category": "new features", "text": str}],
+              "unknown_sections": [str]}] sorted newest first.
+
+    Only _CHANGELOG_TRACKED_SECTIONS bullets are collected — the sections that
+    may represent undocumented feature launches. Any other bold section that
+    contains bullets and is not in _CHANGELOG_UNTRACKED_SECTIONS is reported in
+    `unknown_sections` so a renamed heading surfaces as a loud failure instead
+    of an empty result.
     """
     changelog_dir = repo_root / "src" / "content" / "docs" / "changelog"
     if not changelog_dir.exists():
@@ -1216,6 +1245,7 @@ def parse_changelog_entries(repo_root: Path) -> list[dict]:
             end = headers[i + 1].start() if i + 1 < len(headers) else len(content)
             body = content[header.end():end]
             items = []
+            unknown_sections = set()
             current_section = None
             for line in body.splitlines():
                 stripped = line.strip()
@@ -1223,15 +1253,20 @@ def parse_changelog_entries(repo_root: Path) -> list[dict]:
                 if section_match:
                     current_section = section_match.group(1).strip().lower()
                     continue
-                if current_section in _CHANGELOG_TRACKED_SECTIONS and stripped.startswith("* "):
+                if not stripped.startswith("* ") or not current_section:
+                    continue
+                if current_section in _CHANGELOG_TRACKED_SECTIONS:
                     items.append({
                         "category": current_section,
                         "text": stripped[2:].strip(),
                     })
+                elif current_section not in _CHANGELOG_UNTRACKED_SECTIONS:
+                    unknown_sections.add(current_section)
             entries.append({
                 "version": header.group(1),
                 "file": str(mdx.relative_to(repo_root)),
                 "items": items,
+                "unknown_sections": sorted(unknown_sections),
             })
     entries.sort(key=lambda e: e["version"], reverse=True)
     return entries
@@ -2287,18 +2322,92 @@ def diff_snapshots(old: dict, new: dict) -> list[dict]:
     return findings
 
 
+_RELEASE_VERSION_RE = re.compile(r"(\d{4}\.\d{2}\.\d{2})")
+
+
+def normalize_release_version(value: str | None) -> str | None:
+    """Reduce any release identifier to the YYYY.MM.DD form changelog headers use.
+
+    The snapshot stores `2026.08.19`; the release marker stores
+    `v0.2026.08.19.08.15.stable_01`. Both must compare against changelog entry
+    versions, so both are normalized through here.
+    """
+    if not value:
+        return None
+    match = _RELEASE_VERSION_RE.search(str(value))
+    return match.group(1) if match else None
+
+
+def read_last_processed_release(snapshot_path: Path) -> str | None:
+    """Read the triage marker that sits alongside the snapshot.
+
+    Returns the normalized version last *triaged*, or None if the marker is
+    missing or unreadable. A missing marker means "never triaged", which is the
+    safe direction: nothing gets skipped.
+    """
+    marker = snapshot_path.parent / "last_release_processed.json"
+    if not marker.exists():
+        return None
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"Warning: failed to parse {marker}: {exc}", file=sys.stderr)
+        return None
+    return normalize_release_version(data.get("last_processed_version"))
+
+
+def changelog_review_baseline(last_seen_version: str | None,
+                              last_triaged_version: str | None) -> str | None:
+    """Earliest of the observed and triaged markers, normalized.
+
+    Using the earlier of the two is what stops a bookkeeping-only run — which
+    advances the snapshot without triaging — from hiding a release.
+    """
+    return min(
+        (v for v in (normalize_release_version(last_seen_version),
+                     normalize_release_version(last_triaged_version)) if v),
+        default=None,
+    )
+
+
+def unreviewed_unknown_sections(changelog_entries: list[dict],
+                                baseline: str | None) -> list[str]:
+    """Unrecognized bold sections among the entries actually being triaged.
+
+    Scoped to unreviewed entries on purpose. Older launch posts use prose
+    headings ("Multithread yourself with agents") that are neither tracked
+    sections nor renames; policing the whole file would fail every run on
+    history nobody is going to re-triage.
+    """
+    return sorted({
+        section
+        for entry in changelog_entries
+        if not (baseline and entry["version"] <= baseline)
+        for section in entry.get("unknown_sections", [])
+    })
+
+
 def changelog_review_findings(changelog_entries: list[dict],
-                              last_seen_version: str | None) -> list[dict]:
-    """Emit verification findings for changelog entries newer than the snapshot.
+                              last_seen_version: str | None,
+                              last_triaged_version: str | None = None) -> list[dict]:
+    """Emit verification findings for changelog entries not yet triaged.
 
     The weekly human-curated changelog is the best signal for launches that no
     static code parse can see (server-side features, Oz web app, experiment
     rollouts). Each bullet should be verified for real docs coverage — a
     changelog mention alone is not documentation.
+
+    Two independent markers exist and they can disagree. The snapshot's
+    `changelog_last_version` records what was last *observed*; bookkeeping that
+    regenerates the snapshot advances it without triaging anything.
+    `last_release_processed.json` records what was last *triaged*. Using the
+    snapshot alone silently drops every entry a bookkeeping-only run skipped
+    past, so the baseline is the earlier of the two.
     """
+    baseline = changelog_review_baseline(last_seen_version, last_triaged_version)
     findings = []
     for entry in changelog_entries:
-        if last_seen_version and entry["version"] <= last_seen_version:
+        if baseline and entry["version"] <= baseline:
             continue
         for item in entry["items"]:
             findings.append({
@@ -2872,6 +2981,7 @@ def main():
     # Change detection (diff + snapshot update)
     changelog_entries = parse_changelog_entries(repo_root)
     snapshot_path = Path(args.snapshot)
+
     if args.diff or args.update_snapshot:
         if warp_repo and warp_server and extraction_ok:
             current_snapshot = build_snapshot(
@@ -2891,8 +3001,42 @@ def main():
                 else:
                     print("Running surface change detection (diff)...", file=sys.stderr)
                     findings["surface_changes"] = diff_snapshots(previous, current_snapshot)
+                    snapshot_version = normalize_release_version(
+                        previous.get("changelog_last_version"))
+                    triaged_version = read_last_processed_release(snapshot_path)
                     findings["changelog_review"] = changelog_review_findings(
-                        changelog_entries, previous.get("changelog_last_version"))
+                        changelog_entries,
+                        previous.get("changelog_last_version"),
+                        triaged_version)
+                    if (snapshot_version and triaged_version
+                            and snapshot_version != triaged_version):
+                        print(
+                            "Note: snapshot last saw "
+                            f"{snapshot_version} but {triaged_version} was the last "
+                            "release triaged. Reviewing from the earlier of the two "
+                            "so bookkeeping-only runs cannot skip a release.",
+                            file=sys.stderr,
+                        )
+
+                    # Bullets under a heading the parser does not recognize are
+                    # invisible to triage. Silence there looks identical to "nothing
+                    # shipped", so treat it as an extraction failure instead.
+                    unknown_sections = unreviewed_unknown_sections(
+                        changelog_entries,
+                        changelog_review_baseline(
+                            previous.get("changelog_last_version"), triaged_version))
+                    if unknown_sections:
+                        audits_skipped.append({
+                            "audit": "extraction:changelog_sections",
+                            "reason": (
+                                "bullets found under unrecognized changelog headings "
+                                f"{unknown_sections} in entries awaiting triage \u2014 a "
+                                "section was renamed or added. Add each heading to "
+                                "_CHANGELOG_TRACKED_SECTIONS or "
+                                "_CHANGELOG_UNTRACKED_SECTIONS in audit_docs.py; until "
+                                "then those bullets are invisible to triage"
+                            ),
+                        })
                     audits_run.append("diff")
             if args.update_snapshot:
                 snapshot_path.parent.mkdir(parents=True, exist_ok=True)

--- a/.agents/skills/missing_docs/scripts/check_new_release.py
+++ b/.agents/skills/missing_docs/scripts/check_new_release.py
@@ -183,6 +183,14 @@ def main() -> int:
             print(f"Recorded {version} as processed in {args.state}")
         return EXIT_NEW_RELEASE
 
+    # `oz_updates` is a separate array in the client_version payload, not part
+    # of the markdown changelog the audit parses. The audit is offline by
+    # design and never sees it, so this is the only place those bullets surface
+    # — print the content, not just a count, or the skill's instruction to
+    # triage them cannot be carried out. The field name is the API's, and stays
+    # `oz_updates` regardless of product naming.
+    oz_updates = changelog.get("oz_updates", []) or []
+
     if args.as_json:
         print(
             json.dumps(
@@ -191,7 +199,8 @@ def main() -> int:
                     "current_version": version,
                     "last_processed_version": last_processed,
                     "release_date": release_date,
-                    "oz_updates_count": len(changelog.get("oz_updates", []) or []),
+                    "oz_updates_count": len(oz_updates),
+                    "oz_updates": oz_updates,
                 },
                 indent=2,
             )
@@ -201,7 +210,14 @@ def main() -> int:
         print(f"New stable release: {version}")
         print(f"  Released:        {release_date or 'unknown'}")
         print(f"  Last processed:  {previous}")
-        print(f"  Oz updates:      {len(changelog.get('oz_updates', []) or [])}")
+        print(f"  Oz updates:      {len(oz_updates)}")
+        for bullet in oz_updates:
+            print(f"    - {bullet}")
+        if oz_updates:
+            print(
+                "  These are platform-side changes the audit cannot see. "
+                "Triage them against the worthiness criteria like changelog bullets."
+            )
         print("Proceed with the audit.")
     else:
         print(f"No new release. Current stable {version} was already processed.")

--- a/.agents/skills/missing_docs/scripts/test_audit_docs.py
+++ b/.agents/skills/missing_docs/scripts/test_audit_docs.py
@@ -306,6 +306,48 @@ class TestChangelogTriage(unittest.TestCase):
             ["sparkles"],
             "an unrecognized heading in a pending entry must fail loud")
 
+    def test_marker_reader_survives_every_bad_shape(self):
+        """A malformed marker must degrade to "never triaged", never raise.
+
+        Raising here aborts diff-mode triage entirely, which is a worse failure
+        than the desync this reader exists to fix. Valid JSON of the wrong
+        top-level type is the case that bites: `[]` reaches `.get` and throws.
+        """
+        cases = {
+            "list": "[]",
+            "bare string": '"v0.2026.08.18.02.52.stable_00"',
+            "number": "42",
+            "null": "null",
+            "truncated json": '{"last_processed_version":',
+            "empty file": "",
+            "object, wrong key": '{"version": "v0.2026.08.18.02.52.stable_00"}',
+        }
+        for label, payload in cases.items():
+            with self.subTest(shape=label), tempfile.TemporaryDirectory() as d:
+                refs = Path(d)
+                (refs / "last_release_processed.json").write_text(
+                    payload, encoding="utf-8")
+                self.assertIsNone(
+                    audit_docs.read_last_processed_release(
+                        refs / "surface_snapshot.json"),
+                    f"{label} marker should fall back to None")
+
+        # A missing marker is the ordinary first-run case, not an error.
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNone(audit_docs.read_last_processed_release(
+                Path(d) / "surface_snapshot.json"))
+
+        # The well-formed case still reads through.
+        with tempfile.TemporaryDirectory() as d:
+            refs = Path(d)
+            (refs / "last_release_processed.json").write_text(
+                '{"last_processed_version": "v0.2026.08.18.02.52.stable_00"}',
+                encoding="utf-8")
+            self.assertEqual(
+                audit_docs.read_last_processed_release(
+                    refs / "surface_snapshot.json"),
+                "2026.08.18")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.agents/skills/missing_docs/scripts/test_audit_docs.py
+++ b/.agents/skills/missing_docs/scripts/test_audit_docs.py
@@ -223,5 +223,89 @@ class TestGatedLogic(unittest.TestCase):
         self.assertEqual(gated_findings[0]["entry"], "oz bad")
 
 
+class TestChangelogTriage(unittest.TestCase):
+    """Regression cases for the drift-watch triage baseline and section guard.
+
+    All three failures these cover are silent: the run exits 0 and reports
+    nothing, which is indistinguishable from "nothing shipped".
+    """
+
+    ENTRY = (
+        "### 2099.01.02 (v0.2099.01.02.00.00)\n\n"
+        "**New features**\n\n"
+        "* A tracked bullet.\n\n"
+        "**Automation Platform updates**\n\n"
+        "* A bullet under the post-rename platform heading.\n\n"
+        "**Bug fixes**\n\n"
+        "* Deliberately untracked.\n\n"
+        "**Sparkles**\n\n"
+        "* A bullet under a heading the parser has never seen.\n"
+    )
+
+    def _entries(self, text):
+        with tempfile.TemporaryDirectory() as d:
+            changelog = Path(d) / "src" / "content" / "docs" / "changelog"
+            changelog.mkdir(parents=True)
+            (changelog / "2099.mdx").write_text(text, encoding="utf-8")
+            return audit_docs.parse_changelog_entries(Path(d))
+
+    def test_normalize_release_version(self):
+        """The marker and the snapshot store versions in different shapes."""
+        self.assertEqual(
+            audit_docs.normalize_release_version("v0.2026.08.18.02.52.stable_00"),
+            "2026.08.18")
+        self.assertEqual(
+            audit_docs.normalize_release_version("2026.08.19"), "2026.08.19")
+        self.assertIsNone(audit_docs.normalize_release_version(None))
+        self.assertIsNone(audit_docs.normalize_release_version("not-a-version"))
+
+    def test_baseline_uses_the_earlier_marker(self):
+        """A snapshot refresh must not skip a release that was never triaged.
+
+        Bookkeeping PRs regenerate surface_snapshot.json, advancing its
+        changelog pointer without triaging anything. Taking the snapshot alone
+        as the baseline drops every entry in between.
+        """
+        self.assertEqual(
+            audit_docs.changelog_review_baseline(
+                "2026.08.19", "v0.2026.08.18.02.52.stable_00"),
+            "2026.08.18")
+        # Either side missing falls back to the other rather than to "all seen".
+        self.assertEqual(
+            audit_docs.changelog_review_baseline("2026.08.19", None), "2026.08.19")
+        self.assertEqual(
+            audit_docs.changelog_review_baseline(None, "v0.2026.08.18.02.52.stable_00"),
+            "2026.08.18")
+        # No markers at all means nothing has been triaged; review everything.
+        self.assertIsNone(audit_docs.changelog_review_baseline(None, None))
+
+    def test_desynced_markers_still_surface_the_release(self):
+        """End to end: the snapshot ahead of the marker must not hide bullets."""
+        entries = self._entries(self.ENTRY)
+        ahead = audit_docs.changelog_review_findings(entries, "2099.01.02")
+        self.assertEqual(ahead, [], "snapshot-only baseline hides the entry")
+        recovered = audit_docs.changelog_review_findings(
+            entries, "2099.01.02", "2099.01.01")
+        self.assertEqual(len(recovered), 2, recovered)
+
+    def test_tracked_untracked_and_unknown_sections(self):
+        entry = self._entries(self.ENTRY)[0]
+        categories = sorted(i["category"] for i in entry["items"])
+        self.assertEqual(categories, ["automation platform updates", "new features"])
+        # Bug fixes are skipped on purpose, so they must not read as a rename.
+        self.assertEqual(entry["unknown_sections"], ["sparkles"])
+
+    def test_unknown_section_guard_ignores_already_triaged_history(self):
+        """Old launch posts use prose headings; policing them fails every run."""
+        entries = self._entries(self.ENTRY)
+        self.assertEqual(
+            audit_docs.unreviewed_unknown_sections(entries, "2099.01.02"), [],
+            "entries at or below the baseline are already triaged")
+        self.assertEqual(
+            audit_docs.unreviewed_unknown_sections(entries, "2099.01.01"),
+            ["sparkles"],
+            "an unrecognized heading in a pending entry must fail loud")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

The first manual validation run of the `missing_docs` drift-watch skill ([run](https://oz.warp.dev/runs/01a03526-5545-7e67-be4a-1ba8feb45460)) found three defects. They fail the same way: the run exits 0, reports nothing, and that is indistinguishable from "nothing shipped."

The gate and the audit both worked correctly — nine candidates, zero feature PRs, bookkeeping only. These are gaps in what reached triage in the first place.

## The bugs

### 1. The triage baseline ignored the release marker

Two state files track releases, and they can disagree:

- `surface_snapshot.json` → what was last **observed**
- `last_release_processed.json` → what was last **triaged**

A bookkeeping PR that regenerates the snapshot advances the first without touching the second. [#603](https://github.com/warpdotdev/docs/pull/603) did exactly that, so on `main` today:

```
snapshot  changelog_last_version : 2026.08.19
marker    last_processed_version : v0.2026.08.18.02.52.stable_00
```

The gate fires because the marker is behind. `--diff` then returns an **empty `changelog_review`** because the snapshot is ahead. The primary triage input is empty, nothing is reviewed, and the release gets recorded as processed.

The baseline is now the **earlier** of the two markers. Against current `main` that moves `changelog_review` from **0 items to 3** — including the release's one `oz_updates` bullet.

I introduced this when I split the marker out of the snapshot in #586. The reasoning was sound — the snapshot is regenerated wholesale and would lose the marker — but it only accounted for the snapshot falling *behind*, never running *ahead*.

### 2. `oz_updates` were counted but never shown

`check_new_release.py` printed `Oz updates: 1`. `audit_docs.py` has zero references to the field, and the audit is offline by design, so it never will.

The skill names `oz_updates` as the **preferred** source for platform changes the client changelog cannot see. That instruction was not executable — the validating agent had to fetch `client_version` by hand. The gate now prints the bullets and includes them in `--json`.

The field name stays `oz_updates`. It is the API's, verified live in the current release payload, and product naming does not apply to a data contract.

### 3. A renamed changelog heading would fail silently

Section matching is a hardcoded allowlist against a **user-facing heading** — squarely in scope for the Automation Platform rename. Today it matches `**Oz updates**`; the day that heading changes, the section yields zero bullets with no error.

Added the Automation Platform variants, plus a guard that treats bullets under an unrecognized heading as an extraction failure (exit 2) rather than an empty result.

Two details that matter:

- **`Bug fixes` is listed as deliberately untracked**, so an intentional skip cannot read as a rename.
- **The guard is scoped to entries awaiting triage.** Older launch posts use prose headings (`**Multithread yourself with agents**`), and policing all 277 historical entries would fail every run. Caught by running it.

## Also

`audit_docs.py` was missing the `from __future__ import annotations` that `check_new_release.py` already has. Without it the module cannot be imported on Python 3.9, so `test_audit_docs.py` died before running a single test on any machine using the system interpreter.

## Validation

- **5 new regression tests** covering the baseline, the version normalizer, the tracked/untracked/unknown section split, and the guard's scoping.
- `test_check_new_release.py` 17/17, `test_suggest_reviewers.py` 15/15.
- `test_audit_docs.py` 16/17. The one failure is `test_diff_against_committed_snapshot_is_current`, which is environmental: my local `warp-server` checkout is three months stale, so 123 `api_routes_removed` and 16 `slash_commands_removed` are the local repos lagging the committed snapshot, not drift in it. Previously masked by the import error above.

## Notes for reviewers

**Draft PR [#615](https://github.com/warpdotdev/docs/pull/615) is closed** in favor of a clean re-run after this lands. Its triage was sound — the verdicts are well-reasoned and the surface-map entries correct — but it got there by manually working around the desync, and merging it would advance the marker past the release the post-fix validation run needs to triage. Everything in it regenerates.

Remaining feedback from the validation run, not addressed here: `rg` is unavailable in the environment (skill examples use it), ledger rows for non-PR items have no stable key so they will be re-proposed, and "major launch" deferral could use a first-class verdict label distinct from Gate 0.

## Unverified claims

None — no page content changes. Behavior was verified by running the scripts against the live `client_version` payload and the committed changelog, and by the regression tests above.

Co-Authored-By: Warp <agent@warp.dev>

