### PR TITLE
docs(factory-api): remove the SDK-rename note

### DIFF
--- a/src/content/docs/factories/factory-api.mdx
+++ b/src/content/docs/factories/factory-api.mdx
@@ -121,10 +121,6 @@ Content-Type: application/json
 
 See [key endpoints](/reference/api-and-sdk/#key-endpoints) for the full set of run-management operations, including cancellation.
 
-:::note
-The {VARS.API_SDK_NAME} is in the middle of a rename to align with the {VARS.WARP_AUTOMATION_PLATFORM}: today's `oz_agent_sdk` package and `OzAPI` client will eventually carry renamed Warp Agent and factory API names. The endpoints and fields on this page keep working across that rename; watch the [Python SDK](https://github.com/warpdotdev/oz-sdk-python) and [TypeScript SDK](https://github.com/warpdotdev/oz-sdk-typescript) repos for the updated names.
-:::
-
 ## Related pages
 
 * [Connect your factory](/factories/connect-your-factory/) - Every way work can enter a factory, including the factory API alongside Slack, GitHub, and Factory MCP.


### PR DESCRIPTION
## Summary
Removes the `:::note` on the [factory API page](https://docs.warp.dev/factories/factory-api) about the Oz API & SDK being mid-rename (`oz_agent_sdk` package / `OzAPI` client eventually carrying Warp Agent and factory API names), per follow-up feedback on #609.

Nothing else on the page changes. The `VARS` import stays; it's still used by the Related pages list.

## Verification
- `npm run build` passes.

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
