### PR TITLE
missing_docs: fast-follows from the drift-watch validation runs

### DIFF
--- a/.agents/skills/missing_docs/SKILL.md
+++ b/.agents/skills/missing_docs/SKILL.md
@@ -56,6 +56,27 @@ a fresh sandbox does not have. Install once per sandbox:
 npm ci
 ```
 
+### Regenerate the snapshot only from current checkouts
+
+`--update-snapshot` rewrites `references/surface_snapshot.json` from whatever the sibling
+repos hold at that moment, and it cannot tell a current checkout from a stale one. Running
+it against an old or feature-branched `warp` / `warp-server` writes a baseline describing
+surfaces that are not on the default branch, and the next `--diff` then reports the gap
+between two wrong baselines as real drift. Confirm both repos are current and on their
+default branch — `main` for `warp`, `develop` for `warp-server` — before regenerating:
+
+```bash
+for repo in ../warp ../warp-server; do
+  git -C "$repo" fetch --quiet origin
+  echo "$repo $(git -C "$repo" rev-parse --abbrev-ref HEAD) \
+$(git -C "$repo" log -1 --format=%cd --date=short)"
+done
+```
+
+A cloud sandbox provisions fresh checkouts and satisfies this by construction; a
+developer's machine usually does not. When you cannot confirm it, leave the regen to a
+scheduled run rather than committing a snapshot you cannot vouch for.
+
 ## Public vs. private surfaces (what you may document)
 
 Only document surfaces that are **publicly released**. This is the most important guardrail in this skill: do not reveal private or unreleased surfaces in public docs. Two independent gates, both required:
@@ -66,6 +87,7 @@ Only document surfaces that are **publicly released**. This is the most importan
 Rules of thumb:
 - A `warp-server` API endpoint that is **not already in the OpenAPI spec** is treated as not-yet-public: do NOT hand-write docs for it. Either confirm it has been publicly released and let the `sync-openapi-spec` skill bring it into the spec, or map it `-> internal` / defer it. When unsure, defer — never expose an unreleased endpoint or feature in public docs.
 - A CLI command or API route gated by a **non-GA feature flag** should be mapped `-> gated:<Flag>` (for example, `gated:AIMemories`) rather than `-> internal`: the audit auto-defers it while the flag is non-GA and auto-surfaces it for docs once the flag goes GA. (Feature flags and settings already auto-defer by rollout status; `gated:` extends that to CLI/API.)
+- **A published docs page is not evidence that an API is released.** Early Access features routinely have public pages describing what the product does while their REST routes stay out of the released spec, so "we already document this feature" does not clear Gate 0 for an endpoint. For API surfaces the released OpenAPI spec is the only test. The Factory pages describe dispatching a run, yet no `/factory` path appears in `developers/agent-api-openapi.yaml` — those routes are Gate 0 deferrals despite the prose.
 - The audit still *detects* these as gaps (useful signal), but detection is not permission to document. Every resolution must respect this boundary.
 
 This section is the source of truth for **Gate 0** in
@@ -121,6 +143,15 @@ The script performs these coverage audits:
 4. **Slash command coverage** — parses the static registry in the warp client repo's
    `app/src/search/slash_command_menu/static_commands/` and checks each `/command`
    is mentioned in docs.
+
+   **Known limitation: this check is repo-wide, not surface-scoped.** A command counts as
+   covered when *any* page mentions it (`audit_slash_commands` in `scripts/audit_docs.py`
+   searches every docs page), so a command documented on the GUI slash-commands page reads
+   as covered even when the CLI reference omits it. That is how `/usage` reached a release
+   undocumented for CLI users — only the changelog cross-check caught it. The CLI and
+   settings audits scope their search to the pages that own those surfaces; this one does
+   not. Until that is fixed, do not read a slash command's `doc_covered` bucket as
+   "documented in the right place."
 5. **Settings coverage** — parses every `toml_path: "section.key"` setting
    registration in the warp client repo (the same registry the JSON-schema generator uses)
    and checks the all-settings reference page documents it. Private and
@@ -402,6 +433,8 @@ Add `--reviewers-only` to get just the comma-joined `--add-reviewer` argument (e
 Then **actually request the review on GitHub** with `gh pr edit <PR> --add-reviewer <logins/teams>`. A `/cc @engineer` line in the PR body is not a review request: it puts nothing in the engineer's review queue. All four ambient-drafted docs PRs (#414, #415, #416, #417) named reviewers in prose and got zero reviews, three of them with an empty requested-reviewers list.
 
 An individual unresolved *path* is non-fatal — other paths usually resolve the same owner. An empty *result* is not: fall back to `dannyneira` rather than opening the PR with no reviewer. See step 7 of drift-watch mode for the required command.
+
+**Expect warp-server-only findings to fall back.** The warp client repo's ownership file has a root rule, so nearly any path in it resolves. warp-server's does not, and whole areas — the `/factory` handlers among them — carry no entry, so a finding whose only source file is a warp-server handler resolves to nothing and lands on `dannyneira`. That is the fallback doing its job; report it that way rather than as a resolution failure. Do not hardcode an owner here to paper over it — the fix belongs in warp-server's ownership file, and once an entry exists resolution starts working with no change to this skill.
 
 ### PR strategy: one PR per feature
 

--- a/.agents/skills/missing_docs/SKILL.md
+++ b/.agents/skills/missing_docs/SKILL.md
@@ -63,7 +63,7 @@ repos hold at that moment, and it cannot tell a current checkout from a stale on
 it against an old or feature-branched `warp` / `warp-server` writes a baseline describing
 surfaces that are not on the default branch, and the next `--diff` then reports the gap
 between two wrong baselines as real drift. Confirm both repos are current and on their
-default branch — `main` for `warp`, `develop` for `warp-server` — before regenerating:
+default branch — `master` for `warp`, `develop` for `warp-server` — before regenerating:
 
 ```bash
 for repo in ../warp ../warp-server; do

--- a/.agents/skills/missing_docs/SKILL.md
+++ b/.agents/skills/missing_docs/SKILL.md
@@ -567,6 +567,24 @@ A run that gates out every candidate is a successful run. It opens no feature PR
 only the bookkeeping PR recording the verdicts. Do not manufacture work to justify the
 run.
 
+#### Schedule setup
+
+Two configuration choices decide whether the schedule behaves, and neither is visible from
+the prompt below:
+
+- **Select a cloud agent, not Quick run.** Quick run executes as the calling user, so its
+  pull requests are authored by that person — which for a schedule means whoever created
+  it. Selecting a cloud agent runs as that agent instead, and with team GitHub
+  authorization configured its pull requests are authored by the Warp Factories GitHub
+  App. Any schedule that opens PRs wants the agent. See
+  [Cloud agent accounts](https://docs.warp.dev/platform/agents/).
+- **Give that agent this skill and nothing else.** A run inherits every skill attached to
+  the agent it runs as, and the schedule form will not let you detach an agent-level
+  skill. Pointing drift-watch at a general-purpose docs agent therefore pulls that agent's
+  other skills into every run — and a weekly release-updates skill that defaults to
+  running all of its tasks will do exactly that, daily. Create a dedicated agent rather
+  than reusing one that already carries other work.
+
 Recommended scheduled-agent prompt (copy when setting up the agent):
 
 > Run the missing_docs skill in drift-watch mode. Work from the docs repo root — every


### PR DESCRIPTION
## Summary

Catch-all for the fast-follow items accumulated while validating the drift-watch pipeline. Documentation-only — no script or behavior changes.

Each item was reproduced against the current code rather than carried over from run notes. Two items from the original feedback list turned out to be already handled and are **not** included:

- The stash-based branch split — the skill only ever recommends `git checkout <ref> -- <files>`; `stash` appears nowhere in the skill.
- Bookkeeping PRs shipping without a reviewer — #619 already made the fallback mandatory and verified against read-back.

## Changes

**1. Snapshot regen has an unstated environment precondition.** `--update-snapshot` rewrites the baseline from whatever the sibling repos hold at that moment and cannot tell a current checkout from a stale one. Regenerating from a feature-branched `warp` or a months-old `warp-server` silently writes surfaces that aren't on the default branch — and the next `--diff` then compares two wrong baselines and reports the gap as real drift. The skill says "regenerate with `--update-snapshot`; never hand-edit" and nothing about where it's valid to do so.

This came up concretely during the #624 rebase: the snapshot conflict looked like it needed regeneration, and regenerating locally would have corrupted it. Running the newly documented check on this machine:

```
../warp         rrenk/notify-docs-settings-changed  2026-07-21
../warp-server  develop                             2026-05-21
```

A feature branch and a three-month-old checkout. Neither is a valid basis for a snapshot.

**2. Gate 0 lacked the Early Access case.** A published docs page describing a feature is not evidence that its API is released — EA features routinely have public prose while their REST routes stay out of the released spec. The `/factory` routes are exactly this shape: `factories/factory-api.mdx` describes dispatching a run, but no `/factory` path appears in `developers/agent-api-openapi.yaml`. Both drift-watch runs deferred them correctly, but on judgment rather than a written rule, and the next run has to re-derive it.

**3. Slash-command coverage is repo-wide, not surface-scoped.** `audit_slash_commands` counts a command as covered when *any* docs page mentions it. So `/usage` read as covered from the GUI slash-commands page while both CLI pages omitted it, and only the changelog cross-check caught the gap. The CLI and settings audits scope their search to the pages that own those surfaces; this one searches everything.

Recorded as a known limitation rather than fixed here. Narrowing the scope changes which commands become findings, so it needs its own PR and a look at the resulting volume — not a line buried in a catch-all.

**4. warp-server findings routinely resolve to no owner.** The warp client repo has a root ownership rule so nearly any path resolves; warp-server has none, and the `/factory` handlers carry no entry. Reproduced directly:

```
$ suggest_reviewers.py warp-server:router/handlers/public_api/factory.go \
    warp-server:router/handlers/public_api/factory_automations.go
  ? factory.go — no owner match
  ? factory_automations.go — no owner match
Reviewers (users): (none)
```

Post-#619 this lands on the `dannyneira` fallback rather than shipping unreviewed, so the remaining gap is reporting: the run should call this the fallback working, not a resolution failure. The real fix belongs in warp-server's ownership file — noted in the skill, with an explicit instruction not to hardcode an owner in the docs repo to paper over it.

**5. The schedule's two setup choices were undocumented.** Added after configuring the real schedule, which surfaced both.

*Run identity.* Quick run is the agent picker's default and executes as the calling user, so its PRs are authored by that person — for a schedule, whoever created it. Selecting a cloud agent runs as that agent, and with team GitHub authorization its PRs are authored by the Warp Factories GitHub App. A schedule that opens PRs wants the agent.

This one is genuinely trap-shaped, and I fell in it during review of this very pipeline: both validation runs were quick runs whose PRs were authored by a human, which reads like evidence that agent selection doesn't affect authorship. It isn't — those runs never selected an agent. The skill now states the rule so nobody has to re-derive it from misleading observations.

*Skill inheritance.* A run inherits every skill attached to the agent it runs as, and the schedule form won't let you detach an agent-level skill. Pointing drift-watch at the existing general-purpose docs agent pulled in `release_updates` — a weekly job that defaults to running all of its tasks — onto a daily trigger. The fix is a dedicated agent, not a different skills selection.

## Verification

- Ran the documented freshness check; output above.
- Ran `suggest_reviewers.py` against both factory handler paths; output above.
- Confirmed items 3 and 4 in source (`audit_slash_commands` in `scripts/audit_docs.py`) rather than from notes.
- Confirmed the two excluded items are already handled before dropping them.

Additions only, in regions #630 doesn't touch, so the two should merge in either order.

Caveat on item 4: the local `warp-server` checkout is from 2026-05-21, so factory ownership entries may exist upstream by now. The skill text is written so that resolution starts working automatically if they do, with no further change.

### Rework changes

- ⚠️ [IMPORTANT] The snapshot-regen precondition said the `warp` default branch is `main`; `warpdotdev/warp`'s actual remote `HEAD` is `master`. Updated the line to say `master` for `warp`, `develop` for `warp-server` (commit 1205a1a5). Verified via the GitHub API that `warpdotdev/warp`'s default branch is `master`.

Co-Authored-By: Warp <agent@warp.dev>

