### PR TITLE
docs(factories): document full Factory MCP onboarding and web-app refresh behavior

### DIFF
--- a/src/content/docs/factories/factory-mcp.mdx
+++ b/src/content/docs/factories/factory-mcp.mdx
@@ -7,6 +7,7 @@ sidebar:
   label: "Factory MCP"
 ---
 import AgentOnly from '@components/AgentOnly.astro';
+import { VARS } from '@data/vars';
 
 Factory MCP is a hosted Model Context Protocol (MCP) server that connects coding agents to your team's factories, in both directions: the agent you already work with — in Warp or in any MCP-capable tool — can send work to a factory, or take work over from one by pulling a task down, continuing it locally, and handing the result back.
 
@@ -21,7 +22,7 @@ The factory keeps a single record of each task throughout. Whether a change happ
 * **Send work in** - Turn anything from your local session into a factory task: a bug you found, review feedback, or a half-finished change.
 * **Continue a task locally** - Pull a task's context into your own checkout, work with your own tools, and return the result to the same task.
 * **Stay in sync** - List and search tasks, read a task's conversation, and message its [foreman](/factories/factory-agents/), the agent that orchestrates each task inside the factory.
-* **Create a factory** - Let your coding agent guide you through choosing a team, code forge, repositories, factory agents, and integrations.
+* **Create a factory** - Let your coding agent guide you through choosing a team, code host, repositories, factory agents, and integrations.
 
 Factory MCP is one of several ways work enters a factory, alongside Slack, GitHub, GitLab, Linear, and Jira. See [connect your factory](/factories/connect-your-factory/) for all intake paths and [how Warp Factories work](/factories/how-factories-work/) for how tasks move through a factory.
 
@@ -29,7 +30,7 @@ Factory MCP is one of several ways work enters a factory, alongside Slack, GitHu
 
 ### In Warp
 
-There is nothing to configure. When your account has access, Warp connects agent sessions to Factory MCP and handles authentication for you.
+There is nothing to configure. When your account has access, Warp connects agent sessions to Factory MCP and handles authentication for you. To create your first factory, ask the agent to set one up — the setup prompt below is for agents outside Warp.
 
 ### Set up with your coding agent
 
@@ -38,6 +39,9 @@ Paste this prompt into a coding agent that can run commands and configure MCP se
 ```text
 Set up a factory for me. Read https://docs.warp.dev/factories/factory-mcp.md, follow the setup instructions for your coding environment to connect to and authenticate with Factory MCP, then use Factory MCP to onboard me.
 ```
+
+The agent connects to Factory MCP, opens a browser sign-in where you log in or create a Warp account, then walks you through the same choices as the [setup wizard](/factories/quickstart/#set-up-your-factory): team, code host, repositories, agents, and integrations. It finishes by linking your new factory's dashboard. If the {VARS.FACTORY_WEB_APP} is still open to its setup screen in your browser, refresh the page to pick up the new factory.
+
 <AgentOnly>
 
 ## Coding-agent setup guidance
@@ -49,6 +53,7 @@ After the user pastes the prompt:
 3. Open the browser-based Warp authorization flow, where the user can log in or create a Warp account.
 4. Verify that the Factory MCP tools are available.
 5. Guide the user through the choices needed to create their factory.
+6. When the factory is created, share its link from the tool result, and tell the user to refresh the {VARS.FACTORY_WEB_APP} if its setup screen is still open in a browser tab.
 
 Before configuring anything, identify the coding environment and use that client's current MCP management mechanism. If you are unsure how the client manages MCP servers, check its help or official documentation rather than guessing.
 

--- a/src/content/docs/factories/quickstart.mdx
+++ b/src/content/docs/factories/quickstart.mdx
@@ -38,7 +38,7 @@ You can change any of these after setup, so a best guess is fine for now.
 _~5 minutes_
 
 :::note
-Already using an agent connected to [Factory MCP](/factories/factory-mcp/)? Ask it to run `create_factory` with the team, repositories, and factory name to create the factory directly, skipping the wizard below. Choose agents and connect your tools afterward in the factory's dashboard.
+An agent connected to [Factory MCP](/factories/factory-mcp/#set-up-with-your-coding-agent) can run this whole setup: ask it to set up a factory, and it walks you through the same choices as the wizard. If this wizard is still open when the agent finishes, refresh the page to see the new factory.
 :::
 
 Warp walks you through a setup wizard:

--- a/src/content/docs/factories/troubleshooting.mdx
+++ b/src/content/docs/factories/troubleshooting.mdx
@@ -36,6 +36,12 @@ Fix the problems teams hit most often when setting up a factory and running thei
 1. Ask a team admin to confirm the team's capacity.
 2. If the team needs more agents, [contact sales](https://www.warp.dev/contact-sales).
 
+### The web app still shows the setup wizard after your agent created a factory
+
+**Cause:** Completing setup through [Factory MCP](/factories/factory-mcp/) doesn't update a {VARS.FACTORY_WEB_APP} page that's already open in your browser.
+
+**Fix:** Refresh the page. Once your account has a factory, the web app opens it instead of the setup wizard. The factory link your agent shares at the end of setup opens the same place.
+
 ## Work isn't starting
 
 ### An event that should start work doesn't


### PR DESCRIPTION
## Why

Factory MCP now supports fully onboarding a user from a single prompt in any coding agent (shipped to prod; see the Slack thread on MCP onboarding visibility). The docs landed the prompt itself in #585, but three gaps remained:

- The quickstart's Factory MCP note predated full onboarding: it told readers to ask the agent to run `create_factory` with team/repos/name and to configure agents and integrations afterward in the dashboard. Onboarding now walks through all of those choices.
- Nothing documented that a Warp Factories web app page left open on the setup screen doesn't update when onboarding completes through the MCP — the user has to refresh, after which the web app routes them to their new factory (the point Dave and Harry discussed in the thread).
- The Factory MCP page didn't say that in Warp you can skip the setup prompt and directly ask the agent to set up a factory.

## What changed

- **`factories/factory-mcp.mdx`**
  - "In Warp": note that you can ask the agent to set up a factory directly; the paste-in prompt is for agents outside Warp.
  - "Set up with your coding agent": describe what the flow does end to end (sign-in or account creation, then the same choices as the setup wizard: team, code host, repositories, agents, and integrations; ends by linking the new factory's dashboard) and the refresh step for a still-open web app setup screen.
  - Agent-only guidance (`.md` output): new final step — share the factory link from the tool result and tell the user to refresh a still-open setup page.
  - Terminology: "code forge" → "code host" to match the rest of the factories docs.
- **`factories/quickstart.mdx`**: replace the stale `create_factory` note with the current single-ask flow, deep-linking to the setup section, plus the refresh hint.
- **`factories/troubleshooting.mdx`**: new setup entry — "The web app still shows the setup wizard after your agent created a factory" (cause: MCP onboarding doesn't update an already-open page; fix: refresh).

## Validation

- `npm run build` passes; verified the generated `dist/client/factories/*.md` output resolves `{VARS.*}` and unwraps the `AgentOnly` block (the new step 6 is present in `factory-mcp.md`).
- `style_lint --changed`: no issues on added lines (remaining hits are pre-existing suggestion-level "unrecognized term" warnings).

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
