### PR TITLE
docs(factories): document benchmark suites and tasks as definition files

### DIFF
--- a/src/content/docs/factories/factory-as-code.mdx
+++ b/src/content/docs/factories/factory-as-code.mdx
@@ -50,10 +50,10 @@ scorers/
   tests-run/
     scorer.md
 benchmarks/
-  implementation-quality/
+  review-quality/
     suite.yaml
     tasks/
-      fix-flaky-test.yaml
+      flag-missing-tests.yaml
 skills/
   repository-conventions/
     SKILL.md
@@ -391,12 +391,12 @@ Optional. When `true`, failing scores can feed the factory's self-improvement fl
 
 Optional. Each directory under `benchmarks/` defines a benchmark suite: fixed tasks that compare configurations of one agent. The directory segment is a stable filesystem slug — the required `name` field is the suite's identity, so renaming the suite doesn't move its files. See [Compare configurations with benchmarks](/factories/measure-and-improve/#compare-configurations-with-benchmarks) for how suites run and how to read the results.
 
-```yaml title="benchmarks/implementation-quality/suite.yaml"
-name: implementation-quality
-description: Fixed implementation tasks for comparing models and runners
-agent: implementer
+```yaml title="benchmarks/review-quality/suite.yaml"
+name: review-quality
+description: Fixed review tasks for comparing models and runners
+agent: reviewer
 tasks:
-  - fix-flaky-test
+  - flag-missing-tests
 ```
 
 ### `name`
@@ -419,14 +419,14 @@ Optional. Ordered task slugs, each naming a file at `benchmarks/<suite-slug>/tas
 
 One benchmark task, referenced from its suite's `tasks` list by slug — the file name without the extension.
 
-```yaml title="benchmarks/implementation-quality/tasks/fix-flaky-test.yaml"
-title: Fix the flaky payments integration test
+```yaml title="benchmarks/review-quality/tasks/flag-missing-tests.yaml"
+title: Flag the missing tests in a risky diff
 prompt: |
-  The payments integration test fails intermittently on CI. Find the cause
-  and fix it without changing the test's assertions.
+  Review the latest payments-service diff. Identify the changed code paths
+  that lack test coverage and name the specific tests that are missing.
 successCriteria: |
-  The flaky test is deterministic, the fix explains the root cause, and the
-  full test suite passes.
+  The review names every untested changed code path and proposes a concrete
+  test for each one.
 startingRepoRefs:
   - github.com:acme/payments-service@0123456789abcdef0123456789abcdef01234567
 ```

--- a/src/content/docs/factories/factory-as-code.mdx
+++ b/src/content/docs/factories/factory-as-code.mdx
@@ -2,13 +2,13 @@
 title: Factory definition syntax
 description: >-
   Look up every file and key in a factory definition: factory.yaml, agents,
-  automations, runners, scorers, and skills.
+  automations, runners, scorers, benchmarks, and skills.
 sidebar:
   label: "Definitions as code"
 ---
 import { VARS } from '@data/vars';
 
-Every factory is defined by files: a `factory.yaml` plus directories of agents, automations, runners, scorers, and skills, versioned in a Git repository. The files are the source of truth — when they change, Warp updates the factory to match. This page describes every file and key in a definition.
+Every factory is defined by files: a `factory.yaml` plus directories of agents, automations, runners, scorers, benchmarks, and skills, versioned in a Git repository. The files are the source of truth — when they change, Warp updates the factory to match. This page describes every file and key in a definition.
 
 Definition files are YAML and Markdown. Keys are case-sensitive.
 
@@ -49,6 +49,11 @@ runners/
 scorers/
   tests-run/
     scorer.md
+benchmarks/
+  implementation-quality/
+    suite.yaml
+    tasks/
+      fix-flaky-test.yaml
 skills/
   repository-conventions/
     SKILL.md
@@ -381,6 +386,70 @@ Required. The model that judges the runs.
 ### `selfImprovement`
 
 Optional. When `true`, failing scores can feed the factory's self-improvement flow, which proposes definition changes as pull requests. Defaults to `false`.
+
+## `benchmarks/<suite-slug>/suite.yaml`
+
+Optional. Each directory under `benchmarks/` defines a benchmark suite: fixed tasks that compare configurations of one agent. The directory segment is a stable filesystem slug — the required `name` field is the suite's identity, so renaming the suite doesn't move its files. See [Compare configurations with benchmarks](/factories/measure-and-improve/#compare-configurations-with-benchmarks) for how suites run and how to read the results.
+
+```yaml title="benchmarks/implementation-quality/suite.yaml"
+name: implementation-quality
+description: Fixed implementation tasks for comparing models and runners
+agent: implementer
+tasks:
+  - fix-flaky-test
+```
+
+### `name`
+
+Required. The suite's display name. Must be unique across the factory.
+
+### `description`
+
+Optional. What the suite measures.
+
+### `agent`
+
+Required. The name of an agent defined under [`agents/`](#agentsnameagentmd). Every task in the suite dispatches as this agent.
+
+### `tasks`
+
+Optional. Ordered task slugs, each naming a file at `benchmarks/<suite-slug>/tasks/<slug>.yaml`. Every slug listed here must have a matching file, and every task file must appear here exactly once. A suite with no tasks can be saved, but it can't launch until at least one task exists.
+
+## `benchmarks/<suite-slug>/tasks/<task-slug>.yaml`
+
+One benchmark task, referenced from its suite's `tasks` list by slug — the file name without the extension.
+
+```yaml title="benchmarks/implementation-quality/tasks/fix-flaky-test.yaml"
+title: Fix the flaky payments integration test
+prompt: |
+  The payments integration test fails intermittently on CI. Find the cause
+  and fix it without changing the test's assertions.
+successCriteria: |
+  The flaky test is deterministic, the fix explains the root cause, and the
+  full test suite passes.
+startingRepoRefs:
+  - github.com:acme/payments-service@0123456789abcdef0123456789abcdef01234567
+```
+
+### `title`
+
+Required. The task's display name. It doesn't need to match the file name.
+
+### `prompt`
+
+Required. The input the agent receives on every trial.
+
+### `successCriteria`
+
+Required. What a passing result looks like. The built-in **Correctness** Scorer judges every trial against these criteria.
+
+### `sourceRunId`
+
+Optional. Provenance for a task created from a completed run. It may later point to a deleted run.
+
+### `startingRepoRefs`
+
+Optional. Repositories the task starts from, each pinned to an exact commit so every launch reproduces the same starting state. Each entry is the shorthand `<host>:<owner>/<repo>@<commit-sha>` (the host is `github.com` or `gitlab.com`) or an object with `codeForge` (`GITHUB` or `GITLAB`), `owner`, `repo`, and `ref`. The `ref` is always a full 40-character commit SHA, never a branch or tag. Entries aren't checked against the factory's `repositories` until a run launches.
 
 ## Skills
 

--- a/src/content/docs/factories/measure-and-improve.mdx
+++ b/src/content/docs/factories/measure-and-improve.mdx
@@ -71,7 +71,7 @@ A benchmark compares configurations of a single agent on the same fixed tasks, s
 * **Scorers** - Your classification Scorers, applied to every trial.
 * **Repetitions** - The number of trials per task and configuration.
 
-You can create a benchmark task from a completed run's detail pane, and Warp copies the run's input into the task. Add success criteria before you launch.
+You can create a benchmark task from a completed run's detail pane, and Warp copies the run's input into the task. Add success criteria before you launch. For suites and tasks defined as files in a factory definition, see the [`benchmarks/` syntax](/factories/factory-as-code/#benchmarkssuite-slugsuiteyaml).
 
 Every benchmark also runs **Correctness**, a built-in Scorer that marks each trial as pass or fail against the task's success criteria. Results show pass rates, cost, and quality for each configuration, with per-task detail. Warp doesn't combine these signals into one score or pick a winner; you weigh the results and decide. Benchmark credit totals don't include model usage, so the true cost is higher.
 


### PR DESCRIPTION
## What this feature does

Benchmark suites compare configurations of one agent on the same fixed tasks. Suites and their tasks can be defined as version-controlled files — `benchmarks/<suite-slug>/suite.yaml` plus `tasks/<task-slug>.yaml` — like every other factory resource, and they were the only definition file kinds missing from the syntax reference. Shipped in `v0.2026.08.26.17.59.stable_01` (`2026-08-27`).

## Summary

Found during a factories docs-coverage audit against the published definition schemas. Every field, requirement, and constraint is sourced from the live schema bundle at `app.warp.dev/api/v1/factory-files/schemas/v1alpha1` (`benchmark_suite.schema.json`, `benchmark_suite_task.schema.json`).

## Changes

### src/content/docs/factories/factory-as-code.mdx
- Added `benchmarks/<suite-slug>/suite.yaml` and `benchmarks/<suite-slug>/tasks/<task-slug>.yaml` sections with per-field reference entries, matching the existing per-kind structure
- Added the `benchmarks/` tree to the directory structure listing and to the page intro and description

### src/content/docs/factories/measure-and-improve.mdx
- One-line pointer from "Compare configurations with benchmarks" to the new `benchmarks/` syntax sections

## Content design plan

**Reader and job:** A team that manages its factory as definitions as code and wants benchmark suites reviewed, versioned, and rolled back like the rest of the factory.

**Gap today:** `factory-as-code` documents every file kind except `benchmarks/`, and Measure and improve covers only the dashboard flow — file-based suites were undiscoverable.

**Change:** Two per-kind reference sections (`suite.yaml` fields; task file fields including commit-pinned `startingRepoRefs`) plus the directory listing and a cross-link. Excludes benchmark concepts and result interpretation, which stay on Measure and improve.

## Unverified claims

None — all fields, requirements, and constraints (including the save-vs-launch behavior for empty suites and the 40-character commit-SHA pinning rules) come from the published schema bundle's own descriptions.

## Additional context

The same audit evaluated other factories docs candidates; the notable deferral, recorded per the docs-worthiness criteria:

- **Custom webhook intake** (`provider: webhook` trigger, `FactoryWebhook` API): deferred, not rejected. The trigger provider is in the published schema, but the management endpoints (`/factory/webhooks/*`: create, rotate, deliveries, dry-run) are marked `x-internal` and there is no dashboard surface, so no released end-to-end setup path exists to document. Re-surface when those endpoints reach `developers/agent-api-openapi.yaml` (via the standing spec-sync automation) or a dashboard webhooks surface ships.
- Also evaluated and not pursued: an examples gallery page, foreman/scorers/pricing split-out pages, and a factories FAQ — reasons in the linked plan.

---

* [Warp conversation](https://staging.warp.dev/conversation/aa4b83c8-1908-4ea3-80f2-98c7da52ea51)
* [Implementation plan](https://staging.warp.dev/drive/notebook/ogHfHKku7ApquQZk1X1ckn)

Co-Authored-By: Warp <agent@warp.dev>
