### PR TITLE
docs(inference): call the inference bucket "AI credits", not "Warp AI credits"

### DIFF
--- a/src/content/docs/agents/inference/bring-your-own-api-key.mdx
+++ b/src/content/docs/agents/inference/bring-your-own-api-key.mdx
@@ -97,7 +97,7 @@ To use your own key, select a specific provider model (for example, Claude Opus 
 
 When you select a model with the key icon in your model picker, Warp routes the request through your API key. In that case:
 
-* Inference is billed directly through your provider account rather than drawing from your Warp AI credits.
+* Inference is billed directly through your provider account rather than drawing from your AI credits.
 * Agent Mode prioritizes BYOK over any available Warp credits.
 
 :::note

--- a/src/content/docs/agents/inference/custom-inference-endpoint.mdx
+++ b/src/content/docs/agents/inference/custom-inference-endpoint.mdx
@@ -81,9 +81,9 @@ For example, with a default Ollama install listening on port `11434`, run `ngrok
 
 ## Billing behavior
 
-### Warp AI credits
+### AI credits
 
-When you select an endpoint-routed model from the model picker, inference is billed directly by your endpoint provider, according to their pricing, rather than drawing from your Warp AI credits.
+When you select an endpoint-routed model from the model picker, inference is billed directly by your endpoint provider, according to their pricing, rather than drawing from your AI credits.
 
 :::note
 On Business and Enterprise plans, local agent runs that route through a custom inference endpoint still consume platform credits for Warp's platform infrastructure. See [platform credits](/support-and-community/plans-and-billing/platform-credits/) for the full breakdown.


### PR DESCRIPTION
## What this feature does

Two inference pages named the inference credit bucket "Warp AI credits", which embeds the retired **Warp AI** product name (renamed to Agent Mode). The canonical name for that bucket is **AI credits** — the definition on `plans-and-billing/credits.md` contrasts AI credits with compute credits and platform credits, with no "Warp" prefix. This renames the three live usages so the billing vocabulary matches across pages.

## Summary

- `agents/inference/custom-inference-endpoint.mdx` — the `### Warp AI credits` heading and the sentence under it become "AI credits".
- `agents/inference/bring-your-own-api-key.mdx` — "your Warp AI credits" becomes "your AI credits".

No page links the old `#warp-ai-credits` anchor (checked across `src/`, `vercel.json`, and `src/sidebar.ts`), so no redirect is needed.

## Content design plan

None required — this is a correction, not a new concept. Per `.agents/references/content-design-plan.md`, corrections get no plan.

## Why this wasn't caught before

The `missing_docs` staleness audit has flagged these files on every run, but earlier triage passes bucketed all `warp ai` hits as either verbatim telemetry event names in `privacy.mdx` or the deliberate historical FAQ heading. These three are neither: they are live prose using the retired product name as a modifier on a current billing term. The corrected verdict is recorded in the ledger in the companion bookkeeping PR (#657).

The remaining `Warp AI` occurrences are intentional and unchanged:
- `support-and-community/privacy-and-security/privacy.mdx` — verbatim telemetry event names.
- `agents/getting-started/faqs.mdx` — "What happened to the old Warp AI chat panel?", a deliberate historical reference.

## Validation

`npm run build` passes (380 markdown docs generated, 382 HTML files indexed).

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
