### PR TITLE
fix(docs): hide automated review signals

### DIFF
--- a/.agents/skills/doc_quality_policy/publish_review_signal.py
+++ b/.agents/skills/doc_quality_policy/publish_review_signal.py
@@ -53,8 +53,7 @@ def build_review_payload(
             "The independent agent completed its review for this commit.\n\n"
             f"## Findings\n{findings}\n\n"
             f"## Verdict\n{signal['verdict']}\n\n"
-            "## Review signal\n"
-            f"[SIGNAL:pr-review] {json.dumps(signal, sort_keys=True)}"
+            f"<!-- [SIGNAL:pr-review] {json.dumps(signal, sort_keys=True)} -->"
         ),
     }
 

--- a/.agents/skills/doc_quality_policy/test_publish_review_signal.py
+++ b/.agents/skills/doc_quality_policy/test_publish_review_signal.py
@@ -28,7 +28,14 @@ class TestBuildReviewPayload(unittest.TestCase):
         self.assertEqual(payload["event"], "APPROVE")
         self.assertEqual(payload["commit_id"], "sha1")
         self.assertIn("## Verdict\nApprove", payload["body"])
+        self.assertNotIn("## Review signal", payload["body"])
+        self.assertIn("<!-- [SIGNAL:pr-review]", payload["body"])
         self.assertIn('"reviewer_login": "github-actions[bot]"', payload["body"])
+        published_signal, problems = prs.vrs._parse_signal(
+            payload["body"], "1", "sha1"
+        )
+        self.assertEqual(problems, [])
+        self.assertEqual(published_signal["reviewer_login"], "github-actions[bot]")
 
     def test_approve_with_nits_maps_to_github_approval(self):
         payload = prs.build_review_payload(


### PR DESCRIPTION
## Summary

Hides the machine-readable review signal from GitHub's rendered automated-review body while preserving the exact record required by the review verifier and drafting-improvement collector.

## Changes

* Wraps the published `[SIGNAL:pr-review]` record in an HTML comment and removes its visible heading.
* Adds regression coverage that confirms the hidden signal remains parseable for the matching pull request and commit.

## Unverified claims

None — this change does not alter public product documentation or make product claims.

## Documentation risk
Risk: low
Rationale: This internal documentation-review formatter change does not make public product claims.
Docs override: none

## Validation

* `python3 .agents/skills/doc_quality_policy/test_publish_review_signal.py` — passed (4 tests).
* `python3 .agents/skills/doc_quality_policy/test_verify_review_signal.py` — passed (14 tests).
* Generated review payload inspection — confirms the signal is retained in an HTML comment.

Co-Authored-By: Warp <agent@warp.dev>
