### PR TITLE
docs: add GPT-6 Astra to model choice, drop retired variants

### DIFF
--- a/src/content/docs/agents/inference/model-choice.mdx
+++ b/src/content/docs/agents/inference/model-choice.mdx
@@ -116,7 +116,6 @@ Anthropic requires data retention for Claude Fable 5 and Claude Fable 5.1 for sa
 | Model | `model_id` |
 | --- | --- |
 | Gemini 3.1 Pro | `gemini-3.1-pro` |
-| Gemini 3.8 Flash | `gemini-3.8-flash` |
 | Gemini 3.7 Flash | `gemini-3.7-flash` |
 | Gemini 3.6 Flash | `gemini-3.6-flash` |
 | Gemini 3.5 Flash | `gemini-3.5-flash` |

--- a/src/content/docs/agents/inference/model-choice.mdx
+++ b/src/content/docs/agents/inference/model-choice.mdx
@@ -33,6 +33,11 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 
 | Model | `model_id` | Reasoning Level |
 | --- | --- | --- |
+| GPT-6 Astra | `gpt-6-astra-low` | Low |
+| GPT-6 Astra | `gpt-6-astra-medium` | Medium |
+| GPT-6 Astra | `gpt-6-astra-high` | High |
+| GPT-6 Astra | `gpt-6-astra-xhigh` | Extra High |
+| GPT-6 Astra | `gpt-6-astra-max` | Max |
 | GPT-5.6 Sol | `gpt-5-6-sol-low` | Low |
 | GPT-5.6 Sol | `gpt-5-6-sol-medium` | Medium |
 | GPT-5.6 Sol | `gpt-5-6-sol-high` | High |
@@ -57,14 +62,6 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 | GPT-5.3 Codex | `gpt-5-3-codex-medium` | Medium |
 | GPT-5.3 Codex | `gpt-5-3-codex-high` | High |
 | GPT-5.3 Codex | `gpt-5-3-codex-xhigh` | Extra High |
-| GPT-5.2 Codex | `gpt-5-2-codex-low` | Low |
-| GPT-5.2 Codex | `gpt-5-2-codex-medium` | Medium |
-| GPT-5.2 Codex | `gpt-5-2-codex-high` | High |
-| GPT-5.2 Codex | `gpt-5-2-codex-xhigh` | Extra High |
-| GPT-5.2 | `gpt-5-2-low` | Low |
-| GPT-5.2 | `gpt-5-2-medium` | Medium |
-| GPT-5.2 | `gpt-5-2-high` | High |
-| GPT-5.2 | `gpt-5-2-xhigh` | Extra High |
 
 #### Anthropic
 
@@ -100,7 +97,6 @@ All Auto models perform well across all agent workflows and are ideal if you pre
 | Claude Opus 4.7 | `claude-4-7-opus-xhigh` | Default effort |
 | Claude Opus 4.7 | `claude-4-7-opus-high` | High effort |
 | Claude Opus 4.7 | `claude-4-7-opus-max` | Max effort |
-| Claude Opus 4.7 | `claude-4-7-opus-xhigh-fast` | Fast mode |
 | Claude Opus 4.6 | `claude-4-6-opus-high` | Default effort |
 | Claude Opus 4.6 | `claude-4-6-opus-max` | Max effort |
 | Claude Sonnet 4.6 | `claude-4-6-sonnet-high` | Default effort |
@@ -120,6 +116,7 @@ Anthropic requires data retention for Claude Fable 5 and Claude Fable 5.1 for sa
 | Model | `model_id` |
 | --- | --- |
 | Gemini 3.1 Pro | `gemini-3.1-pro` |
+| Gemini 3.8 Flash | `gemini-3.8-flash` |
 | Gemini 3.7 Flash | `gemini-3.7-flash` |
 | Gemini 3.6 Flash | `gemini-3.6-flash` |
 | Gemini 3.5 Flash | `gemini-3.5-flash` |


### PR DESCRIPTION
## Summary
Syncs the [Model choice](https://docs.warp.dev/agents/inference/model-choice/) catalog with what `warp-server` actually offers in production. GPT-6 Astra was the prompt for this pass; two other drifts turned up while verifying the rest of the table against source.

Everything below was checked against `logic/ai/llm/model_choice.go` (which models get registered), `config/features/features.go` (the gating flag for each), and `config/prod.yaml` (whether that flag is on in prod).

## Changes

### src/content/docs/agents/inference/model-choice.mdx

**Added**

- **GPT-6 Astra** — five reasoning variants (`gpt-6-astra-low` / `-medium` / `-high` / `-xhigh` / `-max`), added to the OpenAI table. Registered behind `GPT6AstraEnabled()`, and `gpt_6_astra: true` in `config/prod.yaml`. Astra is the first OpenAI family in the catalog with a `max` level, so the Reasoning Level column now carries a `Max` value.

**Removed**

- **GPT-5.2** and **GPT-5.2 Codex** (8 rows) — both families are in `DeprecatedBaseModels`, deprecated 08/19/26, and `collectModelChoices` no longer adds them. Existing selections still resolve for backwards compatibility, but the models aren't selectable.
- **Claude Opus 4.7 fast mode** (`claude-4-7-opus-xhigh-fast`) — retired 08/04/26 and moved to `RemappedBaseModels`. Anthropic doesn't support fast mode on Opus 4.7, so the id now resolves to standard Opus 4.7 xhigh. Opus 4.8 and Opus 5 fast mode are unaffected and stay documented.

### Verified as already correct

The rest of the table matches prod, including the omissions: `auto-orchestrator`, Grok 4, Gemini 2.5 Flash, Muse Spark 1.2, GPT-OSS 120B, and Inkling are all registered in code but gated off in `config/prod.yaml`, so they correctly do not appear.

## Unverified claims
None — every `model_id`, display name, and reasoning/effort level in the diff was read from `warp-server` at the commit cited below, and each model's availability was confirmed against its feature flag value in `config/prod.yaml`.

## Documentation risk
Risk: engineering-review-required
Rationale: Changes model availability claims: adds GPT-6 Astra, and removes GPT-5.2, GPT-5.2 Codex, and Claude Opus 4.7 fast mode.
Source files consulted: warp-server/logic/ai/llm/model_choice.go@3899895c, warp-server/model/types/ai/types.go@3899895c, warp-server/config/features/features.go@3899895c, warp-server/config/prod.yaml@3899895c
Requested engineering reviewers: szgupta, cephalonaut, danielpeng2
Engineering review status: pending
Docs override: none

## Validation
- `style_lint.py --changed` — no new issues (3 pre-existing findings on untouched lines).
- `check_links.py --internal-only` — 4051 internal links, 0 broken.

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->

Co-Authored-By: Oz <oz-agent@warp.dev>
Co-Authored-By: Warp <agent@warp.dev>

