### PR TITLE
docs: list gemini as a factory harness type and pair --claude-auth-secret with the claude-code alias

### DIFF
--- a/src/content/docs/platform/harnesses/index.mdx
+++ b/src/content/docs/platform/harnesses/index.mdx
@@ -58,11 +58,11 @@ Set the `harness` field on the agent config to one of the [harness identifiers](
 
 ## Harness identifiers
 
-Surfaces that take the harness as a string all use the same identifiers: `oz` for the Warp Agent, `claude` for Claude Code, and `codex` for Codex. Write `claude` for Claude Code — not `claude-code`:
+Surfaces that take the harness as a string use `oz` for the Warp Agent, `claude` for Claude Code, and `codex` for Codex. Write `claude` for Claude Code — not `claude-code` — unless the surface explicitly accepts that alias:
 
 * **API and SDK** — the agent config's `harness.type` accepts `oz`, `claude`, or `codex`.
 * **CLI** — `oz agent run-cloud --harness` accepts the same identifiers, plus `claude-code` as an alias for `claude`.
-* **Factory definition files** — [`harness.type`](/factories/factory-as-code/#agentdefaultsharness) accepts the same identifiers, plus the `claude-code` alias.
+* **Factory definition files** — [`harness.type`](/factories/factory-as-code/#agentdefaultsharness) accepts `oz`, `claude`, `codex`, or `gemini`, plus `claude-code` as an alias for `claude`.
 
 Where the alias is accepted, it selects the same Claude Code harness as `claude`. Everywhere else — including the API — only the canonical identifiers are valid, so prefer them in anything you script, sync, or store.
 

--- a/src/content/docs/reference/cli/index.mdx
+++ b/src/content/docs/reference/cli/index.mdx
@@ -274,7 +274,7 @@ oz agent run-cloud \
 * `--attach <PATH>` — attach an image file to the agent query. Can be repeated (maximum 5).
 * `--computer-use` / `--no-computer-use` — enable or disable [Computer Use](/agents/capabilities/computer-use/) for this run.
 * `--harness <HARNESS>` — choose the [execution harness](/platform/harnesses/) for the run: `oz` (default, the Warp Agent), `claude` (Claude Code), or `codex` (Codex). `claude-code` is accepted as an alias for `claude`. See [harness identifiers](/platform/harnesses/#harness-identifiers).
-* `--claude-auth-secret <NAME>` — name of the [Warp-managed secret](/platform/secrets/) that authenticates the Claude Code harness. Only valid with `--harness claude`. See [Third-party cloud agent authentication](/platform/harnesses/authentication/).
+* `--claude-auth-secret <NAME>` — name of the [Warp-managed secret](/platform/secrets/) that authenticates the Claude Code harness. Use with `--harness claude` or the `--harness claude-code` alias. See [Third-party cloud agent authentication](/platform/harnesses/authentication/).
 * `--codex-auth-secret <NAME>` — name of the [Warp-managed secret](/platform/secrets/) that authenticates the Codex harness. Only valid with `--harness codex`. See [Third-party cloud agent authentication](/platform/harnesses/authentication/).
 * `--file <PATH>` (`-f`) — load run configuration from a YAML or JSON file.
 


### PR DESCRIPTION
Follow-up to #689. Applies the two review suggestions from that PR that were not accepted before merge; both were verified against source.

## Changes

- **`platform/harnesses/index.mdx`** — The factory definition files bullet under "Harness identifiers" now lists the values the schema actually validates: `oz`, `claude`, `codex`, or `gemini`, plus `claude-code` as an alias for `claude`. Previously it said factories accept only the shared identifiers plus the alias, which contradicted `factory-as-code.mdx` (which already documents `gemini`). The intro sentence now also notes that the alias is fine where a surface explicitly accepts it. Source: `warp-server/logic/factoryfile/schema/v1alpha1/common.schema.json` (`harness.type` enum).
- **`reference/cli/index.mdx`** — `--claude-auth-secret` no longer says it is "only valid with `--harness claude`", since the `--harness` bullet directly above documents `claude-code` as an accepted alias. It now reads "Use with `--harness claude` or the `--harness claude-code` alias." Source: `warp/crates/warp_cli/src/agent.rs` defines `claude-code` as a clap alias for the same `claude` value.

## Validation

- `python3 .agents/skills/style_lint/style_lint.py --changed` — no new issues (the two reported findings are pre-existing and on untouched lines).
- `npm run build` — passes.

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->

Co-Authored-By: Warp <agent@warp.dev>
