### PR TITLE
docs: fix Settings paths for editor options moved to Code > Editor and Code Review

### DIFF
--- a/src/content/docs/code/code-editor/index.mdx
+++ b/src/content/docs/code/code-editor/index.mdx
@@ -33,7 +33,7 @@ Warp can group multiple files into a single tabbed viewer, reducing clutter and 
 
 ![Multiple files grouped into a single tabbed file viewer in Warp's code editor.](../../../../assets/terminal/tabbed-file-viewer.png)
 
-* Enabled by default for new users (can be toggled in **Settings** > **Features** > **General** > **Group files into a single editor pane**)
+* Enabled by default for new users (can be toggled in **Settings** > **Code** > **Editor and Code Review** > **Group files into single editor pane**)
 * Reorder, close, or drag file viewers between tabs.
 * Merge entire panes together by dragging one into another.
 
@@ -43,7 +43,7 @@ Warp can group multiple files into a single tabbed viewer, reducing clutter and 
 
 ### File layout options
 
-Choose how new files open in Warp by default in: **Settings** > **Features** > **General** > **Choose a layout to open files in Warp**
+Choose how new files open in Warp by default in: **Settings** > **Code** > **Editor and Code Review** > **Choose a layout to open files in Warp**
 
 * **Split pane**: new files open alongside the current editor
 * **New tab**: new files open in their own tabbed viewer

--- a/src/content/docs/terminal/more-features/files-and-links.mdx
+++ b/src/content/docs/terminal/more-features/files-and-links.mdx
@@ -45,7 +45,7 @@ Warp parses relative and absolute file paths. Warp also tries to capture line an
 
 * You can also Drag and drop a folder or file onto the Warp dock icon to open a new tab in this directory.
 * You can also right-click on a folder or file in Finder, then select Services, and "Open new Warp Tab | Window here".
-* Configure the default editor to open files by navigating to **Settings** > **Features** > **General** > **Choose an editor to open file links**.
+* Configure the default editor to open files by navigating to **Settings** > **Code** > **Editor and Code Review** > **Choose an editor to open file links**.
   * Selecting "Default App" uses your system's default application for the file type.
 
 #### List of supported editors

--- a/src/content/docs/terminal/more-features/markdown-viewer.mdx
+++ b/src/content/docs/terminal/more-features/markdown-viewer.mdx
@@ -8,7 +8,7 @@ sidebar:
 import DemoVideo from '@components/DemoVideo.astro';
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Warp can be used for both editing and viewing rendered Markdown files in a [split pane](/terminal/windows/split-panes/). Any local file with the `.md` or `.markdown` extension is treated as a Markdown file. Remote files are currently not supported. Turning on **Settings** > **Features** > **General** > **Open Markdown files in Warp's Markdown viewer by default** will make the Markdown viewer default, otherwise Markdown files will open in Warp's editor.
+Warp can be used for both editing and viewing rendered Markdown files in a [split pane](/terminal/windows/split-panes/). Any local file with the `.md` or `.markdown` extension is treated as a Markdown file. Remote files are currently not supported. Turning on **Settings** > **Code** > **Editor and Code Review** > **Open Markdown files in Warp's Markdown Viewer by default** will make the Markdown viewer default, otherwise Markdown files will open in Warp's editor.
 
 ### Opening a file link within a block
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/warpdotdev/docs/issues/587.

Four settings under the old **Settings** > **Features** > **General** location moved to **Settings** > **Code** > **Editor and Code Review** in the settings reorg (changelog 2026.04.22: "Reorganized settings into subpages for Agents, Code, and Cloud platform"), but three docs pages still pointed readers at the old path. This PR updates those references to the current location and aligns two setting labels with the exact strings the app renders.

Every updated path and label was checked directly in the Warp client code: the `Code` umbrella is defined in `app/src/settings_view/mod.rs`, the "Editor and Code Review" page in `app/src/settings_view/code_editor_review_page.rs`, and the four affected controls in `app/src/settings_view/features/external_editor.rs`. The repo's UI-reference validator (`validate_ui_refs.py --changed`) passes on all changed files.

Other `**Settings** > **Features** > **General**` references in the docs (quit warning, sticky command header, default session mode, web-only link preference) were checked and remain correct — those settings still live on the Features page.

## Changes

### src/content/docs/terminal/more-features/files-and-links.mdx
- Updated the "Choose an editor to open file links" path to the new location (the change reported in #587).

### src/content/docs/terminal/more-features/markdown-viewer.mdx
- Pointed the "Open Markdown files in Warp's Markdown Viewer by default" reference at the Editor and Code Review page, and matched the label casing to the app ("Markdown Viewer").

### src/content/docs/code/code-editor/index.mdx
- Pointed the tabbed file viewer toggle at the Editor and Code Review page, and corrected the label to "Group files into single editor pane" to match the app.
- Same path update for "Choose a layout to open files in Warp".

## Unverified claims
None — all updated Settings paths and setting labels were confirmed in the client code (`warpdotdev/warp@6db7fb73`: `app/src/settings_view/mod.rs`, `code_editor_review_page.rs`, `features/external_editor.rs`) and pass `validate_ui_refs.py --changed` against the trusted UI-paths snapshot.

## Documentation risk
Risk: engineering-review-required
Rationale: Corrects four stale Settings paths (UI-path claims) to the current Settings > Code > Editor and Code Review location; verified against the Warp client source.
Source files consulted: warp:app/src/settings_view/mod.rs@6db7fb73, warp:app/src/settings_view/code_editor_review_page.rs@6db7fb73, warp:app/src/settings_view/features/external_editor.rs@6db7fb73
Engineering review status: pending
Docs override: none

Reviewer note: ownership resolution for the source files returned only a team (`warpdotdev/oss-maintainers`), so no reviewer was requested per the single-owner rule.

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->

Co-Authored-By: Warp <agent@warp.dev>
Co-Authored-By: Oz <oz-agent@warp.dev>
