### PR TITLE
docs(factories): correct supported event triggers

### DIFF
--- a/src/content/docs/factories/factory-as-code.mdx
+++ b/src/content/docs/factories/factory-as-code.mdx
@@ -268,11 +268,11 @@ Required. One or more events that start runs. Each trigger declares a `provider`
 
 The providers and their events:
 
-* `github` - `issue_created`, `issue_labeled`, `issue_assigned`, `issue_mentioned`, `pull_request_opened`, `pull_request_closed`, `pull_request_merged`, `pull_request_labeled`, `pull_request_assigned`, `pull_request_mentioned`, `pull_request_ready`, `pull_request_reopened`, `pull_request_synchronized`, `pull_request_review_requested`, `pull_request_review_submitted`, `push`, `check_suite_completed`, `check_run_rerequested`, `check_suite_rerequested`, `workflow_run_completed`
+* `github` - `issue_created`, `issue_labeled`, `issue_assigned`, `issue_mentioned`, `pull_request_opened`, `pull_request_closed`, `pull_request_merged`, `pull_request_labeled`, `pull_request_assigned`, `pull_request_mentioned`, `pull_request_ready`, `pull_request_reopened`, `pull_request_synchronized`, `pull_request_review_requested`, `pull_request_review_submitted`, `push`, `check_suite_completed`, `workflow_run_completed`
 * `gitlab` - `merge_request`, `bot_mentioned`
 * `linear` - `issue_created`, `issue_labeled`, `issue_assigned`, `issue_state_changed`, `comment_created`, `agent_session_created`
 * `jira` - `issue_created`, `issue_labeled`, `status_changed`, `agent_session_created`
-* `slack` - `app_mention`, `message_posted`, `message_dm`, `message_im`, `message_mpim`, `member_joined_channel`, `reaction_added`
+* `slack` - `app_mention`, `message_posted`, `message_dm`, `member_joined_channel`, `reaction_added`
 * `schedule` - `cron_fired`
 * `webhook` - `received`
 * `factory` - `work_item_stage_changed`

--- a/src/content/docs/factories/integrations/github.mdx
+++ b/src/content/docs/factories/integrations/github.mdx
@@ -65,11 +65,10 @@ For a review automation that fires when pull requests open, see [`04-code-review
 <tr><td>Issues</td><td>Created, labeled, assigned, or agent mentioned</td></tr>
 <tr><td>Pull requests</td><td>Opened, marked ready, reopened, updated with commits, assigned, labeled, mentioned, closed, or merged</td></tr>
 <tr><td>Reviews</td><td>Review requested or review submitted</td></tr>
-<tr><td>Code and CI</td><td>Push, a completed check suite or workflow run, or a re-run of a Warp check</td></tr>
+<tr><td>Code and CI</td><td>Push, a completed check suite or workflow run</td></tr>
 </tbody>
 </table>
 
-Re-running a check starts work only for checks Warp itself created. GitHub doesn't send re-run events for other providers' checks, so those can't trigger a factory.
 
 For the exact `event` value each trigger uses in a definition file, see [triggers](/factories/factory-as-code/#triggers).
 

--- a/src/content/docs/factories/integrations/github.mdx
+++ b/src/content/docs/factories/integrations/github.mdx
@@ -98,7 +98,7 @@ Use filters to route work precisely. For example, send failed runs of a specific
 
 Handing an issue or pull request to a factory takes two things:
 
-1. **Add the factory's label.** Each factory has one, derived from its [alias](/factories/factory-as-code/#alias) (the **Foreman name** under **Settings** > **Identity** in the factory dashboard) as `factory:<alias>`. For example, alias `payments` uses `factory:payments`, not the factory's display name. Warp creates the label automatically when you create the factory.
+1. **Add the factory's label.** Each factory has one, derived from its [alias](/factories/factory-as-code/#alias) (the **Foreman name** in the factory dashboard's **Identity** settings) as `factory:<alias>`. For example, alias `payments` uses `factory:payments`, not the factory's display name. Warp creates the label automatically when you create the factory.
 2. Mention **@warp-factory** in the opening body or a new comment.
 
 The factory picks up the request and replies in the same thread.

--- a/src/content/docs/factories/integrations/slack.mdx
+++ b/src/content/docs/factories/integrations/slack.mdx
@@ -28,7 +28,7 @@ Each factory appears in Slack as its own app with the factory's name and avatar.
 Use a factory automation to start work from Slack activity automatically, without anyone mentioning the app, such as on every message in a triage channel or on a specific emoji reaction. Add a **Slack** trigger to an automation and pick one of these events. To learn how to edit those filters, see [Automations](/factories/automations/#edit-filters-on-an-automation).
 
 - **App mentioned** - Filter by joined conversations, authors, and keywords.
-- **Direct message received** - Filter by direct-message conversations, authors, and keywords.
+- **Direct message received** (`message_dm`) - Filter by direct-message conversations, authors, and keywords.
 - **Message posted in channel** - Filter by joined conversations, authors, and keywords.
 - **Reaction added** - Filter by conversations, reactors, keywords, emoji, and reacted-message authors.
 - **Member joined channel** - Filter by conversations and members.


### PR DESCRIPTION
## Summary

Follow up on Lili's feedback from the event-slug discussion in #632.

- Document `message_dm` as the Slack direct-message trigger.
- Remove legacy Slack events `message_im` and `message_mpim` from the user-facing factory-definition reference.
- Remove GitHub check-rerun events and related copy, since they support factory file sync rather than user-configurable automations.

## Validation

- `git diff --check`
- `python3 .agents/skills/check_for_broken_links/check_links.py --internal-only` (4,093 links and anchors checked; 0 broken)
- Targeted `style_lint.py` checks: no errors; remaining warnings predate this change.
- `npm run build` was not run to completion because this fresh worktree has no installed dependencies (`yaml` is unavailable).

Co-Authored-By: Warp <agent@warp.dev>